### PR TITLE
[GAME] Hitbox System verbessern

### DIFF
--- a/code/game/src/character/DungeonCharacter.java
+++ b/code/game/src/character/DungeonCharacter.java
@@ -2,14 +2,14 @@ package character;
 
 import basiselements.AnimatableElement;
 import collision.CharacterDirection;
-import collision.Colideable;
+import collision.Collidable;
 import collision.Hitbox;
 import graphic.Animation;
 import level.elements.ILevel;
 import tools.Point;
 
 /** Characters in the Dugenon. Characters can move, have animations and collision. */
-public abstract class DungeonCharacter extends AnimatableElement implements Colideable {
+public abstract class DungeonCharacter extends AnimatableElement implements Collidable {
 
     protected Point currentPosition;
     protected Animation currentAnimation;
@@ -25,6 +25,7 @@ public abstract class DungeonCharacter extends AnimatableElement implements Coli
     public DungeonCharacter(float movementSpeed, Hitbox hitbox) {
         this.movementSpeed = movementSpeed;
         this.hitbox = hitbox;
+        hitbox.setCollidable(this);
     }
 
     /**
@@ -130,7 +131,6 @@ public abstract class DungeonCharacter extends AnimatableElement implements Coli
     @Override
     public void update() {
         move();
-        hitbox.setPosition(currentPosition);
     }
 
     @Override

--- a/code/game/src/character/monster/Imp.java
+++ b/code/game/src/character/monster/Imp.java
@@ -14,7 +14,7 @@ public class Imp extends Monster {
 
     public Imp() {
         // 16x16
-        super(0.03f, new Hitbox(5, 5, null));
+        super(0.03f, new Hitbox(5, 5));
         int frameTime = 5;
         List<String> texturePaths = TextureHandler.getInstance().getTexturePaths("imp_idle_anim_f");
         Animation animation = new Animation(texturePaths, frameTime * 2);

--- a/code/game/src/character/monster/Monster.java
+++ b/code/game/src/character/monster/Monster.java
@@ -6,6 +6,7 @@ import collision.Collidable;
 import collision.Hitbox;
 import com.badlogic.gdx.ai.pfa.GraphPath;
 import level.elements.Tile;
+import level.tools.Coordinate;
 import level.tools.LevelElement;
 import tools.Point;
 
@@ -35,13 +36,17 @@ public abstract class Monster extends DungeonCharacter {
             Tile.Direction d = currentTile.directionTo(nextTile)[0];
             switch (d) {
                 case N:
-                    return CharacterDirection.UP;
+                    d = checkUP(d);
+                    return convertTileDirectionToCharacterDirection(d);
                 case S:
-                    return CharacterDirection.DOWN;
+                    d = checkDown(d);
+                    return convertTileDirectionToCharacterDirection(d);
                 case E:
-                    return CharacterDirection.RIGHT;
+                    d = checkRight(d);
+                    return convertTileDirectionToCharacterDirection(d);
                 case W:
-                    return CharacterDirection.LEFT;
+                    d = checkLeft(d);
+                    return convertTileDirectionToCharacterDirection(d);
                 default:
                     System.out.println("??");
             }
@@ -50,6 +55,141 @@ public abstract class Monster extends DungeonCharacter {
             calculateGoal(true);
         }
         return CharacterDirection.NONE;
+    }
+
+    private CharacterDirection convertTileDirectionToCharacterDirection(Tile.Direction d) {
+        switch (d) {
+            case N:
+                return CharacterDirection.UP;
+            case E:
+                return CharacterDirection.RIGHT;
+            case S:
+                return CharacterDirection.DOWN;
+            case W:
+                return CharacterDirection.LEFT;
+            default:
+                return CharacterDirection.NONE;
+        }
+    }
+
+    private Tile.Direction checkLeft(Tile.Direction d) {
+        var tmp = moveleft();
+        if (!isHitboxOnFloor(tmp)) {
+            // check top left and bottom left for collision !
+            var corners = hitbox.getCorners();
+            if (!currentLevel
+                    .getTileAt(
+                            new Coordinate(
+                                    (int) (corners[Hitbox.CORNER_BOTTOM_LEFT].x + tmp.x),
+                                    (int) (corners[Hitbox.CORNER_BOTTOM_LEFT].y + tmp.y)))
+                    .isAccessible()) {
+                // bottom left collision move to the TOP
+                d = Tile.Direction.N;
+            }
+            if (!currentLevel
+                    .getTileAt(
+                            new Coordinate(
+                                    (int) (corners[Hitbox.CORNER_TOP_LEFT].x + tmp.x),
+                                    (int) (corners[Hitbox.CORNER_TOP_LEFT].y + tmp.y)))
+                    .isAccessible()) {
+                // top left collision move to the bottom
+                d = Tile.Direction.S;
+            }
+        }
+        return d;
+    }
+
+    private Tile.Direction checkRight(Tile.Direction d) {
+        var tmp = moveright();
+        if (!isHitboxOnFloor(tmp)) {
+            // check top right and bottom right for collision !
+            var corners = hitbox.getCorners();
+            if (!currentLevel
+                    .getTileAt(
+                            new Coordinate(
+                                    (int) (corners[Hitbox.CORNER_BOTTOM_RIGHT].x + tmp.x),
+                                    (int) (corners[Hitbox.CORNER_BOTTOM_RIGHT].y + tmp.y)))
+                    .isAccessible()) {
+                // bottom right collision move to the TOP
+                d = Tile.Direction.N;
+            }
+            if (!currentLevel
+                    .getTileAt(
+                            new Coordinate(
+                                    (int) (corners[Hitbox.CORNER_TOP_RIGHT].x + tmp.x),
+                                    (int) (corners[Hitbox.CORNER_TOP_RIGHT].y + tmp.y)))
+                    .isAccessible()) {
+                // top right collision move to the bottom
+                d = Tile.Direction.S;
+            }
+        }
+        return d;
+    }
+
+    /**
+     * simple check for moving down
+     *
+     * @param d the planned direction
+     * @return the recommended direction
+     */
+    private Tile.Direction checkDown(Tile.Direction d) {
+        var tmp = movedown();
+        if (!isHitboxOnFloor(tmp)) {
+            // check bottom left and bottom right for collision ! first to collide and also
+            var corners = hitbox.getCorners();
+            if (!currentLevel
+                    .getTileAt(
+                            new Coordinate(
+                                    (int) (corners[Hitbox.CORNER_BOTTOM_LEFT].x + tmp.x),
+                                    (int) (corners[Hitbox.CORNER_BOTTOM_LEFT].y + tmp.y)))
+                    .isAccessible()) {
+                // bottom left collision move to the right
+                d = Tile.Direction.E;
+            }
+            if (!currentLevel
+                    .getTileAt(
+                            new Coordinate(
+                                    (int) (corners[Hitbox.CORNER_BOTTOM_RIGHT].x + tmp.x),
+                                    (int) (corners[Hitbox.CORNER_BOTTOM_RIGHT].y + tmp.y)))
+                    .isAccessible()) {
+                // bottom right collision move to the left
+                d = Tile.Direction.W;
+            }
+        }
+        return d;
+    }
+
+    /**
+     * simple check for moving up
+     *
+     * @param d the planned direction
+     * @return the recommended direction
+     */
+    private Tile.Direction checkUP(Tile.Direction d) {
+        var tmp = moveup();
+        if (!isHitboxOnFloor(tmp)) {
+            // check top left and top right for collision ! first to collide and also
+            var corners = hitbox.getCorners();
+            if (!currentLevel
+                    .getTileAt(
+                            new Coordinate(
+                                    (int) (corners[Hitbox.CORNER_TOP_LEFT].x + tmp.x),
+                                    (int) (corners[Hitbox.CORNER_TOP_LEFT].y + tmp.y)))
+                    .isAccessible()) {
+                // top left collision move to the right
+                d = Tile.Direction.E;
+            }
+            if (!currentLevel
+                    .getTileAt(
+                            new Coordinate(
+                                    (int) (corners[Hitbox.CORNER_TOP_RIGHT].x + tmp.x),
+                                    (int) (corners[Hitbox.CORNER_TOP_RIGHT].y + tmp.y)))
+                    .isAccessible()) {
+                // top right collision move to the left
+                d = Tile.Direction.W;
+            }
+        }
+        return d;
     }
 
     /**

--- a/code/game/src/character/monster/Monster.java
+++ b/code/game/src/character/monster/Monster.java
@@ -2,7 +2,7 @@ package character.monster;
 
 import character.DungeonCharacter;
 import collision.CharacterDirection;
-import collision.Colideable;
+import collision.Collidable;
 import collision.Hitbox;
 import com.badlogic.gdx.ai.pfa.GraphPath;
 import level.elements.Tile;
@@ -63,7 +63,7 @@ public abstract class Monster extends DungeonCharacter {
     }
 
     @Override
-    public void colide(Colideable other, CharacterDirection from) {
+    public void colide(Collidable other, CharacterDirection from) {
         // todo
     }
 }

--- a/code/game/src/character/monster/Monster.java
+++ b/code/game/src/character/monster/Monster.java
@@ -3,7 +3,7 @@ package character.monster;
 import character.DungeonCharacter;
 import collision.CharacterDirection;
 import collision.Collidable;
-import collision.CollidableLevel;
+import collision.CollisionMap;
 import collision.Hitbox;
 import com.badlogic.gdx.ai.pfa.GraphPath;
 import level.elements.ILevel;
@@ -17,7 +17,7 @@ public abstract class Monster extends DungeonCharacter {
 
     // curent Point this Monster wants to move to
     private Point currentGoal;
-    private CollidableLevel clevel;
+    private CollisionMap clevel;
 
     public Monster(float movementSpeed, Hitbox hitbox) {
         super(movementSpeed, hitbox);
@@ -242,7 +242,7 @@ public abstract class Monster extends DungeonCharacter {
         // todo
     }
 
-    public void setCLevel(CollidableLevel clevel) {
+    public void setCLevel(CollisionMap clevel) {
         this.clevel = clevel;
     }
 }

--- a/code/game/src/character/monster/Monster.java
+++ b/code/game/src/character/monster/Monster.java
@@ -17,6 +17,7 @@ public abstract class Monster extends DungeonCharacter {
 
     // curent Point this Monster wants to move to
     private Point currentGoal;
+    private CollidableLevel clevel;
 
     public Monster(float movementSpeed, Hitbox hitbox) {
         super(movementSpeed, hitbox);
@@ -38,38 +39,37 @@ public abstract class Monster extends DungeonCharacter {
             Tile.Direction d = currentTile.directionTo(nextTile)[0];
             CharacterDirection direction = convertTileDirectionToCharacterDirection(d);
             ILevel level = currentLevel;
-            if (level.getClass() == CollidableLevel.class) {
-                var collidable = ((CollidableLevel) level).getCollidables();
-                // TODO: create a better fix for hitbox
-                var temp = currentPosition;
-                switch (direction) {
-                    case UP:
-                        currentPosition = moveup();
-                        break;
-                    case DOWN:
-                        currentPosition = movedown();
-                        break;
-                    case RIGHT:
-                        currentPosition = moveright();
-                        break;
-                    case LEFT:
-                        currentPosition = moveleft();
-                        break;
-                }
-
-                for (Collidable collideable : collidable) {
-                    // hitbox has to be moved to new position
-                    var col = hitbox.collide(collideable.getHitbox());
-                    if (col != CharacterDirection.NONE) {
-                        // collision
-
-                        currentPosition = temp;
-                        return handlePathCollision(direction);
-                    }
-                }
-                currentPosition = temp;
-                return convertTileDirectionToCharacterDirection(d);
+            var collidable = clevel.getCollidables();
+            // TODO: create a better fix for hitbox
+            var temp = currentPosition;
+            switch (direction) {
+                case UP:
+                    currentPosition = moveup();
+                    break;
+                case DOWN:
+                    currentPosition = movedown();
+                    break;
+                case RIGHT:
+                    currentPosition = moveright();
+                    break;
+                case LEFT:
+                    currentPosition = moveleft();
+                    break;
             }
+
+            for (Collidable collideable : collidable) {
+                // hitbox has to be moved to new position
+                var col = hitbox.collide(collideable.getHitbox());
+                if (col != CharacterDirection.NONE) {
+                    // collision
+
+                    currentPosition = temp;
+                    return handlePathCollision(direction);
+                }
+            }
+            currentPosition = temp;
+            return convertTileDirectionToCharacterDirection(d);
+
         } catch (Exception e) {
             e.printStackTrace();
             calculateGoal(true);
@@ -240,5 +240,9 @@ public abstract class Monster extends DungeonCharacter {
     @Override
     public void colide(Collidable other, CharacterDirection from) {
         // todo
+    }
+
+    public void setCLevel(CollidableLevel clevel) {
+        this.clevel = clevel;
     }
 }

--- a/code/game/src/character/player/Hero.java
+++ b/code/game/src/character/player/Hero.java
@@ -2,7 +2,7 @@ package character.player;
 
 import character.DungeonCharacter;
 import collision.CharacterDirection;
-import collision.Colideable;
+import collision.Collidable;
 import collision.Hitbox;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input;
@@ -20,7 +20,7 @@ public class Hero extends DungeonCharacter {
 
     public Hero() {
         // 16x28
-        super(0.3f, new Hitbox(6, 6, null));
+        super(0.3f, new Hitbox(6, 6));
         int frameTime = 5;
         List<String> texturePaths =
                 TextureHandler.getInstance().getTexturePaths("knight_m_idle_anim_f");
@@ -63,7 +63,7 @@ public class Hero extends DungeonCharacter {
     }
 
     @Override
-    public void colide(Colideable other, CharacterDirection from) {
+    public void colide(Collidable other, CharacterDirection from) {
         // todo
     }
 }

--- a/code/game/src/collision/Collidable.java
+++ b/code/game/src/collision/Collidable.java
@@ -3,7 +3,7 @@ package collision;
 import tools.Point;
 
 /** Implemented by Objects that can colide with each other */
-public interface Colideable {
+public interface Collidable {
     /**
      * @return The Hitbox of the Object
      */
@@ -20,5 +20,5 @@ public interface Colideable {
      * @param other Object you colide with
      * @param from Direction from where you colide
      */
-    void colide(Colideable other, CharacterDirection from);
+    void colide(Collidable other, CharacterDirection from);
 }

--- a/code/game/src/collision/CollidableLevel.java
+++ b/code/game/src/collision/CollidableLevel.java
@@ -1,26 +1,16 @@
 package collision;
 
 import java.util.ArrayList;
+import level.elements.ILevel;
 import level.elements.Tile;
-import level.elements.TileLevel;
-import level.tools.DesignLabel;
-import level.tools.LevelElement;
 import tools.Point;
 
-public class CollidableLevel extends TileLevel {
+public class CollidableLevel {
     private Collidable[] collidables;
 
-    public CollidableLevel(Tile[][] layout) {
-        super(layout);
-    }
-
-    public CollidableLevel(LevelElement[][] layout, DesignLabel designLabel) {
-        super(layout, designLabel);
-    }
-
-    public void regenHitboxen() {
+    public void regenHitboxen(ILevel level) {
         ArrayList<Collidable> tiles = new ArrayList<>();
-        Tile[][] layout = this.getLayout();
+        Tile[][] layout = level.getLayout();
         for (var tilerow : layout) {
             for (var tile : tilerow) {
                 if (!tile.isAccessible()) {

--- a/code/game/src/collision/CollidableLevel.java
+++ b/code/game/src/collision/CollidableLevel.java
@@ -1,0 +1,47 @@
+package collision;
+
+import java.util.ArrayList;
+import level.elements.Tile;
+import level.elements.TileLevel;
+import level.tools.DesignLabel;
+import level.tools.LevelElement;
+import tools.Point;
+
+public class CollidableLevel extends TileLevel {
+    private Collidable[] collidables;
+
+    public CollidableLevel(Tile[][] layout) {
+        super(layout);
+    }
+
+    public CollidableLevel(LevelElement[][] layout, DesignLabel designLabel) {
+        super(layout, designLabel);
+    }
+
+    public void regenHitboxen() {
+        ArrayList<Collidable> tiles = new ArrayList<>();
+        Tile[][] layout = this.getLayout();
+        for (var tilerow : layout) {
+            for (var tile : tilerow) {
+                if (!tile.isAccessible()) {
+                    TileCollidable tileCollidable = new TileCollidable(tile, new Hitbox(16, 16));
+                    tileCollidable.getHitbox().setCollidable(tileCollidable);
+
+                    tiles.add(tileCollidable);
+                }
+            }
+        }
+        int width = layout[0].length;
+        int height = layout.length;
+        // the level borders
+        tiles.add(new RectCollidable(new Point(-1, -1), 16 * (width + 2), 16)); // bottom
+        tiles.add(new RectCollidable(new Point(-1, -1), 16, 16 * (height + 2))); // left
+        tiles.add(new RectCollidable(new Point(width, -1), 16, 16 * (height + 2))); // right
+        tiles.add(new RectCollidable(new Point(-1, height), 16 * (width + 2), 16)); // top
+        collidables = tiles.toArray(new Collidable[0]);
+    }
+
+    public Collidable[] getCollidables() {
+        return collidables;
+    }
+}

--- a/code/game/src/collision/CollisionMap.java
+++ b/code/game/src/collision/CollisionMap.java
@@ -5,9 +5,16 @@ import level.elements.ILevel;
 import level.elements.Tile;
 import tools.Point;
 
-public class CollidableLevel {
+/**
+ * A Collection of all collidables of a level.
+ */
+public class CollisionMap {
     private Collidable[] collidables;
 
+    /**
+     * Creates all collidables of the given level.
+     * @param level
+     */
     public void regenHitboxen(ILevel level) {
         ArrayList<Collidable> tiles = new ArrayList<>();
         Tile[][] layout = level.getLayout();

--- a/code/game/src/collision/Hitbox.java
+++ b/code/game/src/collision/Hitbox.java
@@ -3,29 +3,43 @@ package collision;
 import tools.Point;
 
 public class Hitbox {
+    private static final int bottomLeft = 0, topLeft = 1, topRight = 2, bottomRight = 3;
+
     // Local Position of the hitbox, bottom left is always (0|0), add position.x/y to get the
     // position of the hitbox in the game
     private Point[] corners;
-    private Point position;
+    private Collidable collidable;
 
+    /**
+     * Position of the lower left corner of the hitbox (0|0)
+     * @param widthInPixel Width of the hitbox in pixels
+     * @param heightInPixel Height of the hitbox in pixels
+     */
+    public Hitbox(int widthInPixel, int heightInPixel) {
+        this(widthInPixel,heightInPixel,new Point(0,0));
+    }
     /**
      * @param widthInPixel Width of the hitbox in pixels
      * @param heightInPixel Height of the hitbox in pixels
-     * @param position Position of the lower left corner of the hitbox (0|0)
+     * @param offset Offset of the corners of the hitbox
      */
-    public Hitbox(int widthInPixel, int heightInPixel, Point position) {
-        this.position = position;
+    public Hitbox(int widthInPixel, int heightInPixel, Point offset) {
         // from pixel to point 16px x 16px =1x1
         float width = widthInPixel / 16f;
         float height = heightInPixel / 16f;
+        float offsetX = offset.x / 16f;
+        float offsetY = offset.y / 16f;
+
         corners = new Point[4];
-        corners[0] = new Point(0, 0);
-        corners[1] = new Point(0, height);
-        corners[2] = new Point(width, height);
-        corners[3] = new Point(width, 0);
+        corners[bottomLeft] = new Point(offsetX, offsetY);
+        corners[topLeft] = new Point(offsetX, offsetY + height);
+        corners[topRight] = new Point(offsetX + width, offsetY + height);
+        corners[bottomRight] = new Point( offsetX + width, offsetY );
     }
 
     /**
+     * topLeft:   1 , topRight:    2
+     * bottomLeft:0 , bottomRight: 3
      * @return The local positions of the corners.
      */
     public Point[] getCorners() {
@@ -33,23 +47,66 @@ public class Hitbox {
     }
 
     /**
-     * Check if two hitboxes colided with each other. TODO
+     * Check if two hitboxes collided with each other. TODO
      *
      * @param other Hitbox to check for collision with
      * @return The direction from which this Hitbox consolidates with the other. NONE if there is no
      *     collision
      */
-    public CharacterDirection colide(Hitbox other) {
+    public CharacterDirection collide(Hitbox other) {
+        // get real position data for the bottomLeft and topRight
+        var bottomLeft = new Point(corners[Hitbox.bottomLeft]);
+        bottomLeft.x += collidable.getPosition().x;
+        bottomLeft.y += collidable.getPosition().y;
+        var topRight =  new Point(corners[Hitbox.topRight]);
+        topRight.x += collidable.getPosition().x;
+        topRight.y += collidable.getPosition().y;
+
+        // get real position data for the bottomLeft and topRight of the possible collided
+        var otherBottomLeft =  new Point(other.corners[Hitbox.bottomLeft]);
+        otherBottomLeft.x += other.collidable.getPosition().x;
+        otherBottomLeft.y += other.collidable.getPosition().y;
+        var otherTopRight =  new Point(other.corners[Hitbox.topRight]);
+        otherTopRight.x += other.collidable.getPosition().x;
+        otherTopRight.y += other.collidable.getPosition().y;
+        // easy axis alligned collision check
+        // https://developer.mozilla.org/en-US/docs/Games/Techniques/2D_collision_detection
+        if (bottomLeft.x < otherTopRight.x &&
+            topRight.x > otherBottomLeft.x &&
+            bottomLeft.y < otherTopRight.y &&
+            topRight.y > otherBottomLeft.y) {
+            // any collision solve the Direction
+            // direction
+            var centerthis = getCenter(bottomLeft,topRight);
+            var centerOther = getCenter(otherBottomLeft,otherTopRight);
+
+            var v = centerOther.sub(centerthis);
+            float rads = v.radians();
+            double piQuarter = Math.PI / 4;
+            // only works with squares well
+            if(rads < 3*-piQuarter){
+                return CharacterDirection.LEFT;
+            } else if(rads < -piQuarter){
+                return CharacterDirection.UP;
+            } else if(rads < piQuarter){
+                return CharacterDirection.RIGHT;
+            } else if (rads < 3* piQuarter){
+                return CharacterDirection.DOWN;
+            } else {
+                return CharacterDirection.LEFT;
+            }
+        }
+
         return CharacterDirection.NONE;
     }
 
     /**
-     * Set the position of the bottom left corner
+     * Set the collidable of the bottom left corner
      *
-     * @param position
+     * @param collidable
      */
-    public void setPosition(Point position) {
-        this.position = position;
+    public void setCollidable(Collidable collidable) {
+        this.collidable = collidable;
     }
 
     /**
@@ -57,7 +114,41 @@ public class Hitbox {
      *
      * @return
      */
-    public Point getPosition() {
-        return position;
+    public Collidable getCollidable() {
+        return collidable;
+    }
+
+    private Vector getCenter(Point p1, Point p2){
+        var v1 = new Vector(p1);
+        var v2 = new Vector(p2);
+        return v2.sub(v1).div(2).add(v1);
+    }
+
+    private class Vector{
+        float x;
+        float y;
+
+        public Vector(Point point){
+            this(point.x, point.y);
+        }
+
+        public Vector(float x, float y) {
+            this.x = x;
+            this.y = y;
+        }
+
+        Vector add(Vector v){
+            return new Vector(this.x +v.x, this.y + v.y);
+        }
+        Vector sub(Vector v){
+            return new Vector(this.x - v.x, this.y - v.y);
+        }
+        Vector div(float div){
+            return new Vector(this.x / div, this.y / div );
+        }
+
+        float radians(){
+            return (float) Math.atan2(y,x);
+        }
     }
 }

--- a/code/game/src/collision/Hitbox.java
+++ b/code/game/src/collision/Hitbox.java
@@ -3,7 +3,10 @@ package collision;
 import tools.Point;
 
 public class Hitbox {
-    private static final int bottomLeft = 0, topLeft = 1, topRight = 2, bottomRight = 3;
+    public static final int CORNER_BOTTOM_LEFT = 0,
+            CORNER_TOP_LEFT = 1,
+            CORNER_TOP_RIGHT = 2,
+            CORNER_BOTTOM_RIGHT = 3;
 
     // Local Position of the hitbox, bottom left is always (0|0), add position.x/y to get the
     // position of the hitbox in the game
@@ -12,11 +15,12 @@ public class Hitbox {
 
     /**
      * Position of the lower left corner of the hitbox (0|0)
+     *
      * @param widthInPixel Width of the hitbox in pixels
      * @param heightInPixel Height of the hitbox in pixels
      */
     public Hitbox(int widthInPixel, int heightInPixel) {
-        this(widthInPixel,heightInPixel,new Point(0,0));
+        this(widthInPixel, heightInPixel, new Point(0, 0));
     }
     /**
      * @param widthInPixel Width of the hitbox in pixels
@@ -31,15 +35,17 @@ public class Hitbox {
         float offsetY = offset.y / 16f;
 
         corners = new Point[4];
-        corners[bottomLeft] = new Point(offsetX, offsetY);
-        corners[topLeft] = new Point(offsetX, offsetY + height);
-        corners[topRight] = new Point(offsetX + width, offsetY + height);
-        corners[bottomRight] = new Point( offsetX + width, offsetY );
+        corners[CORNER_BOTTOM_LEFT] = new Point(offsetX, offsetY);
+        corners[CORNER_TOP_LEFT] = new Point(offsetX, offsetY + height);
+        corners[CORNER_TOP_RIGHT] = new Point(offsetX + width, offsetY + height);
+        corners[CORNER_BOTTOM_RIGHT] = new Point(offsetX + width, offsetY);
     }
 
     /**
-     * topLeft:   1 , topRight:    2
-     * bottomLeft:0 , bottomRight: 3
+     * Get the Corners
+     *
+     * <p>topLeft: 1 , topRight: 2 bottomLeft:0 , bottomRight: 3
+     *
      * @return The local positions of the corners.
      */
     public Point[] getCorners() {
@@ -55,42 +61,42 @@ public class Hitbox {
      */
     public CharacterDirection collide(Hitbox other) {
         // get real position data for the bottomLeft and topRight
-        var bottomLeft = new Point(corners[Hitbox.bottomLeft]);
+        Point bottomLeft = new Point(corners[Hitbox.CORNER_BOTTOM_LEFT]);
         bottomLeft.x += collidable.getPosition().x;
         bottomLeft.y += collidable.getPosition().y;
-        var topRight =  new Point(corners[Hitbox.topRight]);
+        Point topRight = new Point(corners[Hitbox.CORNER_TOP_RIGHT]);
         topRight.x += collidable.getPosition().x;
         topRight.y += collidable.getPosition().y;
 
         // get real position data for the bottomLeft and topRight of the possible collided
-        var otherBottomLeft =  new Point(other.corners[Hitbox.bottomLeft]);
+        Point otherBottomLeft = new Point(other.corners[Hitbox.CORNER_BOTTOM_LEFT]);
         otherBottomLeft.x += other.collidable.getPosition().x;
         otherBottomLeft.y += other.collidable.getPosition().y;
-        var otherTopRight =  new Point(other.corners[Hitbox.topRight]);
+        Point otherTopRight = new Point(other.corners[Hitbox.CORNER_TOP_RIGHT]);
         otherTopRight.x += other.collidable.getPosition().x;
         otherTopRight.y += other.collidable.getPosition().y;
         // easy axis alligned collision check
         // https://developer.mozilla.org/en-US/docs/Games/Techniques/2D_collision_detection
-        if (bottomLeft.x < otherTopRight.x &&
-            topRight.x > otherBottomLeft.x &&
-            bottomLeft.y < otherTopRight.y &&
-            topRight.y > otherBottomLeft.y) {
+        if (bottomLeft.x < otherTopRight.x
+                && topRight.x > otherBottomLeft.x
+                && bottomLeft.y < otherTopRight.y
+                && topRight.y > otherBottomLeft.y) {
             // any collision solve the Direction
-            // direction
-            var centerthis = getCenter(bottomLeft,topRight);
-            var centerOther = getCenter(otherBottomLeft,otherTopRight);
 
-            var v = centerOther.sub(centerthis);
+            Vector centerthis = getCenter(bottomLeft, topRight);
+            Vector centerOther = getCenter(otherBottomLeft, otherTopRight);
+
+            Vector v = centerOther.sub(centerthis);
             float rads = v.radians();
             double piQuarter = Math.PI / 4;
-            // only works with squares well
-            if(rads < 3*-piQuarter){
+            // Direction based on the radians
+            if (rads < 3 * -piQuarter) {
                 return CharacterDirection.LEFT;
-            } else if(rads < -piQuarter){
+            } else if (rads < -piQuarter) {
                 return CharacterDirection.UP;
-            } else if(rads < piQuarter){
+            } else if (rads < piQuarter) {
                 return CharacterDirection.RIGHT;
-            } else if (rads < 3* piQuarter){
+            } else if (rads < 3 * piQuarter) {
                 return CharacterDirection.DOWN;
             } else {
                 return CharacterDirection.LEFT;
@@ -118,17 +124,17 @@ public class Hitbox {
         return collidable;
     }
 
-    private Vector getCenter(Point p1, Point p2){
+    private Vector getCenter(Point p1, Point p2) {
         var v1 = new Vector(p1);
         var v2 = new Vector(p2);
         return v2.sub(v1).div(2).add(v1);
     }
 
-    private class Vector{
+    private class Vector {
         float x;
         float y;
 
-        public Vector(Point point){
+        public Vector(Point point) {
             this(point.x, point.y);
         }
 
@@ -137,18 +143,20 @@ public class Hitbox {
             this.y = y;
         }
 
-        Vector add(Vector v){
-            return new Vector(this.x +v.x, this.y + v.y);
-        }
-        Vector sub(Vector v){
-            return new Vector(this.x - v.x, this.y - v.y);
-        }
-        Vector div(float div){
-            return new Vector(this.x / div, this.y / div );
+        Vector add(Vector v) {
+            return new Vector(this.x + v.x, this.y + v.y);
         }
 
-        float radians(){
-            return (float) Math.atan2(y,x);
+        Vector sub(Vector v) {
+            return new Vector(this.x - v.x, this.y - v.y);
+        }
+
+        Vector div(float div) {
+            return new Vector(this.x / div, this.y / div);
+        }
+
+        float radians() {
+            return (float) Math.atan2(y, x);
         }
     }
 }

--- a/code/game/src/collision/Hitbox.java
+++ b/code/game/src/collision/Hitbox.java
@@ -83,11 +83,12 @@ public class Hitbox {
                 && topRight.y > otherBottomLeft.y) {
             // any collision solve the Direction
 
-            Vector centerthis = getCenter(bottomLeft, topRight);
-            Vector centerOther = getCenter(otherBottomLeft, otherTopRight);
+            Point centerthis = getCenter(bottomLeft, topRight);
+            Point centerOther = getCenter(otherBottomLeft, otherTopRight);
 
-            Vector v = centerOther.sub(centerthis);
-            float rads = v.radians();
+            float y = centerOther.y - centerthis.y;
+            float x = centerOther.x - centerthis.x;
+            float rads = (float) Math.atan2(y, x);
             double piQuarter = Math.PI / 4;
             // Direction based on the radians
             if (rads < 3 * -piQuarter) {
@@ -124,39 +125,11 @@ public class Hitbox {
         return collidable;
     }
 
-    private Vector getCenter(Point p1, Point p2) {
-        var v1 = new Vector(p1);
-        var v2 = new Vector(p2);
-        return v2.sub(v1).div(2).add(v1);
-    }
-
-    private class Vector {
-        float x;
-        float y;
-
-        public Vector(Point point) {
-            this(point.x, point.y);
-        }
-
-        public Vector(float x, float y) {
-            this.x = x;
-            this.y = y;
-        }
-
-        Vector add(Vector v) {
-            return new Vector(this.x + v.x, this.y + v.y);
-        }
-
-        Vector sub(Vector v) {
-            return new Vector(this.x - v.x, this.y - v.y);
-        }
-
-        Vector div(float div) {
-            return new Vector(this.x / div, this.y / div);
-        }
-
-        float radians() {
-            return (float) Math.atan2(y, x);
-        }
+    private Point getCenter(Point p1, Point p2) {
+        // (p2 - p1) / 2 + p1
+        // move p2 to the center with the help of p1 then half the vector and then move back with p1
+        float cx = (p2.x - p1.x) / 2f + p1.x;
+        float cy = (p2.y - p1.y) / 2f + p2.x;
+        return new Point(cx, cy);
     }
 }

--- a/code/game/src/collision/RectCollidable.java
+++ b/code/game/src/collision/RectCollidable.java
@@ -1,0 +1,40 @@
+package collision;
+
+import tools.Point;
+
+public class RectCollidable implements Collidable {
+    private Point position;
+    private float width;
+    private float height;
+
+    private Hitbox hitbox;
+
+    public RectCollidable(Point position, float width, float height) {
+        this.position = position;
+        this.width = width;
+        this.height = height;
+        hitbox = new Hitbox((int) width, (int) height);
+        hitbox.setCollidable(this);
+    }
+
+    public RectCollidable(Point position, int width, int height) {
+        this.position = position;
+        this.width = width / 16f;
+        this.height = height / 16f;
+        hitbox = new Hitbox((int) width, (int) height);
+        hitbox.setCollidable(this);
+    }
+
+    @Override
+    public Hitbox getHitbox() {
+        return hitbox;
+    }
+
+    @Override
+    public Point getPosition() {
+        return position;
+    }
+
+    @Override
+    public void colide(Collidable other, CharacterDirection from) {}
+}

--- a/code/game/src/collision/TileCollidable.java
+++ b/code/game/src/collision/TileCollidable.java
@@ -1,0 +1,29 @@
+package collision;
+
+import level.elements.Tile;
+import tools.Point;
+
+public class TileCollidable implements Collidable {
+    private Tile tile;
+    private Hitbox hitbox;
+
+    public TileCollidable(Tile tile, Hitbox hitbox) {
+        this.tile = tile;
+        this.hitbox = hitbox;
+    }
+
+    @Override
+    public Hitbox getHitbox() {
+        return hitbox;
+    }
+
+    @Override
+    public Point getPosition() {
+        return tile.getCoordinate().toPoint();
+    }
+
+    @Override
+    public void colide(Collidable other, CharacterDirection from) {
+        // do nothing
+    }
+}

--- a/code/game/src/mydungeon/Starter.java
+++ b/code/game/src/mydungeon/Starter.java
@@ -20,6 +20,7 @@ public class Starter extends Game {
     private Hero hero;
     private List<Monster> monster;
     private ScreenController sc;
+    private CollidableLevel clevel;
 
     @Override
     protected void setup() {
@@ -52,8 +53,10 @@ public class Starter extends Game {
 
     @Override
     public void onLevelLoad() {
-        hero.setLevel(levelAPI.getCurrentLevel());
+        ILevel level = levelAPI.getCurrentLevel();
+        hero.setLevel(level);
         spawnMonster();
+        clevel.regenHitboxen(level);
     }
 
     void spawnMonster() {
@@ -62,6 +65,7 @@ public class Starter extends Game {
         for (int i = 0; i < 10; i++) {
             Monster m = new Imp();
             m.setLevel(levelAPI.getCurrentLevel());
+            m.setCLevel(clevel);
             m.getHitbox().setCollidable(m);
             monster.add(m);
             entityController.add(m);

--- a/code/game/src/mydungeon/Starter.java
+++ b/code/game/src/mydungeon/Starter.java
@@ -4,7 +4,7 @@ import character.monster.Imp;
 import character.monster.Monster;
 import character.player.Hero;
 import collision.CharacterDirection;
-import collision.CollidableLevel;
+import collision.CollisionMap;
 import controller.Game;
 import controller.ScreenController;
 import java.util.ArrayList;
@@ -22,11 +22,11 @@ public class Starter extends Game {
     private Hero hero;
     private List<Monster> monster;
     private ScreenController sc;
-    private CollidableLevel clevel;
+    private CollisionMap clevel;
 
     @Override
     protected void setup() {
-        clevel = new CollidableLevel();
+        clevel = new CollisionMap();
         monster = new ArrayList<>();
         hero = new Hero();
         sc = new ScreenController(batch);

--- a/code/game/src/mydungeon/Starter.java
+++ b/code/game/src/mydungeon/Starter.java
@@ -4,10 +4,12 @@ import character.monster.Imp;
 import character.monster.Monster;
 import character.player.Hero;
 import collision.CharacterDirection;
+import collision.CollidableLevel;
 import controller.Game;
 import controller.ScreenController;
 import java.util.ArrayList;
 import java.util.List;
+import level.elements.ILevel;
 import starter.DesktopLauncher;
 
 /**
@@ -24,7 +26,7 @@ public class Starter extends Game {
 
     @Override
     protected void setup() {
-
+        clevel = new CollidableLevel();
         monster = new ArrayList<>();
         hero = new Hero();
         sc = new ScreenController(batch);

--- a/code/game/src/mydungeon/Starter.java
+++ b/code/game/src/mydungeon/Starter.java
@@ -23,11 +23,13 @@ public class Starter extends Game {
 
     @Override
     protected void setup() {
+
         monster = new ArrayList<>();
         hero = new Hero();
         sc = new ScreenController(batch);
         controller.add(sc);
         levelAPI.loadLevel();
+        hero.getHitbox().setCollidable(hero);
         camera.follow(hero);
         entityController.add(hero);
     }
@@ -40,7 +42,7 @@ public class Starter extends Game {
 
     private void checkForCollision() {
         for (Monster m : monster) {
-            CharacterDirection direction = hero.getHitbox().colide(m.getHitbox());
+            CharacterDirection direction = hero.getHitbox().collide(m.getHitbox());
             if (direction != CharacterDirection.NONE) {
                 hero.colide(m, direction);
                 m.colide(hero, direction);
@@ -60,6 +62,7 @@ public class Starter extends Game {
         for (int i = 0; i < 10; i++) {
             Monster m = new Imp();
             m.setLevel(levelAPI.getCurrentLevel());
+            m.getHitbox().setCollidable(m);
             monster.add(m);
             entityController.add(m);
         }


### PR DESCRIPTION
fixes #17 

Ich habe jetzt mal die `Hitbox` erweitert. Was jetzt aktuell vielleicht noch zu einem Problem führen kann, ist nicht quadratische Hitboxen, da ich aus Gründen der Einfachheit beim `Hitbox#collide`, mit statischen Werten angelegt habe anstelle von den Winkelgrenzen jedes Mal neu zu berechnen.



- [x] Kollision zwischen zwei hitboxen
- [x] Monster laufen nicht mehr nur noch gegen die Wand
- [x] Level überladen, um Hitboxen für Wände anzuwenden
- [x] Level Überladung als eigenständiges Plugin umschreiben, damit generierte Level funktionieren.


Der Aktuelle Stand hier die roten linien sind hilfreich vielleicht lohnt es sich dies einmal richtig einzubauen und nicht nur als hack.
![Hitbox pathfinding](https://user-images.githubusercontent.com/32952411/196277858-d057ace2-5c5b-4ed0-8483-255cb2a7e5ea.gif)

