### PR TITLE
Add environments to store types and function definitions

### DIFF
--- a/dsl/src/interpreter/DSLInterpreter.java
+++ b/dsl/src/interpreter/DSLInterpreter.java
@@ -14,6 +14,7 @@ import org.antlr.v4.runtime.CommonTokenStream;
 import parser.AST.*;
 // CHECKSTYLE:ON: AvoidStarImport
 import parser.DungeonASTConverter;
+import runtime.GameEnvironment;
 import runtime.MemorySpace;
 import runtime.Value;
 // importing all required classes from symbolTable will be to verbose
@@ -91,6 +92,7 @@ public class DSLInterpreter implements AstVisitor<Object> {
         var programAST = astConverter.walk(programParseTree);
 
         SymbolTableParser symTableParser = new SymbolTableParser();
+        symTableParser.setup(new GameEnvironment());
         var result = symTableParser.walk(programAST);
         symbolTable = result.symbolTable;
 

--- a/dsl/src/runtime/GameEnvironment.java
+++ b/dsl/src/runtime/GameEnvironment.java
@@ -1,0 +1,104 @@
+package runtime;
+
+import dslToGame.QuestConfig;
+import java.util.ArrayList;
+import java.util.HashMap;
+import runtime.nativeFunctions.NativePrint;
+import semanticAnalysis.IScope;
+import semanticAnalysis.Scope;
+import semanticAnalysis.Symbol;
+import semanticAnalysis.SymbolTable;
+import semanticAnalysis.types.BuiltInType;
+import semanticAnalysis.types.IType;
+import semanticAnalysis.types.TypeBuilder;
+
+public class GameEnvironment implements IEvironment {
+    // TODO: also make HashMaps
+    private static final ArrayList<Symbol> builtInTypes = buildBuiltInTypes();
+    private static final ArrayList<Symbol> nativeFunctions = buildNativeFunctions();
+
+    private final HashMap<String, Symbol> loadedTypes = new HashMap<>();
+    private final HashMap<String, Symbol> loadedFunctions = new HashMap<>();
+    private final SymbolTable symbolTable;
+    private final Scope globalScope;
+
+    /**
+     * Constructor. Creates fresh global scope and symbol table and binds built in types and native
+     * functions
+     */
+    public GameEnvironment() {
+        this.globalScope = new Scope();
+        this.symbolTable = new SymbolTable(this.globalScope);
+
+        for (Symbol type : builtInTypes) {
+            globalScope.bind(type);
+        }
+
+        for (Symbol func : nativeFunctions) {
+            globalScope.bind(func);
+        }
+    }
+
+    @Override
+    public Symbol[] getTypes() {
+        var typesArray = new Symbol[builtInTypes.size() + loadedTypes.size()];
+        var combinedList = new ArrayList<Symbol>();
+        combinedList.addAll(builtInTypes);
+        combinedList.addAll(loadedTypes.values());
+        return combinedList.toArray(typesArray);
+    }
+
+    @Override
+    public Symbol[] getFunctions() {
+        var funcArray = new Symbol[nativeFunctions.size() + loadedFunctions.size()];
+        var combinedList = new ArrayList<Symbol>();
+        combinedList.addAll(nativeFunctions);
+        combinedList.addAll(loadedFunctions.values());
+        return combinedList.toArray(funcArray);
+    }
+
+    @Override
+    public void loadTypes(Symbol[] types) {
+        for (Symbol type : types) {
+            if (!(type instanceof IType)) {
+                continue;
+            }
+            if (loadedTypes.containsKey(type.getName())) {
+                continue;
+            }
+            loadedTypes.put(type.getName(), type);
+            this.globalScope.bind(type);
+        }
+    }
+
+    @Override
+    public SymbolTable getSymbolTable() {
+        return this.symbolTable;
+    }
+
+    @Override
+    public IScope getGlobalScope() {
+        return this.globalScope;
+    }
+
+    private static ArrayList<Symbol> buildBuiltInTypes() {
+        ArrayList<Symbol> types = new ArrayList<>();
+
+        types.add(BuiltInType.intType);
+        types.add(BuiltInType.stringType);
+        types.add(BuiltInType.graphType);
+        types.add(BuiltInType.funcType);
+
+        TypeBuilder tb = new TypeBuilder();
+        var questConfigType = tb.createTypeFromClass(Scope.NULL, QuestConfig.class);
+        types.add(questConfigType);
+
+        return types;
+    }
+
+    private static ArrayList<Symbol> buildNativeFunctions() {
+        ArrayList<Symbol> nativeFunctions = new ArrayList<>();
+        nativeFunctions.add(NativePrint.func);
+        return nativeFunctions;
+    }
+}

--- a/dsl/src/runtime/IEvironment.java
+++ b/dsl/src/runtime/IEvironment.java
@@ -1,0 +1,43 @@
+package runtime;
+
+import semanticAnalysis.FunctionSymbol;
+import semanticAnalysis.IScope;
+import semanticAnalysis.Symbol;
+import semanticAnalysis.SymbolTable;
+
+public interface IEvironment {
+
+    /**
+     * @return all available types of the environment
+     */
+    default Symbol[] getTypes() {
+        return new Symbol[0];
+    }
+
+    /**
+     * @return all available function definitions
+     */
+    default Symbol[] getFunctions() {
+        return new Symbol[0];
+    }
+
+    /**
+     * @param types AggregateTypes to load into the environment
+     */
+    default void loadTypes(Symbol[] types) {}
+
+    /**
+     * @param functionDefinitions FunctionSymbols to load into the environment
+     */
+    default void loadFunctions(FunctionSymbol[] functionDefinitions) {}
+
+    /**
+     * @return symbol table of this environment
+     */
+    SymbolTable getSymbolTable();
+
+    /**
+     * @return global scope of this environment
+     */
+    IScope getGlobalScope();
+}

--- a/dsl/src/runtime/nativeFunctions/NativePrint.java
+++ b/dsl/src/runtime/nativeFunctions/NativePrint.java
@@ -5,18 +5,21 @@ import java.util.List;
 import parser.AST.Node;
 import semanticAnalysis.ICallable;
 import semanticAnalysis.IScope;
+import semanticAnalysis.Scope;
 import semanticAnalysis.ScopedSymbol;
 import semanticAnalysis.Symbol;
 import semanticAnalysis.types.BuiltInType;
 
 // TODO: how to enable semantic analysis for this? e.g. parameter-count, etc.
 public class NativePrint extends ScopedSymbol implements ICallable {
+    public static NativePrint func = new NativePrint(Scope.NULL);
+
     /**
      * Constructor
      *
      * @param parentScope parent scope of this function
      */
-    public NativePrint(IScope parentScope) {
+    private NativePrint(IScope parentScope) {
         super("print", parentScope, BuiltInType.intType);
 
         // bind parameters

--- a/dsl/src/semanticAnalysis/IScope.java
+++ b/dsl/src/semanticAnalysis/IScope.java
@@ -43,6 +43,14 @@ public interface IScope {
     Symbol resolve(String name);
 
     /**
+     * Try to resolve a name in this scope or the parent scopes.
+     *
+     * @param name The name to resolve
+     * @return The symbol with the name or Symbol.NULL, if the symbol could not be resolved
+     */
+    Symbol resolve(String name, boolean resolveInParent);
+
+    /**
      * Get all symbols of this scope in a List
      *
      * @return List containing all symbols in this scope.

--- a/dsl/src/semanticAnalysis/ScopedSymbol.java
+++ b/dsl/src/semanticAnalysis/ScopedSymbol.java
@@ -67,14 +67,24 @@ public class ScopedSymbol extends Symbol implements IScope {
      * @param name the name of the symbol to resolvle
      * @return the resolved symbol or Symbol.NULL, if the name could not be resolved
      */
-    public Symbol resolve(String name) {
+    public Symbol resolve(String name, boolean resolveInParent) {
         if (symbols.containsKey(name)) {
             return symbols.get(name);
-        } else if (scope != null) {
+        } else if (!scope.equals(Scope.NULL) && resolveInParent) {
             return scope.resolve(name);
         } else {
             return Symbol.NULL;
         }
+    }
+
+    /**
+     * Try to resolve the passed name in this scope (or the parent scope).
+     *
+     * @param name the name of the symbol to resolvle
+     * @return the resolved symbol or Symbol.NULL, if the name could not be resolved
+     */
+    public Symbol resolve(String name) {
+        return this.resolve(name, true);
     }
 
     /**

--- a/dsl/src/semanticAnalysis/SymbolTableParser.java
+++ b/dsl/src/semanticAnalysis/SymbolTableParser.java
@@ -99,8 +99,7 @@ public class SymbolTableParser implements AstVisitor<Void> {
     }
 
     private void setupNativeFunctions() {
-        var nativePrint = new NativePrint(globalScope());
-        globalScope().bind(nativePrint);
+        globalScope().bind(NativePrint.func);
     }
 
     private void setupBuiltinTypes() {

--- a/dsl/test/helpers/Helpers.java
+++ b/dsl/test/helpers/Helpers.java
@@ -10,6 +10,7 @@ import org.antlr.v4.runtime.CharStream;
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
 import parser.DungeonASTConverter;
+import runtime.GameEnvironment;
 import semanticAnalysis.SymbolTableParser;
 
 public class Helpers {
@@ -82,6 +83,7 @@ public class Helpers {
      */
     public static SymbolTableParser.Result getSymtableForAST(parser.AST.Node ast) {
         SymbolTableParser symbolTableParser = new SymbolTableParser();
+        symbolTableParser.setup(new GameEnvironment());
         return symbolTableParser.walk(ast);
     }
 }

--- a/dsl/test/helpers/Helpers.java
+++ b/dsl/test/helpers/Helpers.java
@@ -11,7 +11,9 @@ import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
 import parser.DungeonASTConverter;
 import runtime.GameEnvironment;
+import semanticAnalysis.SymbolTable;
 import semanticAnalysis.SymbolTableParser;
+import semanticAnalysis.types.AggregateType;
 
 public class Helpers {
 
@@ -85,5 +87,22 @@ public class Helpers {
         SymbolTableParser symbolTableParser = new SymbolTableParser();
         symbolTableParser.setup(new GameEnvironment());
         return symbolTableParser.walk(ast);
+    }
+
+    /**
+     *
+     * Performs semantic analysis for given AST with loaded types and returns the {@link
+     * semanticAnalysis.SymbolTableParser.Result} output from the SymbolTableParser
+     *
+     * @param ast the AST to create the symbol table for
+     * @param types the types to load into the environment before doing semantic analysis
+     * @return the {@link semanticAnalysis.SymbolTableParser.Result} of the semantic analysis
+     */
+    public static SymbolTableParser.Result getSymtableForASTWithLoadedTypes(parser.AST.Node ast, AggregateType[] types) {
+        var symTableParser = new SymbolTableParser();
+        var env = new GameEnvironment();
+        env.loadTypes(types);
+        symTableParser.setup(env);
+        return symTableParser.walk(ast);
     }
 }

--- a/dsl/test/helpers/Helpers.java
+++ b/dsl/test/helpers/Helpers.java
@@ -11,7 +11,6 @@ import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
 import parser.DungeonASTConverter;
 import runtime.GameEnvironment;
-import semanticAnalysis.SymbolTable;
 import semanticAnalysis.SymbolTableParser;
 import semanticAnalysis.types.AggregateType;
 
@@ -90,7 +89,6 @@ public class Helpers {
     }
 
     /**
-     *
      * Performs semantic analysis for given AST with loaded types and returns the {@link
      * semanticAnalysis.SymbolTableParser.Result} output from the SymbolTableParser
      *
@@ -98,7 +96,8 @@ public class Helpers {
      * @param types the types to load into the environment before doing semantic analysis
      * @return the {@link semanticAnalysis.SymbolTableParser.Result} of the semantic analysis
      */
-    public static SymbolTableParser.Result getSymtableForASTWithLoadedTypes(parser.AST.Node ast, AggregateType[] types) {
+    public static SymbolTableParser.Result getSymtableForASTWithLoadedTypes(
+            parser.AST.Node ast, AggregateType[] types) {
         var symTableParser = new SymbolTableParser();
         var env = new GameEnvironment();
         env.loadTypes(types);


### PR DESCRIPTION
Enables dynamically loading of data types and functions definitions in an environment. This can be used to increase testability of component based definitions and to create environments for different use-cases (e.g. testing the structure of an AST via a DSL-function)