### PR TITLE
[GAME] Pause 

### DIFF
--- a/game/src/ecs/systems/DrawSystem.java
+++ b/game/src/ecs/systems/DrawSystem.java
@@ -45,4 +45,10 @@ public class DrawSystem extends ECS_System {
             }
         }
     }
+
+    @Override
+    public void toggleRun() {
+        // DrawSystem cant pause
+        run = true;
+    }
 }

--- a/game/src/ecs/systems/ECS_System.java
+++ b/game/src/ecs/systems/ECS_System.java
@@ -6,10 +6,25 @@ import mydungeon.ECS;
 /** Marks a Class as a System in the ECS */
 public abstract class ECS_System implements Removable {
 
+    protected boolean run;
+
     public ECS_System() {
         ECS.systems.add(this);
+        run = true;
     }
 
     /** Gets called every Frame */
     public abstract void update();
+
+    /**
+     * @return true if this system is running, false if it is in pause mode
+     */
+    public boolean isRunning() {
+        return run;
+    }
+
+    /** Toggle this system between run and pause */
+    public void toggleRun() {
+        run = !run;
+    }
 }

--- a/game/src/ecs/systems/SystemController.java
+++ b/game/src/ecs/systems/SystemController.java
@@ -11,6 +11,6 @@ public class SystemController extends AbstractController<ECS_System> {
 
     @Override
     public void process(ECS_System e) {
-        e.update();
+        if (e.isRunning()) e.update();
     }
 }

--- a/game/src/mydungeon/ECS.java
+++ b/game/src/mydungeon/ECS.java
@@ -1,5 +1,7 @@
 package mydungeon;
 
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Input;
 import controller.Game;
 import ecs.components.AnimationComponent;
 import ecs.components.PlayableComponent;
@@ -63,6 +65,9 @@ public class ECS extends Game {
     @Override
     protected void frame() {
         camera.setFocusPoint(hero.getPositionComponent().getPosition());
+
+        // debug pause
+        if (Gdx.input.isKeyJustPressed(Input.Keys.P)) togglePause();
     }
 
     @Override
@@ -70,6 +75,13 @@ public class ECS extends Game {
         currentLevel = levelAPI.getCurrentLevel();
         hero.getPositionComponent()
                 .setPosition(currentLevel.getStartTile().getCoordinate().toPoint());
+    }
+
+    /** Toggle between pause and run */
+    public static void togglePause() {
+        if (systems != null) {
+            systems.forEach(s -> s.toggleRun());
+        }
     }
 
     public static void main(String[] args) {

--- a/game/test/ecs/systems/ECS_SystemTest.java
+++ b/game/test/ecs/systems/ECS_SystemTest.java
@@ -1,0 +1,45 @@
+package ecs.systems;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import mydungeon.ECS;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ECS_SystemTest {
+
+    private ECS_System testSystem;
+    private int updates;
+
+    @Before
+    public void setup() {
+        updates = 0;
+        ECS.systems = new SystemController();
+        testSystem =
+                new ECS_System() {
+                    @Override
+                    public void update() {
+                        updates++;
+                    }
+                };
+    }
+
+    @Test
+    public void constructorTest() {
+        assertTrue(ECS.systems.contains(testSystem));
+    }
+
+    @Test
+    public void pauseTest() {
+        assertEquals(0, updates);
+        ECS.systems.update();
+        assertEquals(1, updates);
+        testSystem.toggleRun();
+        ECS.systems.update();
+        assertEquals(1, updates);
+        testSystem.toggleRun();
+        ECS.systems.update();
+        assertEquals(2, updates);
+    }
+}


### PR DESCRIPTION
fixes #76 

- Jedes `ECS_System` hat ein `boolean run` einen entsprechenden getter und eine toggle-funktion.
- der `SystemController` updated nur Systeme deren `run=true` ist 
- Default Implementierung im `ECS_System` 
- Systeme die nicht pausiert werden dürfe (z.B `DrawSystem`) überschreiben die `toggleRun` Methode
- Statische `togglePause` Methode im `ECS` angelegt, welche für jedes System die toggle Funktion aufruft. 
- incl Unit Tests 