### PR TITLE
[DSL->GAME] DSL monster definition prototype

### DIFF
--- a/dsl/src/antlr/DungeonDSL.g4
+++ b/dsl/src/antlr/DungeonDSL.g4
@@ -72,7 +72,7 @@ component_def_list
 // used to configure a used component
 component_def
         : ID
-        | ID '{' property_def_list '}' ;
+        | ID '{' property_def_list? '}' ;
 
 object_def  : type_id=TYPE_SPECIFIER object_id=ID '{' property_def_list? '}' #grammar_type_obj_def
             | type_id=ID object_id=ID '{' property_def_list? '}' #other_type_obj_def

--- a/dsl/src/interpreter/DSLInterpreter.java
+++ b/dsl/src/interpreter/DSLInterpreter.java
@@ -104,6 +104,7 @@ public class DSLInterpreter implements AstVisitor<Object> {
             var propertyDefNode = (PropertyDefNode) propDef;
             var rhsValue = (Value) propertyDefNode.getStmtNode().accept(this);
 
+            // TODO: this fails for adapted types
             var propertySymbol = symbolTable().getSymbolsForAstNode(propDef).get(0);
             Value value = new Value(propertySymbol.getDataType(), rhsValue.getInternalObject());
 
@@ -125,6 +126,8 @@ public class DSLInterpreter implements AstVisitor<Object> {
      */
     public void initializeRuntime(IEvironment environment) {
         this.environment = new RuntimeEnvironment(environment);
+
+        TypeInstantiator typeInstantiator = new TypeInstantiator();
 
         // bind all function definition and object definition symbols to objects
         // in global memorySpace
@@ -167,6 +170,9 @@ public class DSLInterpreter implements AstVisitor<Object> {
      * @return
      */
     private Value createDefaultValue(IType type) {
+        if (type == null) {
+            throw new RuntimeException("Tried to create default value for null type");
+        }
         if (type.getTypeKind().equals(IType.Kind.Basic)) {
             Object internalValue = Value.getDefaultValue(type);
             return new Value(type, internalValue);

--- a/dsl/src/runtime/GameEnvironment.java
+++ b/dsl/src/runtime/GameEnvironment.java
@@ -1,5 +1,6 @@
 package runtime;
 
+import dslToGame.AnimationBuilder;
 import dslToGame.QuestConfig;
 import ecs.components.AnimationComponent;
 import ecs.components.PositionComponent;
@@ -16,6 +17,10 @@ import semanticAnalysis.types.IType;
 import semanticAnalysis.types.TypeBuilder;
 
 public class GameEnvironment implements IEvironment {
+    // TODO: the type builder should also be part of some 'type factory' to
+    //  avoid having only one builder for game Environments
+    protected static final TypeBuilder typeBuilder = new TypeBuilder();
+
     // TODO: also make HashMaps
     protected static final ArrayList<IType> BUILT_IN_TYPES = buildBuiltInTypes();
     protected static final ArrayList<Symbol> NATIVE_FUNCTIONS = buildNativeFunctions();
@@ -24,6 +29,10 @@ public class GameEnvironment implements IEvironment {
     protected final HashMap<String, Symbol> loadedFunctions = new HashMap<>();
     protected final SymbolTable symbolTable;
     protected final Scope globalScope;
+
+    public TypeBuilder getTypeBuilder() {
+        return typeBuilder;
+    }
 
     /**
      * Constructor. Creates fresh global scope and symbol table and binds built in types and native
@@ -34,6 +43,11 @@ public class GameEnvironment implements IEvironment {
         this.symbolTable = new SymbolTable(this.globalScope);
 
         bindBuiltIns();
+        registerDefaultTypeAdapters();
+    }
+
+    protected static void registerDefaultTypeAdapters() {
+        typeBuilder.registerTypeAdapter(AnimationBuilder.class, Scope.NULL);
     }
 
     protected void bindBuiltIns() {
@@ -96,11 +110,14 @@ public class GameEnvironment implements IEvironment {
         types.add(BuiltInType.graphType);
         types.add(BuiltInType.funcType);
 
-        TypeBuilder tb = new TypeBuilder();
-        var questConfigType = tb.createTypeFromClass(Scope.NULL, QuestConfig.class);
-        var entityComponentType = tb.createTypeFromClass(Scope.NULL, Entity.class);
-        var positionComponentType = tb.createTypeFromClass(Scope.NULL, PositionComponent.class);
-        var animationComponentType = tb.createTypeFromClass(Scope.NULL, AnimationComponent.class);
+        registerDefaultTypeAdapters();
+
+        var questConfigType = typeBuilder.createTypeFromClass(Scope.NULL, QuestConfig.class);
+        var entityComponentType = typeBuilder.createTypeFromClass(Scope.NULL, Entity.class);
+        var positionComponentType =
+                typeBuilder.createTypeFromClass(Scope.NULL, PositionComponent.class);
+        var animationComponentType =
+                typeBuilder.createTypeFromClass(Scope.NULL, AnimationComponent.class);
 
         types.add(questConfigType);
         types.add(entityComponentType);

--- a/dsl/src/runtime/IEvironment.java
+++ b/dsl/src/runtime/IEvironment.java
@@ -7,6 +7,7 @@ import semanticAnalysis.SymbolTable;
 import semanticAnalysis.types.IType;
 
 // TODO: this is more of a semantic analysis kind of concept -> put it there
+// TODO: add getTypeBuilder
 public interface IEvironment {
 
     /**

--- a/dsl/src/semanticAnalysis/types/AdaptedType.java
+++ b/dsl/src/semanticAnalysis/types/AdaptedType.java
@@ -1,0 +1,41 @@
+package semanticAnalysis.types;
+
+import semanticAnalysis.IScope;
+
+/** This is used to adapt a type, which only requires a single parameter for construction */
+public class AdaptedType implements IType {
+    final String name;
+    final Class<?> originType;
+    final BuiltInType buildParameterType;
+    final IScope parentScope;
+
+    @Override
+    public String getName() {
+        return this.name;
+    }
+
+    @Override
+    public Kind getTypeKind() {
+        return Kind.PODAdapted;
+    }
+
+    public BuiltInType getBuildParameterType() {
+        return buildParameterType;
+    }
+
+    public IScope getParentScope() {
+        return parentScope;
+    }
+
+    public Class<?> getOriginType() {
+        return originType;
+    }
+
+    public AdaptedType(
+            String name, IScope parentScope, Class<?> originType, BuiltInType buildParameterType) {
+        this.name = name;
+        this.parentScope = parentScope;
+        this.originType = originType;
+        this.buildParameterType = buildParameterType;
+    }
+}

--- a/dsl/src/semanticAnalysis/types/AdaptedType.java
+++ b/dsl/src/semanticAnalysis/types/AdaptedType.java
@@ -1,5 +1,6 @@
 package semanticAnalysis.types;
 
+import java.lang.reflect.Method;
 import semanticAnalysis.IScope;
 
 /** This is used to adapt a type, which only requires a single parameter for construction */
@@ -8,6 +9,9 @@ public class AdaptedType implements IType {
     final Class<?> originType;
     final BuiltInType buildParameterType;
     final IScope parentScope;
+
+    // TODO: this is only a temporary solution
+    final Method builderMethod;
 
     @Override
     public String getName() {
@@ -31,11 +35,20 @@ public class AdaptedType implements IType {
         return originType;
     }
 
+    public Method getBuilderMethod() {
+        return builderMethod;
+    }
+
     public AdaptedType(
-            String name, IScope parentScope, Class<?> originType, BuiltInType buildParameterType) {
+            String name,
+            IScope parentScope,
+            Class<?> originType,
+            BuiltInType buildParameterType,
+            Method builderMethod) {
         this.name = name;
         this.parentScope = parentScope;
         this.originType = originType;
         this.buildParameterType = buildParameterType;
+        this.builderMethod = builderMethod;
     }
 }

--- a/dsl/src/semanticAnalysis/types/AggregateTypeAdapter.java
+++ b/dsl/src/semanticAnalysis/types/AggregateTypeAdapter.java
@@ -1,0 +1,14 @@
+package semanticAnalysis.types;
+
+import semanticAnalysis.IScope;
+
+public class AggregateTypeAdapter extends AggregateType {
+    public AggregateTypeAdapter(String name, IScope parentScope, Class<?> originType) {
+        super(name, parentScope, originType);
+    }
+
+    @Override
+    public Kind getTypeKind() {
+        return Kind.AggregateAdapted;
+    }
+}

--- a/dsl/src/semanticAnalysis/types/DSLTypeAdapter.java
+++ b/dsl/src/semanticAnalysis/types/DSLTypeAdapter.java
@@ -1,0 +1,12 @@
+package semanticAnalysis.types;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface DSLTypeAdapter {
+    Class<?> t();
+}

--- a/dsl/src/semanticAnalysis/types/IType.java
+++ b/dsl/src/semanticAnalysis/types/IType.java
@@ -3,7 +3,9 @@ package semanticAnalysis.types;
 public interface IType {
     enum Kind {
         Basic,
-        Aggregate
+        Aggregate,
+        PODAdapted,
+        AggregateAdapted,
     }
 
     /**

--- a/dsl/src/semanticAnalysis/types/TypeBuilder.java
+++ b/dsl/src/semanticAnalysis/types/TypeBuilder.java
@@ -8,21 +8,19 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import semanticAnalysis.*;
 
 public class TypeBuilder {
-    //private final HashMap<Class<?>, IDSLTypeAdapter> typeAdapters;
     private final HashMap<Class<?>, Method> typeAdapters;
-    private final HashMap<Class<?>, AggregateType> javaTypeToAggregateType;
+    private final HashMap<Class<?>, IType> javaTypeToDSLType;
     private final HashSet<Class<?>> currentLookedUpClasses;
 
     /** Constructor */
     public TypeBuilder() {
         this.typeAdapters = new HashMap<>();
-        this.javaTypeToAggregateType = new HashMap<>();
+        this.javaTypeToDSLType = new HashMap<>();
         this.currentLookedUpClasses = new HashSet<>();
     }
 
@@ -114,19 +112,39 @@ public class TypeBuilder {
      *
      * @param adapterClass the adapter to register
      */
-    public void registerTypeAdapter(Class<?> adapterClass) {
+    public void registerTypeAdapter(Class<?> adapterClass, IScope parentScope) {
         // TODO: create an AggregateType (or a DSLType in general) for the adapter
         for (var method : adapterClass.getDeclaredMethods()) {
-            if (method.isAnnotationPresent(DSLTypeAdapter.class) && Modifier.isStatic(method.getModifiers())) {
+            if (method.isAnnotationPresent(DSLTypeAdapter.class)
+                    && Modifier.isStatic(method.getModifiers())) {
                 var annotation = method.getAnnotation(DSLTypeAdapter.class);
                 var forType = annotation.t();
                 if (this.typeAdapters.containsKey(forType)) {
                     // only one type adapter per type allowed
-                    throw new RuntimeException("There is already a registered type adapter for type " + forType);
+                    throw new RuntimeException(
+                            "There is already a registered type adapter for type " + forType);
                 }
                 this.typeAdapters.put(forType, method);
+
+                // create adapterType
+                var adapterType = createAdapterType(forType, method, parentScope);
+                this.javaTypeToDSLType.put(forType, adapterType);
+
                 return;
             }
+        }
+    }
+
+    public IType createAdapterType(Class<?> forType, Method adapterMethod, IScope parentScope) {
+        String dslTypeName = convertToDSLName(forType.getSimpleName());
+        // get parameters, if only one: PODType, otherwise: AggregateType
+        if (adapterMethod.getParameterCount() == 1) {
+            var paramType = adapterMethod.getParameterTypes()[0];
+            var paramDSLType = getDSLTypeForClass(paramType);
+            return new AdaptedType(dslTypeName, parentScope, forType, (BuiltInType) paramDSLType);
+        } else {
+            // TODO
+            return null;
         }
     }
 
@@ -150,7 +168,12 @@ public class TypeBuilder {
      * @return a new {@link AggregateType}, if the passed Class could be converted to a DSL type;
      *     null otherwise
      */
-    public AggregateType createTypeFromClass(IScope parentScope, Class<?> clazz) {
+    // public AggregateType createTypeFromClass(IScope parentScope, Class<?> clazz) {
+    public IType createTypeFromClass(IScope parentScope, Class<?> clazz) {
+        if (this.javaTypeToDSLType.containsKey(clazz)) {
+            return this.javaTypeToDSLType.get(clazz);
+        }
+
         if (!clazz.isAnnotationPresent(DSLType.class)) {
             return null;
         }
@@ -158,10 +181,6 @@ public class TypeBuilder {
         // catch recursion
         if (this.currentLookedUpClasses.contains(clazz)) {
             throw new RuntimeException("RECURSIVE TYPE DEF");
-        }
-
-        if (this.javaTypeToAggregateType.containsKey(clazz)) {
-            return this.javaTypeToAggregateType.get(clazz);
         }
 
         var annotation = clazz.getAnnotation(DSLType.class);
@@ -180,8 +199,6 @@ public class TypeBuilder {
                 // get datatype
                 var memberDSLType = getDSLTypeForClass(field.getType());
                 if (memberDSLType == null) {
-                    // TODO: handle type adapters
-
                     // lookup the type in already converted types
                     // if it is not already in the converted types, try to convert it -> check for
                     // DSLType
@@ -195,7 +212,7 @@ public class TypeBuilder {
                 type.bind(fieldSymbol);
             }
         }
-        this.javaTypeToAggregateType.put(clazz, type);
+        this.javaTypeToDSLType.put(clazz, type);
         return type;
     }
 }

--- a/dsl/test/interpreter/mockECS/ExternalType.java
+++ b/dsl/test/interpreter/mockECS/ExternalType.java
@@ -1,0 +1,13 @@
+package interpreter.mockECS;
+
+public class ExternalType {
+    public int member1;
+    public int member2;
+    public String member3;
+
+    public ExternalType(int member1, int member2, String member3) {
+        this.member1 = member1;
+        this.member2 = member2;
+        this.member3 = member3;
+    }
+}

--- a/dsl/test/interpreter/mockECS/ExternalTypeBuilder.java
+++ b/dsl/test/interpreter/mockECS/ExternalTypeBuilder.java
@@ -1,0 +1,10 @@
+package interpreter.mockECS;
+
+import semanticAnalysis.types.DSLTypeAdapter;
+
+public class ExternalTypeBuilder {
+    @DSLTypeAdapter(t = ExternalType.class)
+    public static ExternalType buildExternalType(String str) {
+        return new ExternalType(42, 12, str);
+    }
+}

--- a/dsl/test/interpreter/mockECS/TestComponentWithExternalType.java
+++ b/dsl/test/interpreter/mockECS/TestComponentWithExternalType.java
@@ -1,0 +1,19 @@
+package interpreter.mockECS;
+
+import semanticAnalysis.types.DSLType;
+import semanticAnalysis.types.DSLTypeMember;
+
+@DSLType
+public class TestComponentWithExternalType {
+    @DSLTypeMember private int member1;
+    @DSLTypeMember private ExternalType memberExternalType;
+
+    public ExternalType getMemberExternalType() {
+        return memberExternalType;
+    }
+
+    public TestComponentWithExternalType() {
+        member1 = 0;
+        memberExternalType = null;
+    }
+}

--- a/dsl/test/semanticAnalysis/types/RecordBuilder.java
+++ b/dsl/test/semanticAnalysis/types/RecordBuilder.java
@@ -1,0 +1,8 @@
+package semanticAnalysis.types;
+
+public class RecordBuilder {
+    @DSLTypeAdapter(t= TestRecordComponent.class)
+    public static TestRecordComponent buildTestRecord(String param) {
+        return new TestRecordComponent(42, param);
+    }
+}

--- a/dsl/test/semanticAnalysis/types/RecordBuilder.java
+++ b/dsl/test/semanticAnalysis/types/RecordBuilder.java
@@ -1,7 +1,7 @@
 package semanticAnalysis.types;
 
 public class RecordBuilder {
-    @DSLTypeAdapter(t= TestRecordComponent.class)
+    @DSLTypeAdapter(t = TestRecordComponent.class)
     public static TestRecordComponent buildTestRecord(String param) {
         return new TestRecordComponent(42, param);
     }

--- a/dsl/test/semanticAnalysis/types/TestRecordComponent.java
+++ b/dsl/test/semanticAnalysis/types/TestRecordComponent.java
@@ -1,0 +1,3 @@
+package semanticAnalysis.types;
+
+public record TestRecordComponent(int comp1, String comp2) {}

--- a/dsl/test/semanticAnalysis/types/TestRecordUser.java
+++ b/dsl/test/semanticAnalysis/types/TestRecordUser.java
@@ -1,0 +1,12 @@
+package semanticAnalysis.types;
+
+@DSLType
+public class TestRecordUser {
+    @DSLTypeMember int member1;
+    @DSLTypeMember TestRecordComponent componentMember;
+
+    public TestRecordUser() {
+        this.member1 = 0;
+        this.componentMember = null;
+    }
+}

--- a/dsl/test/semanticAnalysis/types/TestTypeBuilder.java
+++ b/dsl/test/semanticAnalysis/types/TestTypeBuilder.java
@@ -111,7 +111,7 @@ public class TestTypeBuilder {
         TypeBuilder tb = new TypeBuilder();
         tb.registerTypeAdapter(RecordBuilder.class, Scope.NULL);
         var type = tb.createTypeFromClass(Scope.NULL, TestRecordUser.class);
-        var memberSymbol = ((AggregateType)type).resolve("component_member");
+        var memberSymbol = ((AggregateType) type).resolve("component_member");
         assertNotEquals(Symbol.NULL, memberSymbol);
         var membersDatatype = memberSymbol.getDataType();
         assertEquals(IType.Kind.PODAdapted, membersDatatype.getTypeKind());

--- a/dsl/test/semanticAnalysis/types/TestTypeBuilder.java
+++ b/dsl/test/semanticAnalysis/types/TestTypeBuilder.java
@@ -1,12 +1,15 @@
 package semanticAnalysis.types;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotSame;
-
 import graph.Graph;
 import org.junit.Test;
 import semanticAnalysis.Scope;
 import semanticAnalysis.Symbol;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.function.Function;
+
+import static org.junit.Assert.*;
 
 public class TestTypeBuilder {
     @Test
@@ -86,5 +89,24 @@ public class TestTypeBuilder {
         var comp2 = dslType.resolve("comp2");
         assertNotSame(comp2, Symbol.NULL);
         assertEquals(BuiltInType.stringType, comp2.getDataType());
+    }
+
+
+    @Test
+    public void testTypeAdapterRegister() {
+        TypeBuilder tb = new TypeBuilder();
+        tb.registerTypeAdapter(RecordBuilder.class);
+
+        var adapter = tb.getRegisteredTypeAdapter(TestRecordComponent.class);
+        assertNotNull(adapter);
+
+        try {
+            var object = adapter.invoke(null, "Hello");
+            assertNotNull(object);
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
+        } catch (InvocationTargetException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/dsl/test/semanticAnalysis/types/TestTypeInstantiator.java
+++ b/dsl/test/semanticAnalysis/types/TestTypeInstantiator.java
@@ -20,7 +20,7 @@ public class TestTypeInstantiator {
         HashMap<String, Object> setValues = new HashMap<>();
 
         TypeBuilder tb = new TypeBuilder();
-        var type = tb.createTypeFromClass(Scope.NULL, QuestConfig.class);
+        var type = (AggregateType) tb.createTypeFromClass(Scope.NULL, QuestConfig.class);
 
         // the fieldName does not necessary match the member name in the created DSLType, so store a
         // map from member to
@@ -76,7 +76,7 @@ public class TestTypeInstantiator {
         HashMap<String, Object> setValues = new HashMap<>();
 
         TypeBuilder tb = new TypeBuilder();
-        var type = tb.createTypeFromClass(Scope.NULL, TestClassOuter.class);
+        var type = (AggregateType) tb.createTypeFromClass(Scope.NULL, TestClassOuter.class);
 
         // the fieldName does not necessary match the member name in the created DSLType, so store a
         // map from member to

--- a/game/src/dslToGame/AnimationBuilder.java
+++ b/game/src/dslToGame/AnimationBuilder.java
@@ -2,14 +2,12 @@ package dslToGame;
 
 import graphic.Animation;
 import semanticAnalysis.types.DSLTypeAdapter;
-import semanticAnalysis.types.IDSLTypeAdapter;
 import textures.TextureHandler;
-
 
 public class AnimationBuilder {
     public static int frameTime = 5;
 
-    @DSLTypeAdapter(t=Animation.class)
+    @DSLTypeAdapter(t = Animation.class)
     public static Animation buildAnimation(String path) {
         return new Animation(TextureHandler.getInstance().getTexturePaths(path), frameTime);
     }

--- a/game/src/dslToGame/AnimationBuilder.java
+++ b/game/src/dslToGame/AnimationBuilder.java
@@ -1,11 +1,15 @@
 package dslToGame;
 
 import graphic.Animation;
+import semanticAnalysis.types.DSLTypeAdapter;
+import semanticAnalysis.types.IDSLTypeAdapter;
 import textures.TextureHandler;
+
 
 public class AnimationBuilder {
     public static int frameTime = 5;
 
+    @DSLTypeAdapter(t=Animation.class)
     public static Animation buildAnimation(String path) {
         return new Animation(TextureHandler.getInstance().getTexturePaths(path), frameTime);
     }

--- a/game/src/ecs/components/AnimationComponent.java
+++ b/game/src/ecs/components/AnimationComponent.java
@@ -2,6 +2,7 @@ package ecs.components;
 
 import ecs.entities.Entity;
 import graphic.Animation;
+import semanticAnalysis.types.DSLContextMember;
 import semanticAnalysis.types.DSLType;
 import semanticAnalysis.types.DSLTypeMember;
 
@@ -40,7 +41,7 @@ public class AnimationComponent extends Component {
     /**
      * @param entity associated entity
      */
-    public AnimationComponent(Entity entity) {
+    public AnimationComponent(@DSLContextMember(name = "entity") Entity entity) {
         super(entity, name);
         this.idleLeft = null;
         this.idleRight = null;

--- a/game/src/ecs/components/PositionComponent.java
+++ b/game/src/ecs/components/PositionComponent.java
@@ -5,7 +5,6 @@ import level.tools.LevelElement;
 import mydungeon.ECS;
 import semanticAnalysis.types.DSLContextMember;
 import semanticAnalysis.types.DSLType;
-import semanticAnalysis.types.DSLTypeMember;
 import tools.Point;
 
 /** PositionComponent is a component that stores the x, y (as Point) position of an entity */
@@ -14,7 +13,8 @@ public class PositionComponent extends Component {
 
     public static String name = "PositionComponent";
 
-    private @DSLTypeMember Point position;
+    // private @DSLTypeMember Point position;
+    private Point position;
 
     /**
      * @param entity associated entity

--- a/game/src/mydungeon/ECS.java
+++ b/game/src/mydungeon/ECS.java
@@ -56,9 +56,14 @@ public class ECS extends Game {
     @Override
     public void onLevelLoad() {
         currentLevel = levelAPI.getCurrentLevel();
+
         entities.clear();
         entities.add(hero);
         heroPositionComponent.setPosition(currentLevel.getStartTile().getCoordinate().toPoint());
+
+        // TODO: when calling this before currentLevel is set, the default ctor of PositionComponent
+        // triggers NullPointerException
+        setupDSLInput();
     }
 
     /** Toggle between pause and run */
@@ -83,9 +88,9 @@ public class ECS extends Game {
                 position_component {
                 },
                 animation_component{
-                    idleLeft: "PATH TO ANIMATIONFILES",
-                    idleRight: "PATH TO ANIMATIONFILES",
-                    currentAnimation: idleLeft
+                    idle_left: "monster/imp/idleLeft",
+                    idle_right: "monster/imp/idleRight",
+                    current_animation: "monster/imp/idleLeft"
                 }
             }
 


### PR DESCRIPTION
Fixes #133 

Aktuell besteht das Problem, dass die Komponenten, die per DSL-Eingabe erstellt werden, "in der Luft hängen", also weder in die `Entity` eingehangen werden, noch in einer globalen Liste landen. Das wird momentan noch manuell nach der DSL-Eingabe (in `Entity::setupDSLInput()`) gemacht.

@AMatutat füg gerne noch weitere Issues hinzu, die von deiner Seite hier gefixt werden, da hast du den besseren Überblick