### PR TITLE
[GAME] add logic for CollideAI

### DIFF
--- a/game/src/ecs/components/ai/AIComponent.java
+++ b/game/src/ecs/components/ai/AIComponent.java
@@ -1,6 +1,7 @@
 package ecs.components.ai;
 
 import ecs.components.Component;
+import ecs.components.ai.fight.CollideAI;
 import ecs.components.ai.fight.IFightAI;
 import ecs.components.ai.idle.IIdleAI;
 import ecs.components.ai.idle.RadiusWalk;
@@ -38,12 +39,8 @@ public class AIComponent extends Component {
     public AIComponent(@DSLContextMember(name = "entity") Entity entity) {
         super(entity, name);
         idleAI = new RadiusWalk(5, 2);
-        transitionAI = new RangeTransition(1.5f);
-        fightAI =
-                entity1 -> {
-                    System.out.println("TIME TO FIGHT!");
-                    // todo replace with melee skill
-                };
+        transitionAI = new RangeTransition(5f);
+        fightAI = new CollideAI(2f);
     }
 
     /** Excecute the ai behavior */

--- a/game/src/ecs/components/ai/fight/CollideAI.java
+++ b/game/src/ecs/components/ai/fight/CollideAI.java
@@ -1,0 +1,43 @@
+package ecs.components.ai.fight;
+
+import com.badlogic.gdx.ai.pfa.GraphPath;
+import ecs.components.ai.AITools;
+import ecs.entities.Entity;
+import level.elements.tile.Tile;
+import mydungeon.ECS;
+import tools.Constants;
+
+public class CollideAI implements IFightAI {
+    private final float rushRange;
+    private final int delay = Constants.FRAME_RATE;
+    private int timeSinceLastUpdate = delay;
+    private GraphPath<Tile> path;
+
+    /**
+     * Attacks the player by colliding if he is within the given range. Otherwise, it will move
+     * towards the player.
+     *
+     * @param rushRange Range in which the faster collide logic should be executed
+     */
+    public CollideAI(float rushRange) {
+        this.rushRange = rushRange;
+    }
+
+    @Override
+    public void fight(Entity entity) {
+        if (AITools.playerInRange(entity, rushRange)) {
+            // the faster pathing once a certain range is reached
+            path = AITools.calculatePath(entity, ECS.hero);
+            AITools.move(entity, path);
+            timeSinceLastUpdate = delay;
+        } else {
+            // check if new pathing update
+            if (timeSinceLastUpdate >= delay) {
+                path = AITools.calculatePath(entity, ECS.hero);
+                timeSinceLastUpdate = -1;
+            }
+            timeSinceLastUpdate++;
+            AITools.move(entity, path);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #88 
Erste Idee war, sobald die rushrange erreicht ist direkt auf den Player zuzulaufen, dies habe ich aber weggeworfen, da es sonst zu viele Edge Cases gibt, welche Probleme erstellen würden.
z.b. Diagonales movement und laufen gegen eine Wand wegen einer Kante 

- New IFightAI CollideAI

Verhalten 
 - Nah dran berechne Pfad jedes Mal neu, damit es sich aktiver anfühlt
 - weiter entfernt berechne Pfad nur alle X Frames neu identisch zu MeleeAI
