### PR TITLE
[GAME] fix falschen Path abfrage in AITools

### DIFF
--- a/game/src/ecs/components/ai/AITools.java
+++ b/game/src/ecs/components/ai/AITools.java
@@ -26,6 +26,10 @@ public class AITools {
      * @param path Path on which the entity moves
      */
     public static void move(Entity entity, GraphPath<Tile> path) {
+        // entity is already at the end
+        if (pathFinished(entity, path)) {
+            return;
+        }
         PositionComponent pc =
                 (PositionComponent)
                         entity.getComponent(PositionComponent.name)
@@ -40,13 +44,16 @@ public class AITools {
         Tile currentTile = level.getTileAt(pc.getPosition().toCoordinate());
         int i = 0;
         Tile nextTile = null;
-        do {
-            if (i >= path.getCount()) return;
+        while (nextTile == null && i < path.getCount()) {
             if (path.get(i).equals(currentTile)) {
                 nextTile = path.get(i + 1);
             }
             i++;
-        } while (nextTile == null);
+        }
+        // currentTile not in path
+        if (nextTile == null) {
+            return;
+        }
 
         switch (currentTile.directionTo(nextTile)[0]) {
             case N -> vc.setCurrentYVelocity(vc.getYVelocity());


### PR DESCRIPTION
Fixes #185 

Das Problem liegt darin, dass, selbst wenn der Pfad bereits abgeschlossen wurde, wird immer noch versucht, das nächste Element im Pfad anzulaufen.
Außerdem ist ein kleiner Schutz gegen das Verlassen des Pfades eingebaut. Falls das neue Tile nicht Teil des gemerkten Pfads wäre.