### PR TITLE
[GAME] fix testUpdateWithoutAnimationComponent

### DIFF
--- a/game/test/ecs/EntityTest.java
+++ b/game/test/ecs/EntityTest.java
@@ -4,7 +4,6 @@ import static org.junit.Assert.*;
 
 import ecs.components.Component;
 import ecs.entities.Entity;
-import java.util.HashSet;
 import mydungeon.ECS;
 import org.junit.Before;
 import org.junit.Test;
@@ -15,7 +14,7 @@ public class EntityTest {
 
     @Before
     public void setup() {
-        ECS.entities = new HashSet<>();
+        ECS.entities.clear();
         entity = new Entity();
     }
 

--- a/game/test/ecs/components/AIComponentTest.java
+++ b/game/test/ecs/components/AIComponentTest.java
@@ -8,6 +8,7 @@ import ecs.components.ai.fight.IFightAI;
 import ecs.components.ai.idle.IIdleAI;
 import ecs.components.ai.transition.ITransition;
 import ecs.entities.Entity;
+import mydungeon.ECS;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -22,6 +23,7 @@ public class AIComponentTest {
 
     @Before
     public void setUp() {
+        ECS.entities.clear();
         mockFightAI = mock(IFightAI.class);
         mockIdleAI = mock(IIdleAI.class);
         mockTransition = mock(ITransition.class);

--- a/game/test/ecs/components/AnimationComponentTest.java
+++ b/game/test/ecs/components/AnimationComponentTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 
 import ecs.entities.Entity;
 import graphic.Animation;
+import mydungeon.ECS;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -17,6 +18,7 @@ public class AnimationComponentTest {
 
     @Before
     public void setup() {
+        ECS.entities.clear();
         entity = new Entity();
         component = new AnimationComponent(entity, idleLeft, idleRight);
     }

--- a/game/test/ecs/components/PlayableComponentTest.java
+++ b/game/test/ecs/components/PlayableComponentTest.java
@@ -3,6 +3,7 @@ package ecs.components;
 import static org.junit.Assert.*;
 
 import ecs.entities.Entity;
+import mydungeon.ECS;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -12,6 +13,7 @@ public class PlayableComponentTest {
 
     @Before
     public void setup() {
+        ECS.entities.clear();
         entity = new Entity();
     }
 

--- a/game/test/ecs/components/PositionComponentTest.java
+++ b/game/test/ecs/components/PositionComponentTest.java
@@ -3,6 +3,7 @@ package ecs.components;
 import static org.junit.Assert.assertEquals;
 
 import ecs.entities.Entity;
+import mydungeon.ECS;
 import org.junit.Before;
 import org.junit.Test;
 import tools.Point;
@@ -14,6 +15,7 @@ public class PositionComponentTest {
 
     @Before
     public void setup() {
+        ECS.entities.clear();
         entity = new Entity();
         position = new Point(3, 3);
     }

--- a/game/test/ecs/components/SkillComponentTest.java
+++ b/game/test/ecs/components/SkillComponentTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.*;
 import ecs.components.skill.Skill;
 import ecs.components.skill.SkillComponent;
 import ecs.entities.Entity;
+import mydungeon.ECS;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -18,6 +19,7 @@ public class SkillComponentTest {
 
     @Before
     public void setup() {
+        ECS.entities.clear();
         entity = new Entity();
         component = new SkillComponent(entity);
         entity.addComponent(SkillComponent.name, component);

--- a/game/test/ecs/components/SkillTest.java
+++ b/game/test/ecs/components/SkillTest.java
@@ -6,6 +6,7 @@ import ecs.components.skill.Skill;
 import graphic.Animation;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import mydungeon.ECS;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -20,6 +21,7 @@ public class SkillTest {
 
     @Before
     public void setup() throws NoSuchMethodException {
+        ECS.entities.clear();
         method = SkillTest.class.getMethod("TestMethode");
         skill = new Skill(method, animation);
     }

--- a/game/test/ecs/components/VelocityComponentTest.java
+++ b/game/test/ecs/components/VelocityComponentTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 
 import ecs.entities.Entity;
 import graphic.Animation;
+import mydungeon.ECS;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -16,6 +17,7 @@ public class VelocityComponentTest {
 
     @Before
     public void setup() {
+        ECS.entities.clear();
         component = new VelocityComponent(new Entity(), 3.0f, 4.0f, moveLeft, moveRight);
     }
 

--- a/game/test/ecs/systems/AISystemTest.java
+++ b/game/test/ecs/systems/AISystemTest.java
@@ -20,6 +20,7 @@ public class AISystemTest {
     @Before
     public void setup() {
         ECS.systems = Mockito.mock(SystemController.class);
+        ECS.entities.clear();
         system = new AISystem();
         entity = new Entity();
         entity.addComponent(AIComponent.name, component);

--- a/game/test/ecs/systems/DrawSystemTest.java
+++ b/game/test/ecs/systems/DrawSystemTest.java
@@ -24,10 +24,10 @@ public class DrawSystemTest {
     @Before
     public void setup() {
         ECS.systems = Mockito.mock(SystemController.class);
+        ECS.entities.clear();
         system = new DrawSystem(painter);
         entity = new Entity();
-        entity.addComponent(PositionComponent.name, new PositionComponent(entity, new Point(3, 3)));
-        entity.addComponent(AnimationComponent.name, new AnimationComponent(entity, animation));
+        ;
     }
 
     @Test
@@ -40,7 +40,7 @@ public class DrawSystemTest {
 
     @Test
     public void testUpdateWithoutPositionComponent() {
-        entity.removeComponent(PositionComponent.name);
+        entity.addComponent(AnimationComponent.name, new AnimationComponent(entity, animation));
         Mockito.verifyNoMoreInteractions(painter);
         assertThrows(
                 MissingComponentException.class,
@@ -51,7 +51,7 @@ public class DrawSystemTest {
 
     @Test
     public void testUpdateWithoutAnimationComponent() {
-        entity.removeComponent(AnimationComponent.name);
+        entity.addComponent(PositionComponent.name, new PositionComponent(entity, new Point(3, 3)));
         Mockito.verifyNoMoreInteractions(painter);
         system.update();
     }

--- a/game/test/ecs/systems/ECS_SystemTest.java
+++ b/game/test/ecs/systems/ECS_SystemTest.java
@@ -16,6 +16,7 @@ public class ECS_SystemTest {
     public void setup() {
         updates = 0;
         ECS.systems = new SystemController();
+        ECS.entities.clear();
         testSystem =
                 new ECS_System() {
                     @Override

--- a/game/test/ecs/systems/VelocitySystemTest.java
+++ b/game/test/ecs/systems/VelocitySystemTest.java
@@ -30,6 +30,7 @@ public class VelocitySystemTest {
     @Before
     public void setup() {
         ECS.systems = Mockito.mock(SystemController.class);
+        ECS.entities.clear();
         velocitySystem = new VelocitySystem();
         entity = new Entity();
         entity.addComponent(PositionComponent.name, new PositionComponent(entity, new Point(2, 4)));


### PR DESCRIPTION
fixes #124 

Ursache:
Liste mit den Entiäten wurde nicht geleert, daher lag sowohl eine Entität mit als auch eine ohne `AnimationComponent` in der Liste. Das mit dem Component hat dann eine `MissingComponentException(PositionComponent)` geworfen. 

Lösung:
- aufruf von `ECS.entities.clear()` in jedem `@Before setup` 
- remove depricated `ECS.entities=new HashSet<>` in `EntityTest` 
