### PR TITLE
[GAME] Cleanup Tests

### DIFF
--- a/game/test/ecs/EntityTest.java
+++ b/game/test/ecs/EntityTest.java
@@ -7,15 +7,19 @@ import ecs.entities.Entity;
 import mydungeon.ECS;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 public class EntityTest {
 
     private Entity entity;
+    private final Component testComponent = Mockito.mock(Component.class);
+    private final String componentName = "TestComponent";
 
     @Before
     public void setup() {
         ECS.entities.clear();
         entity = new Entity();
+        entity.addComponent(componentName, testComponent);
     }
 
     @Test
@@ -25,26 +29,19 @@ public class EntityTest {
 
     @Test
     public void addComponent() {
-        Component c = new TestComponent(entity);
-        assertEquals(c, entity.getComponent(TestComponent.name).get());
+        assertEquals(testComponent, entity.getComponent(componentName).get());
+    }
+
+    @Test
+    public void addAlreadyExistingComponent() {
+        Component newComponent = Mockito.mock(Component.class);
+        entity.addComponent(componentName, newComponent);
+        assertEquals(newComponent, entity.getComponent(componentName).get());
     }
 
     @Test
     public void removeComponent() {
-        Component c = new TestComponent(entity);
-        assertEquals(c, entity.getComponent(TestComponent.name).get());
-        entity.removeComponent(TestComponent.name);
-        assertTrue(entity.getComponent(TestComponent.name).isEmpty());
-    }
-
-    private class TestComponent extends Component {
-
-        public static String name = "TestComponent";
-        /**
-         * @param entity associated entity
-         */
-        public TestComponent(Entity entity) {
-            super(entity, name);
-        }
+        entity.removeComponent(componentName);
+        assertTrue(entity.getComponent(componentName).isEmpty());
     }
 }

--- a/game/test/ecs/EntityTest.java
+++ b/game/test/ecs/EntityTest.java
@@ -23,7 +23,7 @@ public class EntityTest {
     }
 
     @Test
-    public void ctorTest() {
+    public void cTor() {
         assertTrue(ECS.entities.contains(entity));
     }
 

--- a/game/test/ecs/components/AIComponentTest.java
+++ b/game/test/ecs/components/AIComponentTest.java
@@ -29,7 +29,7 @@ public class AIComponentTest {
     }
 
     @Test
-    public void testExecuteFight() {
+    public void executeFight() {
         when(mockTransition.isInFightMode(entity)).thenReturn(true);
         aiComponent.execute();
         verify(mockFightAI, times(1)).fight(entity);
@@ -37,7 +37,7 @@ public class AIComponentTest {
     }
 
     @Test
-    public void testExecuteIdle() {
+    public void executeIdle() {
         when(mockTransition.isInFightMode(entity)).thenReturn(false);
         aiComponent.execute();
         verify(mockFightAI, never()).fight(entity);
@@ -45,21 +45,21 @@ public class AIComponentTest {
     }
 
     @Test
-    public void testSetFightAI() {
+    public void setFightAI() {
         IFightAI newAI = Mockito.mock(IFightAI.class);
         aiComponent.setFightAI(newAI);
         assertEquals(newAI, aiComponent.getFightAI());
     }
 
     @Test
-    public void testSetIdleAI() {
+    public void setIdleAI() {
         IIdleAI newAI = Mockito.mock(IIdleAI.class);
         aiComponent.setIdleAI(newAI);
         assertEquals(newAI, aiComponent.getIdleAI());
     }
 
     @Test
-    public void testSetTransitionAI() {
+    public void setTransitionAI() {
         ITransition newAI = Mockito.mock(ITransition.class);
         aiComponent.setTransitionAI(newAI);
         assertEquals(newAI, aiComponent.getTransitionAI());

--- a/game/test/ecs/components/AIComponentTest.java
+++ b/game/test/ecs/components/AIComponentTest.java
@@ -8,7 +8,6 @@ import ecs.components.ai.fight.IFightAI;
 import ecs.components.ai.idle.IIdleAI;
 import ecs.components.ai.transition.ITransition;
 import ecs.entities.Entity;
-import mydungeon.ECS;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -16,18 +15,16 @@ import org.mockito.Mockito;
 public class AIComponentTest {
 
     private AIComponent aiComponent;
-    private IFightAI mockFightAI;
-    private IIdleAI mockIdleAI;
-    private ITransition mockTransition;
-    private Entity entity;
+    private final IFightAI mockFightAI = mock(IFightAI.class);
+    ;
+    private final IIdleAI mockIdleAI = mock(IIdleAI.class);
+    ;
+    private final ITransition mockTransition = mock(ITransition.class);
+    ;
+    private final Entity entity = Mockito.mock(Entity.class);
 
     @Before
-    public void setUp() {
-        ECS.entities.clear();
-        mockFightAI = mock(IFightAI.class);
-        mockIdleAI = mock(IIdleAI.class);
-        mockTransition = mock(ITransition.class);
-        entity = new Entity();
+    public void setup() {
         aiComponent = new AIComponent(entity, mockFightAI, mockIdleAI, mockTransition);
     }
 

--- a/game/test/ecs/components/AIComponentTest.java
+++ b/game/test/ecs/components/AIComponentTest.java
@@ -16,11 +16,11 @@ public class AIComponentTest {
 
     private AIComponent aiComponent;
     private final IFightAI mockFightAI = mock(IFightAI.class);
-    ;
+
     private final IIdleAI mockIdleAI = mock(IIdleAI.class);
-    ;
+
     private final ITransition mockTransition = mock(ITransition.class);
-    ;
+
     private final Entity entity = Mockito.mock(Entity.class);
 
     @Before

--- a/game/test/ecs/components/AnimationComponentTest.java
+++ b/game/test/ecs/components/AnimationComponentTest.java
@@ -21,7 +21,7 @@ public class AnimationComponentTest {
     }
 
     @Test
-    public void testSetCurrentAnimation() {
+    public void setCurrentAnimation() {
         Animation currentAnimation = animationComponent.getCurrentAnimation();
         // Ensure that the current animation is initially set to the expected value
         assertEquals(currentAnimation, animationComponent.getCurrentAnimation());
@@ -32,7 +32,7 @@ public class AnimationComponentTest {
     }
 
     @Test
-    public void testGetAnimations() {
+    public void getAnimations() {
         assertEquals(idleLeft, animationComponent.getIdleLeft());
         assertEquals(idleRight, animationComponent.getIdleRight());
     }

--- a/game/test/ecs/components/AnimationComponentTest.java
+++ b/game/test/ecs/components/AnimationComponentTest.java
@@ -4,7 +4,6 @@ import static org.junit.Assert.assertEquals;
 
 import ecs.entities.Entity;
 import graphic.Animation;
-import mydungeon.ECS;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -13,30 +12,28 @@ public class AnimationComponentTest {
 
     private final Animation idleLeft = Mockito.mock(Animation.class);
     private final Animation idleRight = Mockito.mock(Animation.class);
-    private Entity entity;
-    private AnimationComponent component;
+    private AnimationComponent animationComponent;
 
     @Before
     public void setup() {
-        ECS.entities.clear();
-        entity = new Entity();
-        component = new AnimationComponent(entity, idleLeft, idleRight);
+        animationComponent =
+                new AnimationComponent(Mockito.mock(Entity.class), idleLeft, idleRight);
     }
 
     @Test
     public void testSetCurrentAnimation() {
-        Animation currentAnimation = component.getCurrentAnimation();
+        Animation currentAnimation = animationComponent.getCurrentAnimation();
         // Ensure that the current animation is initially set to the expected value
-        assertEquals(currentAnimation, component.getCurrentAnimation());
+        assertEquals(currentAnimation, animationComponent.getCurrentAnimation());
 
         // Set a new animation and ensure that it is correctly set
-        component.setCurrentAnimation(idleLeft);
-        assertEquals(idleLeft, component.getCurrentAnimation());
+        animationComponent.setCurrentAnimation(idleLeft);
+        assertEquals(idleLeft, animationComponent.getCurrentAnimation());
     }
 
     @Test
     public void testGetAnimations() {
-        assertEquals(idleLeft, component.getIdleLeft());
-        assertEquals(idleRight, component.getIdleRight());
+        assertEquals(idleLeft, animationComponent.getIdleLeft());
+        assertEquals(idleRight, animationComponent.getIdleRight());
     }
 }

--- a/game/test/ecs/components/PlayableComponentTest.java
+++ b/game/test/ecs/components/PlayableComponentTest.java
@@ -3,26 +3,23 @@ package ecs.components;
 import static org.junit.Assert.*;
 
 import ecs.entities.Entity;
-import mydungeon.ECS;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 public class PlayableComponentTest {
 
-    private Entity entity;
+    private PlayableComponent playableComponent;
 
     @Before
     public void setup() {
-        ECS.entities.clear();
-        entity = new Entity();
+        playableComponent = new PlayableComponent(Mockito.mock(Entity.class));
     }
 
     @Test
     public void testIsPlayable() {
-        PlayableComponent component = new PlayableComponent(entity);
-        assertTrue(component.isPlayable());
-
-        component.setPlayable(false);
-        assertFalse(component.isPlayable());
+        assertTrue(playableComponent.isPlayable());
+        playableComponent.setPlayable(false);
+        assertFalse(playableComponent.isPlayable());
     }
 }

--- a/game/test/ecs/components/PlayableComponentTest.java
+++ b/game/test/ecs/components/PlayableComponentTest.java
@@ -17,7 +17,7 @@ public class PlayableComponentTest {
     }
 
     @Test
-    public void testIsPlayable() {
+    public void isPlayable() {
         assertTrue(playableComponent.isPlayable());
         playableComponent.setPlayable(false);
         assertFalse(playableComponent.isPlayable());

--- a/game/test/ecs/components/PositionComponentTest.java
+++ b/game/test/ecs/components/PositionComponentTest.java
@@ -19,7 +19,7 @@ public class PositionComponentTest {
     }
 
     @Test
-    public void testSetPosition() {
+    public void setPosition() {
         assertEquals(position, positionComponent.getPosition());
         Point newPoint = new Point(3, 4);
         positionComponent.setPosition(newPoint);

--- a/game/test/ecs/components/PositionComponentTest.java
+++ b/game/test/ecs/components/PositionComponentTest.java
@@ -3,29 +3,26 @@ package ecs.components;
 import static org.junit.Assert.assertEquals;
 
 import ecs.entities.Entity;
-import mydungeon.ECS;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 import tools.Point;
 
 public class PositionComponentTest {
 
-    private Point position;
-    private Entity entity;
+    private final Point position = new Point(3, 3);
+    private PositionComponent positionComponent;
 
     @Before
     public void setup() {
-        ECS.entities.clear();
-        entity = new Entity();
-        position = new Point(3, 3);
+        positionComponent = new PositionComponent(Mockito.mock(Entity.class), position);
     }
 
     @Test
     public void testSetPosition() {
-        PositionComponent component = new PositionComponent(entity, position);
-        assertEquals(position, component.getPosition());
+        assertEquals(position, positionComponent.getPosition());
         Point newPoint = new Point(3, 4);
-        component.setPosition(newPoint);
-        assertEquals(newPoint, component.getPosition());
+        positionComponent.setPosition(newPoint);
+        assertEquals(newPoint, positionComponent.getPosition());
     }
 }

--- a/game/test/ecs/components/SkillComponentTest.java
+++ b/game/test/ecs/components/SkillComponentTest.java
@@ -5,37 +5,31 @@ import static org.junit.Assert.*;
 import ecs.components.skill.Skill;
 import ecs.components.skill.SkillComponent;
 import ecs.entities.Entity;
-import mydungeon.ECS;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
 public class SkillComponentTest {
 
-    private Entity entity;
-    private SkillComponent component;
-
-    private Skill testSkill = Mockito.mock(Skill.class);
+    private final Skill testSkill = Mockito.mock(Skill.class);
+    private SkillComponent skillComponent;
 
     @Before
     public void setup() {
-        ECS.entities.clear();
-        entity = new Entity();
-        component = new SkillComponent(entity);
-        entity.addComponent(SkillComponent.name, component);
+        skillComponent = new SkillComponent(Mockito.mock(Entity.class));
     }
 
     @Test
     public void addSkill() {
-        component.addSkill(testSkill);
-        assertTrue(component.getSkillSet().contains(testSkill));
+        skillComponent.addSkill(testSkill);
+        assertTrue(skillComponent.getSkillSet().contains(testSkill));
     }
 
     @Test
     public void removeSkill() {
-        component.addSkill(testSkill);
-        assertTrue(component.getSkillSet().contains(testSkill));
-        component.removeSkill(testSkill);
-        assertFalse(component.getSkillSet().contains(testSkill));
+        skillComponent.addSkill(testSkill);
+        assertTrue(skillComponent.getSkillSet().contains(testSkill));
+        skillComponent.removeSkill(testSkill);
+        assertFalse(skillComponent.getSkillSet().contains(testSkill));
     }
 }

--- a/game/test/ecs/components/SkillTest.java
+++ b/game/test/ecs/components/SkillTest.java
@@ -25,14 +25,14 @@ public class SkillTest {
     }
 
     @Test
-    public void testExecute_active() throws InvocationTargetException, IllegalAccessException {
+    public void execute_active() throws InvocationTargetException, IllegalAccessException {
         value = 0;
         skill.execute();
         assertEquals(1, value);
     }
 
     @Test
-    public void testExecute_inactive() throws InvocationTargetException, IllegalAccessException {
+    public void execute_inactive() throws InvocationTargetException, IllegalAccessException {
         value = 0;
         skill.toggleActive();
         assertFalse(skill.getActive());
@@ -41,7 +41,7 @@ public class SkillTest {
     }
 
     @Test
-    public void testToogle() {
+    public void toogle() {
         assertTrue(skill.getActive());
         skill.toggleActive();
         ;
@@ -52,7 +52,7 @@ public class SkillTest {
     }
 
     @Test
-    public void testGetAnimation() {
+    public void getAnimation() {
         assertEquals(animation, skill.getAnimation());
     }
 

--- a/game/test/ecs/components/SkillTest.java
+++ b/game/test/ecs/components/SkillTest.java
@@ -6,7 +6,6 @@ import ecs.components.skill.Skill;
 import graphic.Animation;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import mydungeon.ECS;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -21,7 +20,6 @@ public class SkillTest {
 
     @Before
     public void setup() throws NoSuchMethodException {
-        ECS.entities.clear();
         method = SkillTest.class.getMethod("TestMethode");
         skill = new Skill(method, animation);
     }

--- a/game/test/ecs/components/VelocityComponentTest.java
+++ b/game/test/ecs/components/VelocityComponentTest.java
@@ -29,33 +29,33 @@ public class VelocityComponentTest {
     }
 
     @Test
-    public void testSetCurrentXVelocity() {
+    public void setCurrentXVelocity() {
         velocityComponent.setCurrentXVelocity(5.0f);
         assertEquals(5.0f, velocityComponent.getCurrentXVelocity(), 0.001);
     }
 
     @Test
-    public void testSetCurrentYVelocity() {
+    public void setCurrentYVelocity() {
         velocityComponent.setCurrentYVelocity(6.0f);
         assertEquals(6.0f, velocityComponent.getCurrentYVelocity(), 0.001);
     }
 
     @Test
-    public void testSetXVelocity() {
+    public void setXVelocity() {
         assertEquals(xVelocityAtStart, velocityComponent.getXVelocity(), 0.001);
         velocityComponent.setXVelocity(6.0f);
         assertEquals(6.0f, velocityComponent.getXVelocity(), 0.001);
     }
 
     @Test
-    public void testSetYVelocity() {
+    public void setYVelocity() {
         assertEquals(yVelocityAtStart, velocityComponent.getYVelocity(), 0.001);
         velocityComponent.setYVelocity(6.0f);
         assertEquals(6.0f, velocityComponent.getYVelocity(), 0.001);
     }
 
     @Test
-    public void testGetAnimation() {
+    public void getAnimation() {
         assertEquals(moveLeft, velocityComponent.getMoveLeftAnimation());
         assertEquals(moveRight, velocityComponent.getMoveRightAnimation());
     }

--- a/game/test/ecs/components/VelocityComponentTest.java
+++ b/game/test/ecs/components/VelocityComponentTest.java
@@ -4,7 +4,6 @@ import static org.junit.Assert.assertEquals;
 
 import ecs.entities.Entity;
 import graphic.Animation;
-import mydungeon.ECS;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -13,43 +12,51 @@ public class VelocityComponentTest {
 
     private final Animation moveLeft = Mockito.mock(Animation.class);
     private final Animation moveRight = Mockito.mock(Animation.class);
-    private VelocityComponent component;
+
+    private final float xVelocityAtStart = 3f;
+    private final float yVelocityAtStart = 3f;
+    private VelocityComponent velocityComponent;
 
     @Before
     public void setup() {
-        ECS.entities.clear();
-        component = new VelocityComponent(new Entity(), 3.0f, 4.0f, moveLeft, moveRight);
+        velocityComponent =
+                new VelocityComponent(
+                        Mockito.mock(Entity.class),
+                        xVelocityAtStart,
+                        yVelocityAtStart,
+                        moveLeft,
+                        moveRight);
     }
 
     @Test
-    public void testSetX() {
-        component.setCurrentXVelocity(5.0f);
-        assertEquals(5.0f, component.getCurrentXVelocity(), 0.001);
+    public void testSetCurrentXVelocity() {
+        velocityComponent.setCurrentXVelocity(5.0f);
+        assertEquals(5.0f, velocityComponent.getCurrentXVelocity(), 0.001);
     }
 
     @Test
-    public void testSetY() {
-        component.setCurrentYVelocity(6.0f);
-        assertEquals(6.0f, component.getCurrentYVelocity(), 0.001);
+    public void testSetCurrentYVelocity() {
+        velocityComponent.setCurrentYVelocity(6.0f);
+        assertEquals(6.0f, velocityComponent.getCurrentYVelocity(), 0.001);
     }
 
     @Test
-    public void testSetXSpeed() {
-        assertEquals(3.0f, component.getXVelocity(), 0.001);
-        component.setXVelocity(6.0f);
-        assertEquals(6.0f, component.getXVelocity(), 0.001);
+    public void testSetXVelocity() {
+        assertEquals(xVelocityAtStart, velocityComponent.getXVelocity(), 0.001);
+        velocityComponent.setXVelocity(6.0f);
+        assertEquals(6.0f, velocityComponent.getXVelocity(), 0.001);
     }
 
     @Test
-    public void testSetYSpeed() {
-        assertEquals(4.0f, component.getYVelocity(), 0.001);
-        component.setYVelocity(6.0f);
-        assertEquals(6.0f, component.getYVelocity(), 0.001);
+    public void testSetYVelocity() {
+        assertEquals(yVelocityAtStart, velocityComponent.getYVelocity(), 0.001);
+        velocityComponent.setYVelocity(6.0f);
+        assertEquals(6.0f, velocityComponent.getYVelocity(), 0.001);
     }
 
     @Test
     public void testGetAnimation() {
-        assertEquals(moveLeft, component.getMoveLeftAnimation());
-        assertEquals(moveRight, component.getMoveRightAnimation());
+        assertEquals(moveLeft, velocityComponent.getMoveLeftAnimation());
+        assertEquals(moveRight, velocityComponent.getMoveRightAnimation());
     }
 }

--- a/game/test/ecs/systems/AISystemTest.java
+++ b/game/test/ecs/systems/AISystemTest.java
@@ -14,21 +14,20 @@ import org.mockito.Mockito;
 public class AISystemTest {
 
     private AISystem system;
-    private AIComponent component = Mockito.mock(AIComponent.class);
-    Entity entity;
+    private AIComponent aiComponent = Mockito.mock(AIComponent.class);
 
     @Before
     public void setup() {
         ECS.systems = Mockito.mock(SystemController.class);
         ECS.entities.clear();
         system = new AISystem();
-        entity = new Entity();
-        entity.addComponent(AIComponent.name, component);
+        Entity entity = new Entity();
+        entity.addComponent(AIComponent.name, aiComponent);
     }
 
     @Test
     public void update() {
         system.update();
-        Mockito.verify(component, times(1)).execute();
+        Mockito.verify(aiComponent, times(1)).execute();
     }
 }

--- a/game/test/ecs/systems/AISystemTest.java
+++ b/game/test/ecs/systems/AISystemTest.java
@@ -14,6 +14,7 @@ import org.mockito.Mockito;
 public class AISystemTest {
 
     private AISystem system;
+    private Entity entity;
     private AIComponent aiComponent = Mockito.mock(AIComponent.class);
 
     @Before
@@ -21,7 +22,7 @@ public class AISystemTest {
         ECS.systems = Mockito.mock(SystemController.class);
         ECS.entities.clear();
         system = new AISystem();
-        Entity entity = new Entity();
+        entity = new Entity();
         entity.addComponent(AIComponent.name, aiComponent);
     }
 
@@ -29,5 +30,12 @@ public class AISystemTest {
     public void update() {
         system.update();
         Mockito.verify(aiComponent, times(1)).execute();
+    }
+
+    @Test
+    public void updateWithoutAIComponent() {
+        entity.removeComponent(AIComponent.name);
+        system.update();
+        Mockito.verify(aiComponent, times(0)).execute();
     }
 }

--- a/game/test/ecs/systems/AISystemTest.java
+++ b/game/test/ecs/systems/AISystemTest.java
@@ -1,11 +1,9 @@
-package ecs.components;
+package ecs.systems;
 
 import static org.mockito.Mockito.times;
 
 import ecs.components.ai.AIComponent;
 import ecs.entities.Entity;
-import ecs.systems.AISystem;
-import ecs.systems.SystemController;
 import mydungeon.ECS;
 import org.junit.Before;
 import org.junit.Test;
@@ -15,7 +13,7 @@ public class AISystemTest {
 
     private AISystem system;
     private Entity entity;
-    private AIComponent aiComponent = Mockito.mock(AIComponent.class);
+    private final AIComponent aiComponent = Mockito.mock(AIComponent.class);
 
     @Before
     public void setup() {

--- a/game/test/ecs/systems/DrawSystemTest.java
+++ b/game/test/ecs/systems/DrawSystemTest.java
@@ -18,16 +18,17 @@ public class DrawSystemTest {
 
     private final Animation animation = Mockito.mock(Animation.class);
     private final Painter painter = Mockito.mock(Painter.class);
-    private DrawSystem system;
+    private DrawSystem drawSystem;
     private Entity entity;
 
     @Before
     public void setup() {
         ECS.systems = Mockito.mock(SystemController.class);
         ECS.entities.clear();
-        system = new DrawSystem(painter);
+        drawSystem = new DrawSystem(painter);
         entity = new Entity();
-        ;
+        entity.addComponent(AnimationComponent.name, new AnimationComponent(entity, animation));
+        entity.addComponent(PositionComponent.name, new PositionComponent(entity, new Point(3, 3)));
     }
 
     @Test
@@ -40,19 +41,19 @@ public class DrawSystemTest {
 
     @Test
     public void testUpdateWithoutPositionComponent() {
-        entity.addComponent(AnimationComponent.name, new AnimationComponent(entity, animation));
+        entity.removeComponent(PositionComponent.name);
         Mockito.verifyNoMoreInteractions(painter);
         assertThrows(
                 MissingComponentException.class,
                 () -> {
-                    system.update();
+                    drawSystem.update();
                 });
     }
 
     @Test
     public void testUpdateWithoutAnimationComponent() {
-        entity.addComponent(PositionComponent.name, new PositionComponent(entity, new Point(3, 3)));
+        entity.removeComponent(AnimationComponent.name);
         Mockito.verifyNoMoreInteractions(painter);
-        system.update();
+        drawSystem.update();
     }
 }

--- a/game/test/ecs/systems/DrawSystemTest.java
+++ b/game/test/ecs/systems/DrawSystemTest.java
@@ -32,7 +32,7 @@ public class DrawSystemTest {
     }
 
     @Test
-    public void testUpdate() {
+    public void update() {
         /*
          * This method can not be tested because we can not mock the internal PainterConfig Object
          * in the DrawSystem. The PainterConfig needs libGDX setup
@@ -40,7 +40,7 @@ public class DrawSystemTest {
     }
 
     @Test
-    public void testUpdateWithoutPositionComponent() {
+    public void updateWithoutPositionComponent() {
         entity.removeComponent(PositionComponent.name);
         Mockito.verifyNoMoreInteractions(painter);
         assertThrows(
@@ -51,7 +51,7 @@ public class DrawSystemTest {
     }
 
     @Test
-    public void testUpdateWithoutAnimationComponent() {
+    public void updateWithoutAnimationComponent() {
         entity.removeComponent(AnimationComponent.name);
         Mockito.verifyNoMoreInteractions(painter);
         drawSystem.update();

--- a/game/test/ecs/systems/DrawSystemTest.java
+++ b/game/test/ecs/systems/DrawSystemTest.java
@@ -43,11 +43,7 @@ public class DrawSystemTest {
     public void updateWithoutPositionComponent() {
         entity.removeComponent(PositionComponent.name);
         Mockito.verifyNoMoreInteractions(painter);
-        assertThrows(
-                MissingComponentException.class,
-                () -> {
-                    drawSystem.update();
-                });
+        assertThrows(MissingComponentException.class, () -> drawSystem.update());
     }
 
     @Test

--- a/game/test/ecs/systems/ECS_SystemTest.java
+++ b/game/test/ecs/systems/ECS_SystemTest.java
@@ -26,12 +26,12 @@ public class ECS_SystemTest {
     }
 
     @Test
-    public void constructorTest() {
+    public void cTor() {
         assertTrue(ECS.systems.contains(testSystem));
     }
 
     @Test
-    public void pauseTest() {
+    public void pause() {
         assertEquals(0, updates);
         ECS.systems.update();
         assertEquals(1, updates);

--- a/game/test/ecs/systems/ECS_SystemTest.java
+++ b/game/test/ecs/systems/ECS_SystemTest.java
@@ -16,7 +16,6 @@ public class ECS_SystemTest {
     public void setup() {
         updates = 0;
         ECS.systems = new SystemController();
-        ECS.entities.clear();
         testSystem =
                 new ECS_System() {
                     @Override

--- a/game/test/ecs/systems/VelocitySystemTest.java
+++ b/game/test/ecs/systems/VelocitySystemTest.java
@@ -1,8 +1,10 @@
 package ecs.systems;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 import ecs.components.AnimationComponent;
+import ecs.components.MissingComponentException;
 import ecs.components.PositionComponent;
 import ecs.components.VelocityComponent;
 import ecs.entities.Entity;
@@ -89,6 +91,7 @@ public class VelocitySystemTest {
         assertEquals(startYPosition, position.y, 0.001);
     }
 
+    @Test
     public void updateUnValidMoveWithNegativVelocity() {
         Mockito.when(tile.isAccessible()).thenReturn(false);
         velocityComponent.setCurrentXVelocity(-4);
@@ -128,5 +131,34 @@ public class VelocitySystemTest {
         velocitySystem.update();
         assertEquals(idleLeft, animationComponent.getCurrentAnimation());
         ;
+    }
+
+    @Test
+    public void updateWithoutVelocityComponent() {
+        entity.removeComponent(VelocityComponent.name);
+        velocitySystem.update();
+        assertEquals(startXPosition, positionComponent.getPosition().x, 0.001f);
+        assertEquals(startYPosition, positionComponent.getPosition().y, 0.001f);
+    }
+
+    @Test
+    public void updateWithoutPositionComponent() {
+        entity.removeComponent(PositionComponent.name);
+        assertThrows(
+                MissingComponentException.class,
+                () -> {
+                    velocitySystem.update();
+                });
+    }
+
+    @Test
+    public void updateWithoutAnimationComponent() {
+        Mockito.when(tile.isAccessible()).thenReturn(true);
+        entity.removeComponent(AnimationComponent.name);
+        assertThrows(
+                MissingComponentException.class,
+                () -> {
+                    velocitySystem.update();
+                });
     }
 }

--- a/game/test/ecs/systems/VelocitySystemTest.java
+++ b/game/test/ecs/systems/VelocitySystemTest.java
@@ -130,7 +130,6 @@ public class VelocitySystemTest {
 
         velocitySystem.update();
         assertEquals(idleLeft, animationComponent.getCurrentAnimation());
-        ;
     }
 
     @Test
@@ -144,21 +143,13 @@ public class VelocitySystemTest {
     @Test
     public void updateWithoutPositionComponent() {
         entity.removeComponent(PositionComponent.name);
-        assertThrows(
-                MissingComponentException.class,
-                () -> {
-                    velocitySystem.update();
-                });
+        assertThrows(MissingComponentException.class, () -> velocitySystem.update());
     }
 
     @Test
     public void updateWithoutAnimationComponent() {
         Mockito.when(tile.isAccessible()).thenReturn(true);
         entity.removeComponent(AnimationComponent.name);
-        assertThrows(
-                MissingComponentException.class,
-                () -> {
-                    velocitySystem.update();
-                });
+        assertThrows(MissingComponentException.class, () -> velocitySystem.update());
     }
 }


### PR DESCRIPTION
Die ECS Testfälle waren zwar (meist) alle Sinnvoll, aber nicht einheitlich. 
Ich hab etwas aufgeräumt
- Präfix "test" entfernt
- Einheitliche Bennung von `setup`
- Tests für Missing-Components hinzugefügt
- Weitere (kleinere) Tests hinzugefügt
- Mockito verwendet wo sinnvoll
- Kleinere Code Anpassungen 