### PR TITLE
[GAME] add names to DSLType(Members)

### DIFF
--- a/game/src/ecs/components/AnimationComponent.java
+++ b/game/src/ecs/components/AnimationComponent.java
@@ -11,13 +11,13 @@ import semanticAnalysis.types.DSLTypeMember;
  * AnimationComponent is a component that stores the possible animations and the current animation
  * of an entity
  */
-@DSLType
+@DSLType(name = "animation_component")
 public class AnimationComponent extends Component {
     private static List<String> missingTexture = List.of("animation/missingTexture.png");
     public static String name = "AnimationComponent";
-    private @DSLTypeMember Animation idleLeft;
-    private @DSLTypeMember Animation idleRight;
-    private @DSLTypeMember Animation currentAnimation;
+    private @DSLTypeMember(name = "idle_left") Animation idleLeft;
+    private @DSLTypeMember(name = "idle_right") Animation idleRight;
+    private @DSLTypeMember(name = "current_animation") Animation currentAnimation;
 
     /**
      * @param entity associated entity

--- a/game/src/ecs/components/HitboxComponent.java
+++ b/game/src/ecs/components/HitboxComponent.java
@@ -8,11 +8,11 @@ import semanticAnalysis.types.DSLContextMember;
 import semanticAnalysis.types.DSLType;
 import tools.Point;
 
-@DSLType
+@DSLType(name = "hitbox_component")
 public class HitboxComponent extends Component {
     public static final String name = "HitboxComponent";
-    private Point offset;
-    private Point size;
+    private /*@DSLTypeMember(name="offset")*/ Point offset;
+    private /*@DSLTypeMember(name="size")*/ Point size;
     private Method method;
 
     public HitboxComponent(Entity entity, Point offset, Point size, Method method) {

--- a/game/src/ecs/components/PositionComponent.java
+++ b/game/src/ecs/components/PositionComponent.java
@@ -8,13 +8,12 @@ import semanticAnalysis.types.DSLType;
 import tools.Point;
 
 /** PositionComponent is a component that stores the x, y (as Point) position of an entity */
-@DSLType
+@DSLType(name = "position_component")
 public class PositionComponent extends Component {
 
     public static String name = "PositionComponent";
 
-    // private @DSLTypeMember Point position;
-    private Point position;
+    private /*@DSLTypeMember(name="position")*/ Point position;
 
     /**
      * @param entity associated entity

--- a/game/src/ecs/components/VelocityComponent.java
+++ b/game/src/ecs/components/VelocityComponent.java
@@ -8,17 +8,17 @@ import semanticAnalysis.types.DSLType;
 import semanticAnalysis.types.DSLTypeMember;
 
 /** VelocityComponent is a component that stores the x, y movement direction */
-@DSLType
+@DSLType(name = "velocity_component")
 public class VelocityComponent extends Component {
     private static List<String> missingTexture = List.of("animation/missingTexture.png");
     public static String name = "VelocityComponent";
     private float currentXVelocity;
     private float currentYVelocity;
-    private @DSLTypeMember float xVelocity;
-    private @DSLTypeMember float yVelocity;
+    private @DSLTypeMember(name = "x_velocity") float xVelocity;
+    private @DSLTypeMember(name = "y_velocity") float yVelocity;
 
-    private @DSLTypeMember Animation moveRightAnimation;
-    private @DSLTypeMember Animation moveLeftAnimation;
+    private @DSLTypeMember(name = "move_right_animation") Animation moveRightAnimation;
+    private @DSLTypeMember(name = "move_left_animation") Animation moveLeftAnimation;
 
     /**
      * @param entity associated entity

--- a/game/src/ecs/components/ai/AIComponent.java
+++ b/game/src/ecs/components/ai/AIComponent.java
@@ -16,9 +16,9 @@ import semanticAnalysis.types.DSLType;
 public class AIComponent extends Component {
 
     public static String name = "AIComponent";
-    private /*@DSLTypeMember*/ IFightAI fightAI;
-    private /*@DSLTypeMember*/ IIdleAI idleAI;
-    private /*@DSLTypeMember*/ ITransition transitionAI;
+    private /*@DSLTypeMember(name="fight_ai)*/ IFightAI fightAI;
+    private /*@DSLTypeMember(name="idle_ai)*/ IIdleAI idleAI;
+    private /*@DSLTypeMember(name="transition_ai)*/ ITransition transitionAI;
 
     /**
      * @param entity associated entity


### PR DESCRIPTION
fixes #186 

- Alle Components haben jetzt eine `name in der `DSLType` Annotation
- Alle Attribute haben jetzt ein `name` in der `DSLTypeMemeber`Annotation
  - Teilweise noch auskommentiert (siehe #207) 