### PR TITLE
[DSL] Dont crash on unsupported data types

### DIFF
--- a/dsl/src/interpreter/DSLInterpreter.java
+++ b/dsl/src/interpreter/DSLInterpreter.java
@@ -171,7 +171,8 @@ public class DSLInterpreter implements AstVisitor<Object> {
      */
     private Value createDefaultValue(IType type) {
         if (type == null) {
-            throw new RuntimeException("Tried to create default value for null type");
+            System.out.println("Tried to create default value for null type");
+            return Value.NONE;
         }
         if (type.getTypeKind().equals(IType.Kind.Basic)) {
             Object internalValue = Value.getDefaultValue(type);

--- a/dsl/src/runtime/Value.java
+++ b/dsl/src/runtime/Value.java
@@ -63,6 +63,7 @@ public class Value implements IClonable {
             this.dirty = true;
             return true;
         }
+        System.out.println("Tried to set internal value of immutable value");
         return false;
     }
 

--- a/dsl/src/semanticAnalysis/types/TypeInstantiator.java
+++ b/dsl/src/semanticAnalysis/types/TypeInstantiator.java
@@ -143,7 +143,7 @@ public class TypeInstantiator {
                     var fieldValue = ms.resolve(fieldName);
                     // we only should set the field value explicitly,
                     // if it was set in the program (indicated by the dirty-flag)
-                    if (fieldValue != null && fieldValue.isDirty()) {
+                    if (fieldValue != Value.NONE && fieldValue.isDirty()) {
                         var internalValue = fieldValue.getInternalObject();
 
                         if (fieldValue.getDataType().getTypeKind().equals(IType.Kind.PODAdapted)) {

--- a/dsl/test/semanticAnalysis/types/ComponentWithExternalTypeMember.java
+++ b/dsl/test/semanticAnalysis/types/ComponentWithExternalTypeMember.java
@@ -1,0 +1,8 @@
+package semanticAnalysis.types;
+
+import tools.Point;
+
+@DSLType
+public class ComponentWithExternalTypeMember {
+    @DSLTypeMember public Point point;
+}

--- a/dsl/test/semanticAnalysis/types/ComponentWithInterfaceMember.java
+++ b/dsl/test/semanticAnalysis/types/ComponentWithInterfaceMember.java
@@ -1,0 +1,6 @@
+package semanticAnalysis.types;
+
+@DSLType
+public class ComponentWithInterfaceMember {
+    private @DSLTypeMember ITestInterface interfaceMember;
+}

--- a/dsl/test/semanticAnalysis/types/ITestInterface.java
+++ b/dsl/test/semanticAnalysis/types/ITestInterface.java
@@ -1,0 +1,5 @@
+package semanticAnalysis.types;
+
+public interface ITestInterface {
+    boolean getThing();
+}

--- a/dsl/test/semanticAnalysis/types/TestTypeBuilder.java
+++ b/dsl/test/semanticAnalysis/types/TestTypeBuilder.java
@@ -121,4 +121,28 @@ public class TestTypeBuilder {
         var membersDatatype = memberSymbol.getDataType();
         assertEquals(IType.Kind.PODAdapted, membersDatatype.getTypeKind());
     }
+
+    @Test
+    public void testExternalTypeMember() {
+        TypeBuilder typeBuilder = new TypeBuilder();
+        var dslType =
+                (AggregateType)
+                        typeBuilder.createTypeFromClass(
+                                Scope.NULL, ComponentWithExternalTypeMember.class);
+
+        assertNotSame(dslType, null);
+        assertNotSame(dslType, Symbol.NULL);
+    }
+
+    @Test
+    public void testInterfaceMember() {
+        TypeBuilder typeBuilder = new TypeBuilder();
+        var dslType =
+                (AggregateType)
+                        typeBuilder.createTypeFromClass(
+                                Scope.NULL, ComponentWithInterfaceMember.class);
+
+        assertNotSame(dslType, null);
+        assertNotSame(dslType, Symbol.NULL);
+    }
 }


### PR DESCRIPTION
Fixes #207 

Der Interpreter wirft keine Exception mehr, wenn der an `createDefaultValue` übergeben `type` null ist (was der Fall ist, falls es keine DSL Repräsentation für einen Java-Typen gibt). Die mit `@DSLTypeMember` markierten Member der erzeugten Java-Instanzen sind anschließend `null`.

Tests wurden um einen entsprechenden Testcase ergänzt.