### PR TITLE
[GAME] add HealthComponent and HealthSystem

### DIFF
--- a/game/src/ecs/components/HealthComponent.java
+++ b/game/src/ecs/components/HealthComponent.java
@@ -9,7 +9,7 @@ import semanticAnalysis.types.DSLContextMember;
 import semanticAnalysis.types.DSLType;
 import semanticAnalysis.types.DSLTypeMember;
 
-@DSLType(name = "healt_chomponent")
+@DSLType(name = "health_component")
 /** The HealthComponent makes an entity vulnerable and killable */
 public class HealthComponent extends Component {
     public static String name = "HealthComponent";

--- a/game/src/ecs/components/HealthComponent.java
+++ b/game/src/ecs/components/HealthComponent.java
@@ -16,8 +16,8 @@ public class HealthComponent extends Component {
     private static final List<String> missingTexture = List.of("animation/missingTexture.png");
 
     private final List<Damage> damageToGet;
-    private @DSLTypeMember(name = "maximal_hit_points") int maximalHitPoints;
-    private int currentHitPoints;
+    private @DSLTypeMember(name = "maximal_health_points") int maximalHealthpoints;
+    private int currentHealthpoints;
     private @DSLTypeMember(name = "on_death_function") IOnDeathFunction onDeath;
     private @DSLTypeMember(name = "get_hit_animation") Animation getHitAnimation;
     private @DSLTypeMember(name = "die_animation") Animation dieAnimation;
@@ -39,8 +39,8 @@ public class HealthComponent extends Component {
             Animation getHitAnimation,
             Animation dieAnimation) {
         super(entity);
-        this.maximalHitPoints = maximalHitPoints;
-        this.currentHitPoints = maximalHitPoints;
+        this.maximalHealthpoints = maximalHitPoints;
+        this.currentHealthpoints = maximalHitPoints;
         this.onDeath = onDeath;
         this.getHitAnimation = getHitAnimation;
         this.dieAnimation = dieAnimation;
@@ -96,21 +96,21 @@ public class HealthComponent extends Component {
     /**
      * Sets the current life points, capped at the value of the maximum hit-points
      *
-     * @param amount new amount of current hit-points
+     * @param amount new amount of current health-points
      */
-    public void setCurrentHitPoints(int amount) {
-        this.currentHitPoints = Math.min(maximalHitPoints, amount);
+    public void setCurrentHealthpoints(int amount) {
+        this.currentHealthpoints = Math.min(maximalHealthpoints, amount);
     }
 
     /**
-     * Sets the value of the Maximum Hit-points. If the new maximum hit-points are less than the
-     * current hit-points, the current points are set to the new maximum hit-points.
+     * Sets the value of the Maximum health-points. If the new maximum health-points are less than
+     * the current health-points, the current points are set to the new maximum health-points.
      *
-     * @param amount new amount of maximal hit-points
+     * @param amount new amount of maximal health-points
      */
-    public void setMaximalHitPoints(int amount) {
-        this.maximalHitPoints = amount;
-        currentHitPoints = Math.min(currentHitPoints, maximalHitPoints);
+    public void setMaximalHealthpoints(int amount) {
+        this.maximalHealthpoints = amount;
+        currentHealthpoints = Math.min(currentHealthpoints, maximalHealthpoints);
     }
 
     /**
@@ -141,17 +141,17 @@ public class HealthComponent extends Component {
     }
 
     /**
-     * @return The current hit-points the entity has
+     * @return The current health-points the entity has
      */
-    public int getCurrentHitPoints() {
-        return currentHitPoints;
+    public int getCurrentHealthpoints() {
+        return currentHealthpoints;
     }
 
     /**
-     * @return The maximal hit-points the entity can have
+     * @return The maximal health-points the entity can have
      */
-    public int getMaximalHitPoints() {
-        return maximalHitPoints;
+    public int getMaximalHealthpoints() {
+        return maximalHealthpoints;
     }
 
     /**

--- a/game/src/ecs/components/HealthComponent.java
+++ b/game/src/ecs/components/HealthComponent.java
@@ -9,8 +9,8 @@ import semanticAnalysis.types.DSLContextMember;
 import semanticAnalysis.types.DSLType;
 import semanticAnalysis.types.DSLTypeMember;
 
-@DSLType(name = "health_component")
 /** The HealthComponent makes an entity vulnerable and killable */
+@DSLType(name = "health_component")
 public class HealthComponent extends Component {
     public static String name = "HealthComponent";
     private static List<String> missingTexture = List.of("animation/missingTexture.png");
@@ -56,11 +56,7 @@ public class HealthComponent extends Component {
         super(entity, name);
         this.maximalHitPoints = 1;
         this.currentHitPoints = 1;
-        this.onDeath =
-                new IOnDeathFunction() {
-                    @Override
-                    public void onDeath(Entity entity) {}
-                };
+        this.onDeath = entity2 -> {};
         this.getHitAnimation = new Animation(missingTexture, 100);
         this.dieAnimation = new Animation(missingTexture, 100);
         damageToGet = new ArrayList<>();
@@ -85,6 +81,11 @@ public class HealthComponent extends Component {
      */
     public List<Damage> getDamageList() {
         return damageToGet;
+    }
+
+    /** Clear the damage list */
+    public void clearDamageList() {
+        damageToGet.clear();
     }
 
     /**

--- a/game/src/ecs/components/HealthComponent.java
+++ b/game/src/ecs/components/HealthComponent.java
@@ -1,6 +1,7 @@
 package ecs.components;
 
 import ecs.damage.Damage;
+import ecs.damage.DamageType;
 import ecs.entities.Entity;
 import graphic.Animation;
 import java.util.ArrayList;
@@ -12,9 +13,9 @@ import semanticAnalysis.types.DSLTypeMember;
 /** The HealthComponent makes an entity vulnerable and killable */
 @DSLType(name = "health_component")
 public class HealthComponent extends Component {
-    private static List<String> missingTexture = List.of("animation/missingTexture.png");
+    private static final List<String> missingTexture = List.of("animation/missingTexture.png");
 
-    private List<Damage> damageToGet;
+    private final List<Damage> damageToGet;
     private @DSLTypeMember(name = "maximal_hit_points") int maximalHitPoints;
     private int currentHitPoints;
     private @DSLTypeMember(name = "on_death_function") IOnDeathFunction onDeath;
@@ -25,7 +26,7 @@ public class HealthComponent extends Component {
      * Creates a new HealthComponent
      *
      * @param entity associated entity
-     * @param maximalHitPoints maximum ammout of hitpoints, currentHitPoints cant be biggter than
+     * @param maximalHitPoints maximum amount of hit-points, currentHitPoints cant be bigger than
      *     that
      * @param onDeath Function that gets called, when this entity dies
      * @param getHitAnimation Animation to be played as the entity was hit
@@ -47,7 +48,7 @@ public class HealthComponent extends Component {
     }
 
     /**
-     * Creates a HelthComponent with default values
+     * Creates a HealthComponent with default values
      *
      * @param entity associated entity
      */
@@ -82,28 +83,41 @@ public class HealthComponent extends Component {
         return damageToGet;
     }
 
+    /**
+     * Calculate the amount of damage of a certain type
+     *
+     * @param dt Type of damage object that still need to be accounted for
+     * @return Sum of all damage objects of type dt (default: 0)
+     */
+    public int getDamage(DamageType dt) {
+        return damageToGet.stream()
+                .filter(d -> d.damageType() == dt)
+                .mapToInt(Damage::damageAmount)
+                .sum();
+    }
+
     /** Clear the damage list */
     public void clearDamageList() {
         damageToGet.clear();
     }
 
     /**
-     * Sets the current life points, capped at the value of the maximum hitpoints
+     * Sets the current life points, capped at the value of the maximum hit-points
      *
-     * @param ammount new ammount of current hitpoints
+     * @param amount new amount of current hit-points
      */
-    public void setCurrentHitPoints(int ammount) {
-        this.currentHitPoints = Math.min(maximalHitPoints, ammount);
+    public void setCurrentHitPoints(int amount) {
+        this.currentHitPoints = Math.min(maximalHitPoints, amount);
     }
 
     /**
-     * Sets the value of the Maximum Hitpoints. If the new maximum hitpoints are less than the
-     * current hitpoints, the current hitpoints are set to the new maximum hitpoints.
+     * Sets the value of the Maximum Hit-points. If the new maximum hit-points are less than the
+     * current hit-points, the current points are set to the new maximum hit-points.
      *
-     * @param ammount new ammount of maximal hitpoints
+     * @param amount new amount of maximal hit-points
      */
-    public void setMaximalHitPoints(int ammount) {
-        this.maximalHitPoints = ammount;
+    public void setMaximalHitPoints(int amount) {
+        this.maximalHitPoints = amount;
         currentHitPoints = Math.min(currentHitPoints, maximalHitPoints);
     }
 
@@ -135,14 +149,14 @@ public class HealthComponent extends Component {
     }
 
     /**
-     * @return The current hitpoints the entity has
+     * @return The current hit-points the entity has
      */
     public int getCurrentHitPoints() {
         return currentHitPoints;
     }
 
     /**
-     * @return The maximal hitpoints the entity can have
+     * @return The maximal hit-points the entity can have
      */
     public int getMaximalHitPoints() {
         return maximalHitPoints;

--- a/game/src/ecs/components/HealthComponent.java
+++ b/game/src/ecs/components/HealthComponent.java
@@ -26,7 +26,7 @@ public class HealthComponent extends Component {
      * Creates a new HealthComponent
      *
      * @param entity associated entity
-     * @param maximalHitPoints maximum amount of hit-points, currentHitPoints cant be bigger than
+     * @param maximalHitPoints maximum amount of hit-points, currentHitPoints can't be bigger than
      *     that
      * @param onDeath Function that gets called, when this entity dies
      * @param getHitAnimation Animation to be played as the entity was hit
@@ -53,13 +53,12 @@ public class HealthComponent extends Component {
      * @param entity associated entity
      */
     public HealthComponent(@DSLContextMember(name = "entity") Entity entity) {
-        super(entity);
-        this.maximalHitPoints = 1;
-        this.currentHitPoints = 1;
-        this.onDeath = entity2 -> {};
-        this.getHitAnimation = new Animation(missingTexture, 100);
-        this.dieAnimation = new Animation(missingTexture, 100);
-        damageToGet = new ArrayList<>();
+        this(
+                entity,
+                1,
+                entity2 -> {},
+                new Animation(missingTexture, 100),
+                new Animation(missingTexture, 100));
     }
 
     /**
@@ -67,20 +66,13 @@ public class HealthComponent extends Component {
      *
      * @param damage Damage that should be inflicted
      */
-    public void getHit(Damage damage) {
+    public void receiveHit(Damage damage) {
         damageToGet.add(damage);
     }
 
     /** Triggers the onDeath Function */
     public void triggerOnDeath() {
         onDeath.onDeath(entity);
-    }
-
-    /**
-     * @return List with all damage objects that still need to be accounted for
-     */
-    public List<Damage> getDamageList() {
-        return damageToGet;
     }
 
     /**
@@ -97,7 +89,7 @@ public class HealthComponent extends Component {
     }
 
     /** Clear the damage list */
-    public void clearDamageList() {
+    public void clearDamage() {
         damageToGet.clear();
     }
 

--- a/game/src/ecs/components/HealthComponent.java
+++ b/game/src/ecs/components/HealthComponent.java
@@ -1,0 +1,164 @@
+package ecs.components;
+
+import ecs.damage.Damage;
+import ecs.entities.Entity;
+import graphic.Animation;
+import java.util.ArrayList;
+import java.util.List;
+import semanticAnalysis.types.DSLContextMember;
+import semanticAnalysis.types.DSLType;
+import semanticAnalysis.types.DSLTypeMember;
+
+@DSLType(name = "healt_chomponent")
+/** The HealthComponent makes an entity vulnerable and killable */
+public class HealthComponent extends Component {
+    public static String name = "HealthComponent";
+    private static List<String> missingTexture = List.of("animation/missingTexture.png");
+
+    private List<Damage> damageToGet;
+    private @DSLTypeMember(name = "maximal_hit_points") int maximalHitPoints;
+    private int currentHitPoints;
+    private @DSLTypeMember(name = "on_death_function") IOnDeathFunction onDeath;
+    private @DSLTypeMember(name = "get_hit_animation") Animation getHitAnimation;
+    private @DSLTypeMember(name = "die_animation") Animation dieAnimation;
+
+    /**
+     * Creates a new HealthComponent
+     *
+     * @param entity associated entity
+     * @param maximalHitPoints maximum ammout of hitpoints, currentHitPoints cant be biggter than
+     *     that
+     * @param onDeath Function that gets called, when this entity dies
+     * @param getHitAnimation Animation to be played as the entity was hit
+     * @param dieAnimation Animation to be played as the entity dies
+     */
+    public HealthComponent(
+            Entity entity,
+            int maximalHitPoints,
+            IOnDeathFunction onDeath,
+            Animation getHitAnimation,
+            Animation dieAnimation) {
+        super(entity, name);
+        this.maximalHitPoints = maximalHitPoints;
+        this.currentHitPoints = maximalHitPoints;
+        this.onDeath = onDeath;
+        this.getHitAnimation = getHitAnimation;
+        this.dieAnimation = dieAnimation;
+        damageToGet = new ArrayList<>();
+    }
+
+    /**
+     * Creates a HelthComponent with default values
+     *
+     * @param entity associated entity
+     */
+    public HealthComponent(@DSLContextMember(name = "entity") Entity entity) {
+        super(entity, name);
+        this.maximalHitPoints = 1;
+        this.currentHitPoints = 1;
+        this.onDeath =
+                new IOnDeathFunction() {
+                    @Override
+                    public void onDeath(Entity entity) {}
+                };
+        this.getHitAnimation = new Animation(missingTexture, 100);
+        this.dieAnimation = new Animation(missingTexture, 100);
+        damageToGet = new ArrayList<>();
+    }
+
+    /**
+     * Adds damage, which is accounted for by the system
+     *
+     * @param damage Damage that should be inflicted
+     */
+    public void getHit(Damage damage) {
+        damageToGet.add(damage);
+    }
+
+    /** Triggers the onDeath Function */
+    public void triggerOnDeath() {
+        onDeath.onDeath(entity);
+    }
+
+    /**
+     * @return List with all damage objects that still need to be accounted for
+     */
+    public List<Damage> getDamageList() {
+        return damageToGet;
+    }
+
+    /**
+     * Sets the current life points, capped at the value of the maximum hitpoints
+     *
+     * @param ammount new ammount of current hitpoints
+     */
+    public void setCurrentHitPoints(int ammount) {
+        this.currentHitPoints = Math.min(maximalHitPoints, ammount);
+    }
+
+    /**
+     * Sets the value of the Maximum Hitpoints. If the new maximum hitpoints are less than the
+     * current hitpoints, the current hitpoints are set to the new maximum hitpoints.
+     *
+     * @param ammount new ammount of maximal hitpoints
+     */
+    public void setMaximalHitPoints(int ammount) {
+        this.maximalHitPoints = ammount;
+        currentHitPoints = Math.min(currentHitPoints, maximalHitPoints);
+    }
+
+    /**
+     * Set the animation to be played when the entity dies
+     *
+     * @param dieAnimation new dieAnimation
+     */
+    public void setDieAnimation(Animation dieAnimation) {
+        this.dieAnimation = dieAnimation;
+    }
+
+    /**
+     * Set the animation to be played when the entity is hit
+     *
+     * @param isHitAnimation new isHitAnimation
+     */
+    public void setGetHitAnimation(Animation isHitAnimation) {
+        this.getHitAnimation = isHitAnimation;
+    }
+
+    /**
+     * Set a new function to be called when dying.
+     *
+     * @param onDeath new onDeath function
+     */
+    public void setOnDeath(IOnDeathFunction onDeath) {
+        this.onDeath = onDeath;
+    }
+
+    /**
+     * @return The current hitpoints the entity has
+     */
+    public int getCurrentHitPoints() {
+        return currentHitPoints;
+    }
+
+    /**
+     * @return The maximal hitpoints the entity can have
+     */
+    public int getMaximalHitPoints() {
+        return maximalHitPoints;
+    }
+
+    /**
+     * @return Animation to be played as the entity was hit
+     */
+    public Animation getGetHitAnimation() {
+        return getHitAnimation;
+    }
+
+    /**
+     * @return Animation to be played when dying
+     */
+    public Animation getDieAnimation() {
+        return dieAnimation;
+    }
+}

--- a/game/src/ecs/components/HealthComponent.java
+++ b/game/src/ecs/components/HealthComponent.java
@@ -12,7 +12,6 @@ import semanticAnalysis.types.DSLTypeMember;
 /** The HealthComponent makes an entity vulnerable and killable */
 @DSLType(name = "health_component")
 public class HealthComponent extends Component {
-    public static String name = "HealthComponent";
     private static List<String> missingTexture = List.of("animation/missingTexture.png");
 
     private List<Damage> damageToGet;
@@ -38,7 +37,7 @@ public class HealthComponent extends Component {
             IOnDeathFunction onDeath,
             Animation getHitAnimation,
             Animation dieAnimation) {
-        super(entity, name);
+        super(entity);
         this.maximalHitPoints = maximalHitPoints;
         this.currentHitPoints = maximalHitPoints;
         this.onDeath = onDeath;
@@ -53,7 +52,7 @@ public class HealthComponent extends Component {
      * @param entity associated entity
      */
     public HealthComponent(@DSLContextMember(name = "entity") Entity entity) {
-        super(entity, name);
+        super(entity);
         this.maximalHitPoints = 1;
         this.currentHitPoints = 1;
         this.onDeath = entity2 -> {};

--- a/game/src/ecs/components/IOnDeathFunction.java
+++ b/game/src/ecs/components/IOnDeathFunction.java
@@ -1,0 +1,14 @@
+package ecs.components;
+
+import ecs.entities.Entity;
+
+/** Functional interfaces for implementing a function that is called when an entity dies */
+public interface IOnDeathFunction {
+
+    /**
+     * Function that is performed when an entity dies
+     *
+     * @param entity Entity that has died
+     */
+    void onDeath(Entity entity);
+}

--- a/game/src/ecs/damage/Damage.java
+++ b/game/src/ecs/damage/Damage.java
@@ -1,0 +1,11 @@
+package ecs.damage;
+
+/**
+ * Damage that can reduce the life points of an entity
+ *
+ * @param damageAmmount Number of life points to be deducted. Value before taking into account
+ *     resitences and vulnerabilities.
+ * @param damageType Type of damage, this is important for accounting the actual damage taking into
+ *     account resistances or vulnerabilities
+ */
+public record Damage(int damageAmmount, DamageType damageType) {}

--- a/game/src/ecs/damage/Damage.java
+++ b/game/src/ecs/damage/Damage.java
@@ -3,9 +3,9 @@ package ecs.damage;
 /**
  * Damage that can reduce the life points of an entity
  *
- * @param damageAmmount Number of life points to be deducted. Value before taking into account
- *     resitences and vulnerabilities.
+ * @param damageAmount Number of life points to be deducted. Value before taking into account
+ *     resistances and vulnerabilities.
  * @param damageType Type of damage, this is important for accounting the actual damage taking into
  *     account resistances or vulnerabilities
  */
-public record Damage(int damageAmmount, DamageType damageType) {}
+public record Damage(int damageAmount, DamageType damageType) {}

--- a/game/src/ecs/damage/DamageType.java
+++ b/game/src/ecs/damage/DamageType.java
@@ -1,0 +1,8 @@
+package ecs.damage;
+
+/** Type of damage to include resistent and vulnerabilities in the damage calculation. */
+public enum DamageType {
+    PHYSICAL,
+    MAGIC,
+    FIRE
+}

--- a/game/src/ecs/damage/DamageType.java
+++ b/game/src/ecs/damage/DamageType.java
@@ -1,6 +1,6 @@
 package ecs.damage;
 
-/** Type of damage to include resistent and vulnerabilities in the damage calculation. */
+/** Type of damage to include resistances and vulnerabilities in the damage calculation. */
 public enum DamageType {
     PHYSICAL,
     MAGIC,

--- a/game/src/ecs/systems/HealthSystem.java
+++ b/game/src/ecs/systems/HealthSystem.java
@@ -16,18 +16,17 @@ public class HealthSystem extends ECS_System {
     @Override
     public void update() {
         for (Entity entity : ECS.entities) {
-            entity.getComponent(HealthComponent.name)
+            entity.getComponent(HealthComponent.class)
                     .ifPresent(
                             healthComponent -> {
                                 {
                                     final AnimationComponent animationComponent =
                                             (AnimationComponent)
-                                                    entity.getComponent(AnimationComponent.name)
+                                                    entity.getComponent(AnimationComponent.class)
                                                             .orElseThrow(
                                                                     () ->
                                                                             new MissingComponentException(
-                                                                                    AnimationComponent
-                                                                                            .name));
+                                                                                    "AnimationComponent"));
 
                                     HealthComponent hpComponent = (HealthComponent) healthComponent;
 

--- a/game/src/ecs/systems/HealthSystem.java
+++ b/game/src/ecs/systems/HealthSystem.java
@@ -68,7 +68,7 @@ public class HealthSystem extends ECS_System {
         ECS.entitiesToRemove.add(hsd.hc.getEntity());
     }
 
-    private MissingComponentException missingAC() {
+    private static MissingComponentException missingAC() {
         return new MissingComponentException("AnimationComponent");
     }
 }

--- a/game/src/ecs/systems/HealthSystem.java
+++ b/game/src/ecs/systems/HealthSystem.java
@@ -12,7 +12,7 @@ import mydungeon.ECS;
 
 /**
  * The HealthSystem offsets the damage to be done to all entities with the HealthComponent. Triggers
- * the death of an entity when the hit-points have fallen below 0.
+ * the death of an entity when the health-points have fallen below 0.
  */
 public class HealthSystem extends ECS_System {
 
@@ -29,7 +29,7 @@ public class HealthSystem extends ECS_System {
                 // Apply damage
                 .map(this::applyDamage)
                 // Filter all dead entities
-                .filter(hsd -> hsd.hc.getCurrentHitPoints() <= 0)
+                .filter(hsd -> hsd.hc.getCurrentHealthpoints() <= 0)
                 // Remove all dead entities
                 .forEach(this::removeDeadEntities);
     }
@@ -55,7 +55,7 @@ public class HealthSystem extends ECS_System {
 
         // reset all damage objects in health component and apply damage
         hsd.hc.clearDamage();
-        hsd.hc.setCurrentHitPoints(hsd.hc.getCurrentHitPoints() - dmgAmount);
+        hsd.hc.setCurrentHealthpoints(hsd.hc.getCurrentHealthpoints() - dmgAmount);
 
         return hsd;
     }

--- a/game/src/ecs/systems/HealthSystem.java
+++ b/game/src/ecs/systems/HealthSystem.java
@@ -33,27 +33,35 @@ public class HealthSystem extends ECS_System {
 
                                     // is the entity dead?
                                     if (hpComponent.getCurrentHitPoints() <= 0) {
+                                        // Entity appears to be dead, so let's clean up the mess
                                         hpComponent.triggerOnDeath();
                                         ac.setCurrentAnimation(hpComponent.getDieAnimation());
-                                        // todo: After animation is finished
+                                        /*
+                                        todo: Before removing the entity, check if the animation is finished
+                                        Issue #246
+                                        */
                                         ECS.entitiesToRemove.add(entity);
                                     } else {
-                                        // make damage
+                                        // Entity is (still) alive - apply damage
                                         List<Damage> damageToGet = hpComponent.getDamageList();
                                         int dmgAmmount = 0;
                                         for (Damage dmg : damageToGet) {
-                                            // place to increase or decrease dmg based on skills,
-                                            // items
-                                            dmgAmmount += dmg.damageAmmount();
+                                            // todo: after we implemented Items like Armor: reduce
+                                            // (or increase) the damage based on the stats and the
+                                            // damage type
+                                            switch (dmg.damageType()) {
+                                                case PHYSICAL -> dmgAmmount += dmg.damageAmmount();
+                                                case MAGIC -> dmgAmmount += dmg.damageAmmount();
+                                                case FIRE -> dmgAmmount += dmg.damageAmmount();
+                                            }
                                         }
                                         // if damage was caused, play getHitAnimation
                                         if (dmgAmmount > 0) {
                                             ac.setCurrentAnimation(
                                                     hpComponent.getGetHitAnimation());
                                         }
-                                        // clear list
-                                        damageToGet.clear();
-                                        // set hit points
+
+                                        hpComponent.clearDamageList();
                                         hpComponent.setCurrentHitPoints(
                                                 hpComponent.getCurrentHitPoints() - dmgAmmount);
                                     }

--- a/game/src/ecs/systems/HealthSystem.java
+++ b/game/src/ecs/systems/HealthSystem.java
@@ -39,7 +39,7 @@ public class HealthSystem extends ECS_System {
 
         AnimationComponent ac =
                 (AnimationComponent)
-                        e.getComponent(AnimationComponent.class).orElseThrow(this::missingAC);
+                        e.getComponent(AnimationComponent.class).orElseThrow(HealthSystem::missingAC);
 
         return new HSData(e, hc, ac);
     }

--- a/game/src/ecs/systems/HealthSystem.java
+++ b/game/src/ecs/systems/HealthSystem.java
@@ -54,7 +54,7 @@ public class HealthSystem extends ECS_System {
         }
 
         // reset all damage objects in health component and apply damage
-        hsd.hc.clearDamageList();
+        hsd.hc.clearDamage();
         hsd.hc.setCurrentHitPoints(hsd.hc.getCurrentHitPoints() - dmgAmount);
 
         return hsd;

--- a/game/src/ecs/systems/HealthSystem.java
+++ b/game/src/ecs/systems/HealthSystem.java
@@ -39,7 +39,8 @@ public class HealthSystem extends ECS_System {
 
         AnimationComponent ac =
                 (AnimationComponent)
-                        e.getComponent(AnimationComponent.class).orElseThrow(HealthSystem::missingAC);
+                        e.getComponent(AnimationComponent.class)
+                                .orElseThrow(HealthSystem::missingAC);
 
         return new HSData(e, hc, ac);
     }

--- a/game/src/ecs/systems/HealthSystem.java
+++ b/game/src/ecs/systems/HealthSystem.java
@@ -1,0 +1,64 @@
+package ecs.systems;
+
+import ecs.components.AnimationComponent;
+import ecs.components.HealthComponent;
+import ecs.components.MissingComponentException;
+import ecs.damage.Damage;
+import ecs.entities.Entity;
+import java.util.List;
+import mydungeon.ECS;
+
+/**
+ * The HealthSystem offsets the damage to be done to all entities with the HealthComponent. Triggers
+ * the death of an entity when the hitpoints have fallen below 0.
+ */
+public class HealthSystem extends ECS_System {
+    @Override
+    public void update() {
+        for (Entity entity : ECS.entities) {
+            entity.getComponent(HealthComponent.name)
+                    .ifPresent(
+                            component -> {
+                                {
+                                    final AnimationComponent ac =
+                                            (AnimationComponent)
+                                                    entity.getComponent(AnimationComponent.name)
+                                                            .orElseThrow(
+                                                                    () ->
+                                                                            new MissingComponentException(
+                                                                                    AnimationComponent
+                                                                                            .name));
+
+                                    HealthComponent hpComponent = (HealthComponent) component;
+
+                                    // is the entity dead?
+                                    if (hpComponent.getCurrentHitPoints() <= 0) {
+                                        hpComponent.triggerOnDeath();
+                                        ac.setCurrentAnimation(hpComponent.getDieAnimation());
+                                        // todo: After animation is finished
+                                        ECS.entitiesToRemove.add(entity);
+                                    } else {
+                                        // make damage
+                                        List<Damage> damageToGet = hpComponent.getDamageList();
+                                        int dmgAmmount = 0;
+                                        for (Damage dmg : damageToGet) {
+                                            // place to increase or decrease dmg based on skills,
+                                            // items
+                                            dmgAmmount += dmg.damageAmmount();
+                                        }
+                                        // if damage was caused, play getHitAnimation
+                                        if (dmgAmmount > 0) {
+                                            ac.setCurrentAnimation(
+                                                    hpComponent.getGetHitAnimation());
+                                        }
+                                        // clear list
+                                        damageToGet.clear();
+                                        // set hit points
+                                        hpComponent.setCurrentHitPoints(
+                                                hpComponent.getCurrentHitPoints() - dmgAmmount);
+                                    }
+                                }
+                            });
+        }
+    }
+}

--- a/game/src/mydungeon/ECS.java
+++ b/game/src/mydungeon/ECS.java
@@ -21,7 +21,10 @@ import tools.Point;
 
 public class ECS extends Game {
 
+    /** All entities that are currently active in the dungeon */
     public static Set<Entity> entities = new HashSet<>();
+    /** All entities to be removed from the dungeon in the next frame */
+    public static Set<Entity> entitiesToRemove = new HashSet<>();
 
     /** List of all Systems in the ECS */
     public static SystemController systems;
@@ -50,12 +53,14 @@ public class ECS extends Game {
         new KeyboardSystem();
         new AISystem();
         new CollisionSystem();
+        new HealthSystem();
     }
 
     @Override
     protected void frame() {
         camera.setFocusPoint(heroPositionComponent.getPosition());
-
+        entities.remove(entitiesToRemove);
+        entitiesToRemove.clear();
         if (isOnEndTile()) levelAPI.loadLevel();
         if (Gdx.input.isKeyJustPressed(Input.Keys.P)) togglePause();
     }

--- a/game/src/mydungeon/ECS.java
+++ b/game/src/mydungeon/ECS.java
@@ -59,7 +59,7 @@ public class ECS extends Game {
     @Override
     protected void frame() {
         camera.setFocusPoint(heroPositionComponent.getPosition());
-        entities.remove(entitiesToRemove);
+        entities.removeAll(entitiesToRemove);
         entitiesToRemove.clear();
         if (isOnEndTile()) levelAPI.loadLevel();
         if (Gdx.input.isKeyJustPressed(Input.Keys.P)) togglePause();

--- a/game/test/ecs/components/HealthComponentTest.java
+++ b/game/test/ecs/components/HealthComponentTest.java
@@ -32,45 +32,45 @@ public class HealthComponentTest {
     }
 
     @Test
-    public void setMaximalHitPointsLowerThanCurrent() {
+    public void setMaximalHealthPointsLowerThanCurrent() {
         ECS.entities.clear();
         Entity entity = new Entity();
         HealthComponent hc = new HealthComponent(entity, 10, null, null, null);
-        assertEquals(10, hc.getMaximalHitPoints());
-        assertEquals(10, hc.getCurrentHitPoints());
-        hc.setMaximalHitPoints(8);
-        assertEquals(8, hc.getMaximalHitPoints());
-        assertEquals(8, hc.getCurrentHitPoints());
+        assertEquals(10, hc.getMaximalHealthpoints());
+        assertEquals(10, hc.getCurrentHealthpoints());
+        hc.setMaximalHealthpoints(8);
+        assertEquals(8, hc.getMaximalHealthpoints());
+        assertEquals(8, hc.getCurrentHealthpoints());
     }
 
     @Test
-    public void setMaximalHitPointsHigherThanCurrent() {
+    public void setMaximalHealthPointsHigherThanCurrent() {
         ECS.entities.clear();
         Entity entity = new Entity();
         HealthComponent hc = new HealthComponent(entity, 10, null, null, null);
-        assertEquals(10, hc.getMaximalHitPoints());
-        assertEquals(10, hc.getCurrentHitPoints());
-        hc.setMaximalHitPoints(12);
-        assertEquals(12, hc.getMaximalHitPoints());
-        assertEquals(10, hc.getCurrentHitPoints());
+        assertEquals(10, hc.getMaximalHealthpoints());
+        assertEquals(10, hc.getCurrentHealthpoints());
+        hc.setMaximalHealthpoints(12);
+        assertEquals(12, hc.getMaximalHealthpoints());
+        assertEquals(10, hc.getCurrentHealthpoints());
     }
 
     @Test
-    public void setCurrentHitPointsHigherThanMaximum() {
+    public void setCurrentHealthPointsHigherThanMaximum() {
         ECS.entities.clear();
         Entity entity = new Entity();
         HealthComponent hc = new HealthComponent(entity, 10, null, null, null);
-        hc.setCurrentHitPoints(12);
-        assertEquals(10, hc.getCurrentHitPoints());
+        hc.setCurrentHealthpoints(12);
+        assertEquals(10, hc.getCurrentHealthpoints());
     }
 
     @Test
-    public void setCurrentHitPointsLowerThanMaximum() {
+    public void setCurrentHealthPointsLowerThanMaximum() {
         ECS.entities.clear();
         Entity entity = new Entity();
         HealthComponent hc = new HealthComponent(entity, 10, null, null, null);
-        hc.setCurrentHitPoints(8);
-        assertEquals(8, hc.getCurrentHitPoints());
+        hc.setCurrentHealthpoints(8);
+        assertEquals(8, hc.getCurrentHealthpoints());
     }
 
     @Test

--- a/game/test/ecs/components/HealthComponentTest.java
+++ b/game/test/ecs/components/HealthComponentTest.java
@@ -1,7 +1,6 @@
 package ecs.components;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.times;
 
 import ecs.damage.Damage;
@@ -15,13 +14,21 @@ import org.mockito.Mockito;
 public class HealthComponentTest {
 
     @Test
-    public void getHit() {
+    public void receiveHit() {
         ECS.entities.clear();
         Entity entity = new Entity();
         HealthComponent hc = new HealthComponent(entity);
-        Damage dmg = new Damage(3, DamageType.FIRE);
-        hc.getHit(dmg);
-        assertTrue(hc.getDamageList().contains(dmg));
+        Damage fdmg = new Damage(3, DamageType.FIRE);
+        Damage fdmg2 = new Damage(5, DamageType.FIRE);
+        Damage mdmg = new Damage(-1, DamageType.MAGIC);
+        Damage pdmg = new Damage(4, DamageType.PHYSICAL);
+        hc.receiveHit(fdmg);
+        hc.receiveHit(fdmg2);
+        hc.receiveHit(mdmg);
+        hc.receiveHit(pdmg);
+        assertEquals(fdmg.damageAmount() + fdmg2.damageAmount(), hc.getDamage(DamageType.FIRE));
+        assertEquals(mdmg.damageAmount(), hc.getDamage(DamageType.MAGIC));
+        assertEquals(pdmg.damageAmount(), hc.getDamage(DamageType.PHYSICAL));
     }
 
     @Test
@@ -49,7 +56,7 @@ public class HealthComponentTest {
     }
 
     @Test
-    public void setCurrentHitPointsHigherThanMaxmimum() {
+    public void setCurrentHitPointsHigherThanMaximum() {
         ECS.entities.clear();
         Entity entity = new Entity();
         HealthComponent hc = new HealthComponent(entity, 10, null, null, null);
@@ -58,7 +65,7 @@ public class HealthComponentTest {
     }
 
     @Test
-    public void setCurrentHitPointsLowerThanMaxmimum() {
+    public void setCurrentHitPointsLowerThanMaximum() {
         ECS.entities.clear();
         Entity entity = new Entity();
         HealthComponent hc = new HealthComponent(entity, 10, null, null, null);

--- a/game/test/ecs/components/HealthComponentTest.java
+++ b/game/test/ecs/components/HealthComponentTest.java
@@ -1,0 +1,109 @@
+package ecs.components;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.times;
+
+import ecs.damage.Damage;
+import ecs.damage.DamageType;
+import ecs.entities.Entity;
+import graphic.Animation;
+import mydungeon.ECS;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class HealthComponentTest {
+
+    @Test
+    public void getHit() {
+        ECS.entities.clear();
+        Entity entity = new Entity();
+        HealthComponent hc = new HealthComponent(entity);
+        Damage dmg = new Damage(3, DamageType.FIRE);
+        hc.getHit(dmg);
+        assertTrue(hc.getDamageList().contains(dmg));
+    }
+
+    @Test
+    public void setMaximalHitPointsLowerThanCurrent() {
+        ECS.entities.clear();
+        Entity entity = new Entity();
+        HealthComponent hc = new HealthComponent(entity, 10, null, null, null);
+        assertEquals(10, hc.getMaximalHitPoints());
+        assertEquals(10, hc.getCurrentHitPoints());
+        hc.setMaximalHitPoints(8);
+        assertEquals(8, hc.getMaximalHitPoints());
+        assertEquals(8, hc.getCurrentHitPoints());
+    }
+
+    @Test
+    public void setMaximalHitPointsHigherThanCurrent() {
+        ECS.entities.clear();
+        Entity entity = new Entity();
+        HealthComponent hc = new HealthComponent(entity, 10, null, null, null);
+        assertEquals(10, hc.getMaximalHitPoints());
+        assertEquals(10, hc.getCurrentHitPoints());
+        hc.setMaximalHitPoints(12);
+        assertEquals(12, hc.getMaximalHitPoints());
+        assertEquals(10, hc.getCurrentHitPoints());
+    }
+
+    @Test
+    public void setCurrentHitPointsHigherThanMaxmimum() {
+        ECS.entities.clear();
+        Entity entity = new Entity();
+        HealthComponent hc = new HealthComponent(entity, 10, null, null, null);
+        hc.setCurrentHitPoints(12);
+        assertEquals(10, hc.getCurrentHitPoints());
+    }
+
+    @Test
+    public void setCurrentHitPointsLowerThanMaxmimum() {
+        ECS.entities.clear();
+        Entity entity = new Entity();
+        HealthComponent hc = new HealthComponent(entity, 10, null, null, null);
+        hc.setCurrentHitPoints(8);
+        assertEquals(8, hc.getCurrentHitPoints());
+    }
+
+    @Test
+    public void triggerOnDeath() {
+        ECS.entities.clear();
+        Entity entity = new Entity();
+        IOnDeathFunction onDeathFunction = Mockito.mock(IOnDeathFunction.class);
+        HealthComponent hc = new HealthComponent(entity, 10, onDeathFunction, null, null);
+        hc.triggerOnDeath();
+        Mockito.verify(onDeathFunction, times(1)).onDeath(entity);
+    }
+
+    @Test
+    public void setDieAnimation() {
+        ECS.entities.clear();
+        Entity entity = new Entity();
+        HealthComponent hc = new HealthComponent(entity);
+        Animation animation = Mockito.mock(Animation.class);
+        hc.setDieAnimation(animation);
+        assertEquals(animation, hc.getDieAnimation());
+    }
+
+    @Test
+    public void setGetHitAnimation() {
+        ECS.entities.clear();
+        Entity entity = new Entity();
+        HealthComponent hc = new HealthComponent(entity);
+        Animation animation = Mockito.mock(Animation.class);
+        hc.setGetHitAnimation(animation);
+        assertEquals(animation, hc.getGetHitAnimation());
+    }
+
+    @Test
+    public void setOnDeathFunction() {
+        ECS.entities.clear();
+        Entity entity = new Entity();
+        HealthComponent hc = new HealthComponent(entity);
+        IOnDeathFunction function = Mockito.mock(IOnDeathFunction.class);
+        hc.setOnDeath(function);
+        hc.triggerOnDeath();
+        Mockito.verify(function, times(1)).onDeath(entity);
+    }
+}

--- a/game/test/ecs/systems/HealthSystemTest.java
+++ b/game/test/ecs/systems/HealthSystemTest.java
@@ -1,18 +1,103 @@
 package ecs.systems;
 
+import static org.junit.Assert.*;
+
+import ecs.components.AnimationComponent;
+import ecs.components.HealthComponent;
+import ecs.components.IOnDeathFunction;
+import ecs.components.MissingComponentException;
+import ecs.damage.Damage;
+import ecs.damage.DamageType;
+import ecs.entities.Entity;
+import graphic.Animation;
+import mydungeon.ECS;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 public class HealthSystemTest {
 
     @Test
-    public void updateEntiteDies() {}
+    public void updateEntiteDies() {
+        ECS.entities.clear();
+        ECS.systems = new SystemController();
+        Entity entity = new Entity();
+        IOnDeathFunction onDeath = Mockito.mock(IOnDeathFunction.class);
+        Animation dieAnimation = Mockito.mock(Animation.class);
+        AnimationComponent ac = new AnimationComponent(entity);
+        HealthComponent component = new HealthComponent(entity, 1, onDeath, null, dieAnimation);
+        HealthSystem system = new HealthSystem();
+        component.setCurrentHitPoints(0);
+        system.update();
+        assertEquals(dieAnimation, ac.getCurrentAnimation());
+        assertTrue(ECS.entitiesToRemove.contains(entity));
+    }
 
     @Test
-    public void updateEntiteGetDamage() {}
+    public void updateEntiteGetDamage() {
+        ECS.entities.clear();
+        ECS.systems = new SystemController();
+        Entity entity = new Entity();
+        IOnDeathFunction onDeath = Mockito.mock(IOnDeathFunction.class);
+        Animation hitAnimation = Mockito.mock(Animation.class);
+        AnimationComponent ac = new AnimationComponent(entity);
+        HealthComponent component = new HealthComponent(entity, 10, onDeath, hitAnimation, null);
+        component.getHit(new Damage(5, DamageType.FIRE));
+        component.getHit(new Damage(2, DamageType.FIRE));
+        HealthSystem system = new HealthSystem();
+        system.update();
+        assertEquals(3, component.getCurrentHitPoints());
+        assertEquals(hitAnimation, ac.getCurrentAnimation());
+    }
 
     @Test
-    public void updateEntiteGetNegativeDamage() {}
+    public void updateEntiteGetNegativeDamage() {
+        ECS.entities.clear();
+        ECS.systems = new SystemController();
+        Entity entity = new Entity();
+        IOnDeathFunction onDeath = Mockito.mock(IOnDeathFunction.class);
+        Animation hitAnimation = Mockito.mock(Animation.class);
+        AnimationComponent ac = new AnimationComponent(entity);
+        HealthComponent component = new HealthComponent(entity, 10, onDeath, hitAnimation, null);
+        component.setCurrentHitPoints(3);
+        component.getHit(new Damage(-3, DamageType.FIRE));
+        HealthSystem system = new HealthSystem();
+        system.update();
+        assertEquals(6, component.getCurrentHitPoints());
+        assertNotEquals(hitAnimation, ac.getCurrentAnimation());
+    }
 
     @Test
-    public void updateEntiteGetZeroDamage() {}
+    public void updateEntiteGetZeroDamage() {
+        ECS.entities.clear();
+        ECS.systems = new SystemController();
+        Entity entity = new Entity();
+        IOnDeathFunction onDeath = Mockito.mock(IOnDeathFunction.class);
+        Animation hitAnimation = Mockito.mock(Animation.class);
+        AnimationComponent ac = new AnimationComponent(entity);
+        HealthComponent component = new HealthComponent(entity, 10, onDeath, hitAnimation, null);
+        component.getHit(new Damage(0, DamageType.FIRE));
+        HealthSystem system = new HealthSystem();
+        system.update();
+        assertEquals(10, component.getCurrentHitPoints());
+        assertNotEquals(hitAnimation, ac.getCurrentAnimation());
+    }
+
+    @Test
+    public void updateWithoutHealthComponent() {
+        ECS.entities.clear();
+        ECS.systems = new SystemController();
+        Entity entity = new Entity();
+        HealthSystem system = new HealthSystem();
+        system.update();
+    }
+
+    @Test
+    public void updateWithoutAnimationComponent() {
+        ECS.entities.clear();
+        ECS.systems = new SystemController();
+        Entity entity = new Entity();
+        HealthComponent component = new HealthComponent(entity);
+        HealthSystem system = new HealthSystem();
+        assertThrows(MissingComponentException.class, () -> system.update());
+    }
 }

--- a/game/test/ecs/systems/HealthSystemTest.java
+++ b/game/test/ecs/systems/HealthSystemTest.java
@@ -41,8 +41,8 @@ public class HealthSystemTest {
         Animation hitAnimation = Mockito.mock(Animation.class);
         AnimationComponent ac = new AnimationComponent(entity);
         HealthComponent component = new HealthComponent(entity, 10, onDeath, hitAnimation, null);
-        component.getHit(new Damage(5, DamageType.FIRE));
-        component.getHit(new Damage(2, DamageType.FIRE));
+        component.receiveHit(new Damage(5, DamageType.FIRE));
+        component.receiveHit(new Damage(2, DamageType.FIRE));
         HealthSystem system = new HealthSystem();
         system.update();
         assertEquals(3, component.getCurrentHitPoints());
@@ -59,7 +59,7 @@ public class HealthSystemTest {
         AnimationComponent ac = new AnimationComponent(entity);
         HealthComponent component = new HealthComponent(entity, 10, onDeath, hitAnimation, null);
         component.setCurrentHitPoints(3);
-        component.getHit(new Damage(-3, DamageType.FIRE));
+        component.receiveHit(new Damage(-3, DamageType.FIRE));
         HealthSystem system = new HealthSystem();
         system.update();
         assertEquals(6, component.getCurrentHitPoints());
@@ -75,7 +75,7 @@ public class HealthSystemTest {
         Animation hitAnimation = Mockito.mock(Animation.class);
         AnimationComponent ac = new AnimationComponent(entity);
         HealthComponent component = new HealthComponent(entity, 10, onDeath, hitAnimation, null);
-        component.getHit(new Damage(0, DamageType.FIRE));
+        component.receiveHit(new Damage(0, DamageType.FIRE));
         HealthSystem system = new HealthSystem();
         system.update();
         assertEquals(10, component.getCurrentHitPoints());

--- a/game/test/ecs/systems/HealthSystemTest.java
+++ b/game/test/ecs/systems/HealthSystemTest.java
@@ -26,7 +26,7 @@ public class HealthSystemTest {
         AnimationComponent ac = new AnimationComponent(entity);
         HealthComponent component = new HealthComponent(entity, 1, onDeath, null, dieAnimation);
         HealthSystem system = new HealthSystem();
-        component.setCurrentHitPoints(0);
+        component.setCurrentHealthpoints(0);
         system.update();
         assertEquals(dieAnimation, ac.getCurrentAnimation());
         assertTrue(ECS.entitiesToRemove.contains(entity));
@@ -45,7 +45,7 @@ public class HealthSystemTest {
         component.receiveHit(new Damage(2, DamageType.FIRE));
         HealthSystem system = new HealthSystem();
         system.update();
-        assertEquals(3, component.getCurrentHitPoints());
+        assertEquals(3, component.getCurrentHealthpoints());
         assertEquals(hitAnimation, ac.getCurrentAnimation());
     }
 
@@ -58,11 +58,11 @@ public class HealthSystemTest {
         Animation hitAnimation = Mockito.mock(Animation.class);
         AnimationComponent ac = new AnimationComponent(entity);
         HealthComponent component = new HealthComponent(entity, 10, onDeath, hitAnimation, null);
-        component.setCurrentHitPoints(3);
+        component.setCurrentHealthpoints(3);
         component.receiveHit(new Damage(-3, DamageType.FIRE));
         HealthSystem system = new HealthSystem();
         system.update();
-        assertEquals(6, component.getCurrentHitPoints());
+        assertEquals(6, component.getCurrentHealthpoints());
         assertNotEquals(hitAnimation, ac.getCurrentAnimation());
     }
 
@@ -78,7 +78,7 @@ public class HealthSystemTest {
         component.receiveHit(new Damage(0, DamageType.FIRE));
         HealthSystem system = new HealthSystem();
         system.update();
-        assertEquals(10, component.getCurrentHitPoints());
+        assertEquals(10, component.getCurrentHealthpoints());
         assertNotEquals(hitAnimation, ac.getCurrentAnimation());
     }
 

--- a/game/test/ecs/systems/HealthSystemTest.java
+++ b/game/test/ecs/systems/HealthSystemTest.java
@@ -17,7 +17,7 @@ import org.mockito.Mockito;
 public class HealthSystemTest {
 
     @Test
-    public void updateEntiteDies() {
+    public void updateEntityDies() {
         ECS.entities.clear();
         ECS.systems = new SystemController();
         Entity entity = new Entity();
@@ -33,7 +33,7 @@ public class HealthSystemTest {
     }
 
     @Test
-    public void updateEntiteGetDamage() {
+    public void updateEntityGetDamage() {
         ECS.entities.clear();
         ECS.systems = new SystemController();
         Entity entity = new Entity();
@@ -50,7 +50,7 @@ public class HealthSystemTest {
     }
 
     @Test
-    public void updateEntiteGetNegativeDamage() {
+    public void updateEntityGetNegativeDamage() {
         ECS.entities.clear();
         ECS.systems = new SystemController();
         Entity entity = new Entity();
@@ -67,7 +67,7 @@ public class HealthSystemTest {
     }
 
     @Test
-    public void updateEntiteGetZeroDamage() {
+    public void updateEntityGetZeroDamage() {
         ECS.entities.clear();
         ECS.systems = new SystemController();
         Entity entity = new Entity();

--- a/game/test/ecs/systems/HealthSystemTest.java
+++ b/game/test/ecs/systems/HealthSystemTest.java
@@ -1,0 +1,18 @@
+package ecs.systems;
+
+import org.junit.Test;
+
+public class HealthSystemTest {
+
+    @Test
+    public void updateEntiteDies() {}
+
+    @Test
+    public void updateEntiteGetDamage() {}
+
+    @Test
+    public void updateEntiteGetNegativeDamage() {}
+
+    @Test
+    public void updateEntiteGetZeroDamage() {}
+}


### PR DESCRIPTION
fixes #227  and #228 

- `Damage` und `enum DamageType` hinzugefügt, um später die Implementierungen von komplexeren Schadensberechnungen zu vereinfachen.
- `HealthComponent` hinzugefügt 
- `IOnDeathFunction` hinzugefügt, wieder mit dem Strategy-Pattern den Methode definieren die beim sterben ausgeführt weden soll (z.B Loot verteilen)
- `HealthSystem` hinzugefügt, verrechnet den Schaden und kümmert sich um den Entitäts-Tot
  - Programmiermethoden/PM-Dungeon#246 


- [x] Tests