### PR TITLE
[DSL] Support inline definition of aggregate value in grammar

### DIFF
--- a/dsl/src/antlr/DungeonDSL.g4
+++ b/dsl/src/antlr/DungeonDSL.g4
@@ -64,21 +64,17 @@ game_obj_def
 
 // used to specify, which components should be used in a game object
 component_def_list
-        : component_def ',' component_def_list
-        | component_def
+        : aggregate_value_def ',' component_def_list
+        | aggregate_value_def
         ;
 
-// TODO: could component_def and object_def be united (component_def
-//  would be 'anonymous object', which is defined in place)?
-// used to configure a used component
-component_def
-        : ID
-        | ID '{' property_def_list? '}' ;
+aggregate_value_def
+        : type_id=ID
+        | type_id=ID '{' property_def_list? '}' ;
 
 object_def  : type_id=TYPE_SPECIFIER object_id=ID '{' property_def_list? '}' #grammar_type_obj_def
             | type_id=ID object_id=ID '{' property_def_list? '}' #other_type_obj_def
             ;
-
 
 property_def_list
         : property_def ',' property_def_list
@@ -97,12 +93,12 @@ param_list
         | primary
         ;
 
-// temporary, for testing
 primary : ID
         | STRING_LITERAL
         | NUM
         | NUM_DEC
         | func_call
+        | aggregate_value_def
         ;
 
 /*

--- a/dsl/src/interpreter/DSLInterpreter.java
+++ b/dsl/src/interpreter/DSLInterpreter.java
@@ -81,7 +81,8 @@ public class DSLInterpreter implements AstVisitor<Object> {
                     var gameObjDefNode = (GameObjectDefinitionNode) creationAstNode;
                     for (var node : gameObjDefNode.getComponentDefinitionNodes()) {
                         // add new component prototype to the enclosing game object prototype
-                        AggregateValueDefinitionNode compDefNode = (AggregateValueDefinitionNode) node;
+                        AggregateValueDefinitionNode compDefNode =
+                                (AggregateValueDefinitionNode) node;
                         var componentPrototype = createComponentPrototype(compDefNode);
                         prototype.addDefaultValue(compDefNode.getIdName(), componentPrototype);
                     }

--- a/dsl/src/interpreter/DSLInterpreter.java
+++ b/dsl/src/interpreter/DSLInterpreter.java
@@ -81,7 +81,7 @@ public class DSLInterpreter implements AstVisitor<Object> {
                     var gameObjDefNode = (GameObjectDefinitionNode) creationAstNode;
                     for (var node : gameObjDefNode.getComponentDefinitionNodes()) {
                         // add new component prototype to the enclosing game object prototype
-                        ComponentDefinitionNode compDefNode = (ComponentDefinitionNode) node;
+                        AggregateValueDefinitionNode compDefNode = (AggregateValueDefinitionNode) node;
                         var componentPrototype = createComponentPrototype(compDefNode);
                         prototype.addDefaultValue(compDefNode.getIdName(), componentPrototype);
                     }
@@ -91,7 +91,7 @@ public class DSLInterpreter implements AstVisitor<Object> {
         }
     }
 
-    private Prototype createComponentPrototype(ComponentDefinitionNode node) {
+    private Prototype createComponentPrototype(AggregateValueDefinitionNode node) {
         var componentSymbol = this.symbolTable().getSymbolsForAstNode(node).get(0);
         assert componentSymbol.getDataType() instanceof AggregateType;
 

--- a/dsl/src/parser/AST/AggregateValueDefinitionNode.java
+++ b/dsl/src/parser/AST/AggregateValueDefinitionNode.java
@@ -3,7 +3,7 @@ package parser.AST;
 import java.util.ArrayList;
 import java.util.List;
 
-public class ComponentDefinitionNode extends Node {
+public class AggregateValueDefinitionNode extends Node {
 
     public final int idIdx = 0;
     public final int propertyDefinitionListIdx = 1;
@@ -44,7 +44,7 @@ public class ComponentDefinitionNode extends Node {
      * @param propertyDefinitionList node representing the property definition list of the component
      *     definition
      */
-    public ComponentDefinitionNode(Node idNode, Node propertyDefinitionList) {
+    public AggregateValueDefinitionNode(Node idNode, Node propertyDefinitionList) {
         super(Type.AggregateValueDefinition, new ArrayList<>(2));
         this.children.add(idNode);
         this.children.add(propertyDefinitionList);

--- a/dsl/src/parser/AST/AggregateValueDefinitionNode.java
+++ b/dsl/src/parser/AST/AggregateValueDefinitionNode.java
@@ -45,7 +45,7 @@ public class ComponentDefinitionNode extends Node {
      *     definition
      */
     public ComponentDefinitionNode(Node idNode, Node propertyDefinitionList) {
-        super(Type.ComponentDefinition, new ArrayList<>(2));
+        super(Type.AggregateValueDefinition, new ArrayList<>(2));
         this.children.add(idNode);
         this.children.add(propertyDefinitionList);
     }

--- a/dsl/src/parser/AST/AstVisitor.java
+++ b/dsl/src/parser/AST/AstVisitor.java
@@ -141,7 +141,7 @@ public interface AstVisitor<T> {
      * @param node Node to visit
      * @return T
      */
-    default T visit(ComponentDefinitionNode node) {
+    default T visit(AggregateValueDefinitionNode node) {
         return null;
     }
 

--- a/dsl/src/parser/AST/Node.java
+++ b/dsl/src/parser/AST/Node.java
@@ -22,7 +22,7 @@ public class Node {
         PropertyDefinition,
         GameObjectDefinition,
         ComponentDefinitionList,
-        ComponentDefinition,
+        AggregateValueDefinition,
         DotDefinition,
         DotStmtList,
         DotStmt,

--- a/dsl/src/parser/DungeonASTConverter.java
+++ b/dsl/src/parser/DungeonASTConverter.java
@@ -105,7 +105,7 @@ public class DungeonASTConverter implements antlr.main.DungeonDSLListener {
         if (ctx.component_def_list() == null) {
             // trivial component definition list
             var innerComponentList = astStack.pop();
-            assert (innerComponentList.type == Node.Type.ComponentDefinition);
+            assert (innerComponentList.type == Node.Type.AggregateValueDefinition);
 
             var list = new ArrayList<Node>(1);
             list.add(innerComponentList);
@@ -118,7 +118,7 @@ public class DungeonASTConverter implements antlr.main.DungeonDSLListener {
             assert (rhsList.type == Node.Type.ComponentDefinitionList);
 
             var leftComponentDef = astStack.pop();
-            assert (leftComponentDef.type == Node.Type.ComponentDefinition);
+            assert (leftComponentDef.type == Node.Type.AggregateValueDefinition);
 
             var childList = new ArrayList<Node>(rhsList.getChildren().size() + 1);
             childList.add(leftComponentDef);
@@ -145,7 +145,7 @@ public class DungeonASTConverter implements antlr.main.DungeonDSLListener {
         var idNode = astStack.pop();
         assert idNode.type == Node.Type.Identifier;
 
-        var componentDefinitionNode = new ComponentDefinitionNode(idNode, propertyDefListNode);
+        var componentDefinitionNode = new AggregateValueDefinitionNode(idNode, propertyDefListNode);
         astStack.push(componentDefinitionNode);
     }
 

--- a/dsl/src/parser/DungeonASTConverter.java
+++ b/dsl/src/parser/DungeonASTConverter.java
@@ -130,10 +130,10 @@ public class DungeonASTConverter implements antlr.main.DungeonDSLListener {
     }
 
     @Override
-    public void enterComponent_def(DungeonDSLParser.Component_defContext ctx) {}
+    public void enterAggregate_value_def(DungeonDSLParser.Aggregate_value_defContext ctx) {}
 
     @Override
-    public void exitComponent_def(DungeonDSLParser.Component_defContext ctx) {
+    public void exitAggregate_value_def(DungeonDSLParser.Aggregate_value_defContext ctx) {
         // if we have a propertyDefList, it will be on the stack
         var propertyDefListNode = Node.NONE;
         if (ctx.property_def_list() != null) {

--- a/dsl/src/semanticAnalysis/SymbolTableParser.java
+++ b/dsl/src/semanticAnalysis/SymbolTableParser.java
@@ -252,7 +252,7 @@ public class SymbolTableParser implements AstVisitor<Void> {
 
     // TODO: Symbols for members?
     @Override
-    public Void visit(ComponentDefinitionNode node) {
+    public Void visit(AggregateValueDefinitionNode node) {
         // push datatype of component
         // resolve in current scope, which will be datatype of game object definition
         var memberSymbol = currentScope().resolve(node.getIdName());

--- a/dsl/src/semanticAnalysis/types/TypeBinder.java
+++ b/dsl/src/semanticAnalysis/types/TypeBinder.java
@@ -1,7 +1,7 @@
 package semanticAnalysis.types;
 
 import parser.AST.AstVisitor;
-import parser.AST.ComponentDefinitionNode;
+import parser.AST.AggregateValueDefinitionNode;
 import parser.AST.GameObjectDefinitionNode;
 import parser.AST.Node;
 import runtime.IEvironment;
@@ -52,8 +52,8 @@ public class TypeBinder implements AstVisitor<Object> {
 
         // visit all component definitions and get type and create new symbol in gameObject type
         for (var componentDef : node.getComponentDefinitionNodes()) {
-            assert componentDef.type == Node.Type.ComponentDefinition;
-            var compDefNode = (ComponentDefinitionNode) componentDef;
+            assert componentDef.type == Node.Type.AggregateValueDefinition;
+            var compDefNode = (AggregateValueDefinitionNode) componentDef;
 
             var componentType = componentDef.accept(this);
             if (componentType != null) {
@@ -69,7 +69,7 @@ public class TypeBinder implements AstVisitor<Object> {
     }
 
     @Override
-    public Object visit(ComponentDefinitionNode node) {
+    public Object visit(AggregateValueDefinitionNode node) {
         // resolve components name in global scope
         var componentName = node.getIdName();
         var typeSymbol = resolveGlobal(componentName);

--- a/dsl/src/semanticAnalysis/types/TypeBinder.java
+++ b/dsl/src/semanticAnalysis/types/TypeBinder.java
@@ -1,7 +1,7 @@
 package semanticAnalysis.types;
 
-import parser.AST.AstVisitor;
 import parser.AST.AggregateValueDefinitionNode;
+import parser.AST.AstVisitor;
 import parser.AST.GameObjectDefinitionNode;
 import parser.AST.Node;
 import runtime.IEvironment;

--- a/dsl/test/interpreter/mockECS/ExternalTypeBuilderMultiParam.java
+++ b/dsl/test/interpreter/mockECS/ExternalTypeBuilderMultiParam.java
@@ -1,0 +1,10 @@
+package interpreter.mockECS;
+
+import semanticAnalysis.types.DSLTypeAdapter;
+
+public class ExternalTypeBuilderMultiParam {
+    @DSLTypeAdapter(t = ExternalType.class)
+    public static ExternalType buildExternalType(int n, String str) {
+        return new ExternalType(n, 12, str);
+    }
+}

--- a/dsl/test/parser/TestDungeonASTConverter.java
+++ b/dsl/test/parser/TestDungeonASTConverter.java
@@ -1,7 +1,6 @@
 package parser;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 
 import helpers.Helpers;
 import org.junit.Test;
@@ -264,7 +263,8 @@ public class TestDungeonASTConverter {
         componentName = ((AggregateValueDefinitionNode) component).getIdName();
         assertEquals("complex_component2", componentName);
 
-        propertyDefinitions = ((AggregateValueDefinitionNode) component).getPropertyDefinitionNodes();
+        propertyDefinitions =
+                ((AggregateValueDefinitionNode) component).getPropertyDefinitionNodes();
         assertEquals(2, propertyDefinitions.size());
 
         firstPropertyDefNode = (PropertyDefNode) propertyDefinitions.get(0);
@@ -290,9 +290,10 @@ public class TestDungeonASTConverter {
             """;
 
         var ast = Helpers.getASTFromString(program);
-        var gameObjectDef = (GameObjectDefinitionNode)ast.getChild(0);
-        var componentDef = (AggregateValueDefinitionNode)gameObjectDef.getComponentDefinitionNodes().get(0);
-        var propertyDef = (PropertyDefNode)componentDef.getPropertyDefinitionNodes().get(0);
+        var gameObjectDef = (GameObjectDefinitionNode) ast.getChild(0);
+        var componentDef =
+                (AggregateValueDefinitionNode) gameObjectDef.getComponentDefinitionNodes().get(0);
+        var propertyDef = (PropertyDefNode) componentDef.getPropertyDefinitionNodes().get(0);
         var stmtNode = propertyDef.getStmtNode();
         assertEquals(stmtNode.type, Node.Type.AggregateValueDefinition);
     }

--- a/dsl/test/parser/TestDungeonASTConverter.java
+++ b/dsl/test/parser/TestDungeonASTConverter.java
@@ -166,13 +166,13 @@ public class TestDungeonASTConverter {
         assertEquals(1, componentDefinitions.size());
 
         var component = componentDefinitions.get(0);
-        assertEquals(Node.Type.ComponentDefinition, component.type);
+        assertEquals(Node.Type.AggregateValueDefinition, component.type);
 
-        String componentName = ((ComponentDefinitionNode) component).getIdName();
+        String componentName = ((AggregateValueDefinitionNode) component).getIdName();
         assertEquals("this_is_a_component", componentName);
 
         var propertyDefinitionListNode =
-                ((ComponentDefinitionNode) component).getPropertyDefinitionListNode();
+                ((AggregateValueDefinitionNode) component).getPropertyDefinitionListNode();
         assertEquals(Node.NONE, propertyDefinitionListNode);
     }
 
@@ -203,13 +203,13 @@ public class TestDungeonASTConverter {
         assertEquals(1, componentDefinitions.size());
 
         var component = componentDefinitions.get(0);
-        assertEquals(Node.Type.ComponentDefinition, component.type);
+        assertEquals(Node.Type.AggregateValueDefinition, component.type);
 
-        String componentName = ((ComponentDefinitionNode) component).getIdName();
+        String componentName = ((AggregateValueDefinitionNode) component).getIdName();
         assertEquals("complex_component", componentName);
 
         var propertyDefinitions =
-                ((ComponentDefinitionNode) component).getPropertyDefinitionNodes();
+                ((AggregateValueDefinitionNode) component).getPropertyDefinitionNodes();
         assertEquals(2, propertyDefinitions.size());
 
         var firstPropertyDefNode = (PropertyDefNode) propertyDefinitions.get(0);
@@ -245,11 +245,11 @@ public class TestDungeonASTConverter {
 
         // test first component
         var component = componentDefinitions.get(0);
-        String componentName = ((ComponentDefinitionNode) component).getIdName();
+        String componentName = ((AggregateValueDefinitionNode) component).getIdName();
         assertEquals("complex_component1", componentName);
 
         var propertyDefinitions =
-                ((ComponentDefinitionNode) component).getPropertyDefinitionNodes();
+                ((AggregateValueDefinitionNode) component).getPropertyDefinitionNodes();
         assertEquals(2, propertyDefinitions.size());
 
         var firstPropertyDefNode = (PropertyDefNode) propertyDefinitions.get(0);
@@ -260,10 +260,10 @@ public class TestDungeonASTConverter {
 
         // test second component
         component = componentDefinitions.get(1);
-        componentName = ((ComponentDefinitionNode) component).getIdName();
+        componentName = ((AggregateValueDefinitionNode) component).getIdName();
         assertEquals("complex_component2", componentName);
 
-        propertyDefinitions = ((ComponentDefinitionNode) component).getPropertyDefinitionNodes();
+        propertyDefinitions = ((AggregateValueDefinitionNode) component).getPropertyDefinitionNodes();
         assertEquals(2, propertyDefinitions.size());
 
         firstPropertyDefNode = (PropertyDefNode) propertyDefinitions.get(0);

--- a/dsl/test/parser/TestDungeonASTConverter.java
+++ b/dsl/test/parser/TestDungeonASTConverter.java
@@ -1,6 +1,7 @@
 package parser;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 import helpers.Helpers;
 import org.junit.Test;
@@ -271,5 +272,28 @@ public class TestDungeonASTConverter {
 
         secondPropertyDefNode = (PropertyDefNode) propertyDefinitions.get(1);
         assertEquals("prop4", secondPropertyDefNode.getIdName());
+    }
+
+    @Test
+    public void adaptedAggregateType() {
+        String program =
+                """
+            game_object my_obj {
+                test_component_with_external_type {
+                    member_external_type: external_type { str: "Hello, World!", n: 42 }
+                }
+            }
+
+            quest_config config {
+                entity: my_obj
+            }
+            """;
+
+        var ast = Helpers.getASTFromString(program);
+        var gameObjectDef = (GameObjectDefinitionNode)ast.getChild(0);
+        var componentDef = (AggregateValueDefinitionNode)gameObjectDef.getComponentDefinitionNodes().get(0);
+        var propertyDef = (PropertyDefNode)componentDef.getPropertyDefinitionNodes().get(0);
+        var stmtNode = propertyDef.getStmtNode();
+        assertEquals(stmtNode.type, Node.Type.AggregateValueDefinition);
     }
 }


### PR DESCRIPTION
Fixes #248

`ComponentDefinitionNode` wurde zu `AggregateValueDefinitionNode` umbenannt, da dieser AST-Knoten nicht mehr nur zur Komponenten-Definition in `GameObjectDefinitionNodes` verwendet wird.