### PR TITLE
[GAME] use .class for Component identification

### DIFF
--- a/game/src/ecs/components/AnimationComponent.java
+++ b/game/src/ecs/components/AnimationComponent.java
@@ -14,7 +14,6 @@ import semanticAnalysis.types.DSLTypeMember;
 @DSLType(name = "animation_component")
 public class AnimationComponent extends Component {
     private static List<String> missingTexture = List.of("animation/missingTexture.png");
-    public static String name = "AnimationComponent";
     private @DSLTypeMember(name = "idle_left") Animation idleLeft;
     private @DSLTypeMember(name = "idle_right") Animation idleRight;
     private @DSLTypeMember(name = "current_animation") Animation currentAnimation;
@@ -25,7 +24,7 @@ public class AnimationComponent extends Component {
      * @param idleRight Idleanimation faced right
      */
     public AnimationComponent(Entity entity, Animation idleLeft, Animation idleRight) {
-        super(entity, name);
+        super(entity, AnimationComponent.class);
         this.idleRight = idleRight;
         this.idleLeft = idleLeft;
         this.currentAnimation = idleLeft;
@@ -43,7 +42,7 @@ public class AnimationComponent extends Component {
      * @param entity associated entity
      */
     public AnimationComponent(@DSLContextMember(name = "entity") Entity entity) {
-        super(entity, name);
+        super(entity, AnimationComponent.class);
         this.idleLeft = new Animation(missingTexture, 100);
         this.idleRight = new Animation(missingTexture, 100);
         this.currentAnimation = new Animation(missingTexture, 100);

--- a/game/src/ecs/components/AnimationComponent.java
+++ b/game/src/ecs/components/AnimationComponent.java
@@ -24,7 +24,7 @@ public class AnimationComponent extends Component {
      * @param idleRight Idleanimation faced right
      */
     public AnimationComponent(Entity entity, Animation idleLeft, Animation idleRight) {
-        super(entity, AnimationComponent.class);
+        super(entity);
         this.idleRight = idleRight;
         this.idleLeft = idleLeft;
         this.currentAnimation = idleLeft;
@@ -42,7 +42,7 @@ public class AnimationComponent extends Component {
      * @param entity associated entity
      */
     public AnimationComponent(@DSLContextMember(name = "entity") Entity entity) {
-        super(entity, AnimationComponent.class);
+        super(entity);
         this.idleLeft = new Animation(missingTexture, 100);
         this.idleRight = new Animation(missingTexture, 100);
         this.currentAnimation = new Animation(missingTexture, 100);

--- a/game/src/ecs/components/Component.java
+++ b/game/src/ecs/components/Component.java
@@ -16,11 +16,11 @@ public abstract class Component {
      * Create a new component and add it to the associated entity
      *
      * @param entity associated entity
-     * @param name Name of the Component
+     * @param klaas Class of the Component
      */
-    public Component(Entity entity, String name) {
+    public Component(Entity entity, Class klaas) {
         this.entity = entity;
-        entity.addComponent(name, this);
+        entity.addComponent(klaas, this);
     }
 
     /**

--- a/game/src/ecs/components/Component.java
+++ b/game/src/ecs/components/Component.java
@@ -16,11 +16,10 @@ public abstract class Component {
      * Create a new component and add it to the associated entity
      *
      * @param entity associated entity
-     * @param klaas Class of the Component
      */
-    public Component(Entity entity, Class klaas) {
+    public Component(Entity entity) {
         this.entity = entity;
-        entity.addComponent(klaas, this);
+        entity.addComponent(this);
     }
 
     /**

--- a/game/src/ecs/components/HitboxComponent.java
+++ b/game/src/ecs/components/HitboxComponent.java
@@ -10,13 +10,12 @@ import tools.Point;
 
 @DSLType(name = "hitbox_component")
 public class HitboxComponent extends Component {
-    public static final String name = "HitboxComponent";
     private /*@DSLTypeMember(name="offset")*/ Point offset;
     private /*@DSLTypeMember(name="size")*/ Point size;
     private Method method;
 
     public HitboxComponent(Entity entity, Point offset, Point size, Method method) {
-        super(entity, name);
+        super(entity, HitboxComponent.class);
         this.offset = offset;
         this.size = size;
         this.method = method;
@@ -33,7 +32,7 @@ public class HitboxComponent extends Component {
     }
 
     public HitboxComponent(@DSLContextMember(name = "entity") Entity entity) {
-        super(entity, name);
+        super(entity, HitboxComponent.class);
         offset = new Point(0.25f, 0.25f);
         size = new Point(0.5f, 0.5f);
         try {
@@ -56,7 +55,7 @@ public class HitboxComponent extends Component {
         PositionComponent pc =
                 (PositionComponent)
                         getEntity()
-                                .getComponent(PositionComponent.name)
+                                .getComponent(PositionComponent.class)
                                 .orElseThrow(
                                         () -> new MissingComponentException("PositionComponent"));
         return new Point(pc.getPosition().x + offset.x, pc.getPosition().y + offset.y);
@@ -66,7 +65,7 @@ public class HitboxComponent extends Component {
         PositionComponent pc =
                 (PositionComponent)
                         getEntity()
-                                .getComponent(PositionComponent.name)
+                                .getComponent(PositionComponent.class)
                                 .orElseThrow(
                                         () -> new MissingComponentException("PositionComponent"));
         return new Point(
@@ -77,7 +76,7 @@ public class HitboxComponent extends Component {
         PositionComponent pc =
                 (PositionComponent)
                         getEntity()
-                                .getComponent(PositionComponent.name)
+                                .getComponent(PositionComponent.class)
                                 .orElseThrow(
                                         () -> new MissingComponentException("PositionComponent"));
         return new Point(

--- a/game/src/ecs/components/HitboxComponent.java
+++ b/game/src/ecs/components/HitboxComponent.java
@@ -15,7 +15,7 @@ public class HitboxComponent extends Component {
     private Method method;
 
     public HitboxComponent(Entity entity, Point offset, Point size, Method method) {
-        super(entity, HitboxComponent.class);
+        super(entity);
         this.offset = offset;
         this.size = size;
         this.method = method;
@@ -32,7 +32,7 @@ public class HitboxComponent extends Component {
     }
 
     public HitboxComponent(@DSLContextMember(name = "entity") Entity entity) {
-        super(entity, HitboxComponent.class);
+        super(entity);
         offset = new Point(0.25f, 0.25f);
         size = new Point(0.5f, 0.5f);
         try {

--- a/game/src/ecs/components/PlayableComponent.java
+++ b/game/src/ecs/components/PlayableComponent.java
@@ -5,12 +5,11 @@ import ecs.entities.Entity;
 /** Marks an entity as player */
 public class PlayableComponent extends Component {
 
-    public static String name = "PlayableComponent";
     private boolean playable;
 
     /** {@inheritDoc} */
     public PlayableComponent(Entity entity) {
-        super(entity, name);
+        super(entity, PlayableComponent.class);
         playable = true;
     }
 

--- a/game/src/ecs/components/PlayableComponent.java
+++ b/game/src/ecs/components/PlayableComponent.java
@@ -9,7 +9,7 @@ public class PlayableComponent extends Component {
 
     /** {@inheritDoc} */
     public PlayableComponent(Entity entity) {
-        super(entity, PlayableComponent.class);
+        super(entity);
         playable = true;
     }
 

--- a/game/src/ecs/components/PositionComponent.java
+++ b/game/src/ecs/components/PositionComponent.java
@@ -18,7 +18,7 @@ public class PositionComponent extends Component {
      * @param point position of the entity
      */
     public PositionComponent(@DSLContextMember(name = "entity") Entity entity, Point point) {
-        super(entity, PositionComponent.class);
+        super(entity);
         this.position = point;
     }
 
@@ -26,7 +26,7 @@ public class PositionComponent extends Component {
      * @param entity associated entity
      */
     public PositionComponent(@DSLContextMember(name = "entity") Entity entity) {
-        super(entity, PositionComponent.class);
+        super(entity);
         this.position =
                 ECS.currentLevel.getRandomTile(LevelElement.FLOOR).getCoordinate().toPoint();
     }

--- a/game/src/ecs/components/PositionComponent.java
+++ b/game/src/ecs/components/PositionComponent.java
@@ -11,8 +11,6 @@ import tools.Point;
 @DSLType(name = "position_component")
 public class PositionComponent extends Component {
 
-    public static String name = "PositionComponent";
-
     private /*@DSLTypeMember(name="position")*/ Point position;
 
     /**
@@ -20,7 +18,7 @@ public class PositionComponent extends Component {
      * @param point position of the entity
      */
     public PositionComponent(@DSLContextMember(name = "entity") Entity entity, Point point) {
-        super(entity, name);
+        super(entity, PositionComponent.class);
         this.position = point;
     }
 
@@ -28,7 +26,7 @@ public class PositionComponent extends Component {
      * @param entity associated entity
      */
     public PositionComponent(@DSLContextMember(name = "entity") Entity entity) {
-        super(entity, name);
+        super(entity, PositionComponent.class);
         this.position =
                 ECS.currentLevel.getRandomTile(LevelElement.FLOOR).getCoordinate().toPoint();
     }

--- a/game/src/ecs/components/VelocityComponent.java
+++ b/game/src/ecs/components/VelocityComponent.java
@@ -11,7 +11,6 @@ import semanticAnalysis.types.DSLTypeMember;
 @DSLType(name = "velocity_component")
 public class VelocityComponent extends Component {
     private static List<String> missingTexture = List.of("animation/missingTexture.png");
-    public static String name = "VelocityComponent";
     private float currentXVelocity;
     private float currentYVelocity;
     private @DSLTypeMember(name = "x_velocity") float xVelocity;
@@ -33,7 +32,7 @@ public class VelocityComponent extends Component {
             float yVelocity,
             Animation moveLeftAnimation,
             Animation moveRightAnimation) {
-        super(entity, name);
+        super(entity, VelocityComponent.class);
         this.currentXVelocity = 0;
         this.currentYVelocity = 0;
         this.xVelocity = xVelocity;
@@ -46,7 +45,7 @@ public class VelocityComponent extends Component {
      * @param entity associated entity
      */
     public VelocityComponent(@DSLContextMember(name = "entity") Entity entity) {
-        super(entity, name);
+        super(entity, VelocityComponent.class);
         this.currentXVelocity = 0;
         this.currentYVelocity = 0;
         this.xVelocity = 0;

--- a/game/src/ecs/components/VelocityComponent.java
+++ b/game/src/ecs/components/VelocityComponent.java
@@ -32,7 +32,7 @@ public class VelocityComponent extends Component {
             float yVelocity,
             Animation moveLeftAnimation,
             Animation moveRightAnimation) {
-        super(entity, VelocityComponent.class);
+        super(entity);
         this.currentXVelocity = 0;
         this.currentYVelocity = 0;
         this.xVelocity = xVelocity;
@@ -45,7 +45,7 @@ public class VelocityComponent extends Component {
      * @param entity associated entity
      */
     public VelocityComponent(@DSLContextMember(name = "entity") Entity entity) {
-        super(entity, VelocityComponent.class);
+        super(entity);
         this.currentXVelocity = 0;
         this.currentYVelocity = 0;
         this.xVelocity = 0;

--- a/game/src/ecs/components/ai/AIComponent.java
+++ b/game/src/ecs/components/ai/AIComponent.java
@@ -27,7 +27,7 @@ public class AIComponent extends Component {
      * @param transition Determines when to fight
      */
     public AIComponent(Entity entity, IFightAI fightAI, IIdleAI idleAI, ITransition transition) {
-        super(entity, name);
+        super(entity, AIComponent.class);
         this.fightAI = fightAI;
         this.idleAI = idleAI;
         this.transitionAI = transition;
@@ -37,7 +37,7 @@ public class AIComponent extends Component {
      * @param entity associated entity
      */
     public AIComponent(@DSLContextMember(name = "entity") Entity entity) {
-        super(entity, name);
+        super(entity, AIComponent.class);
         idleAI = new RadiusWalk(5, 2);
         transitionAI = new RangeTransition(5f);
         fightAI = new CollideAI(2f);

--- a/game/src/ecs/components/ai/AIComponent.java
+++ b/game/src/ecs/components/ai/AIComponent.java
@@ -27,7 +27,7 @@ public class AIComponent extends Component {
      * @param transition Determines when to fight
      */
     public AIComponent(Entity entity, IFightAI fightAI, IIdleAI idleAI, ITransition transition) {
-        super(entity, AIComponent.class);
+        super(entity);
         this.fightAI = fightAI;
         this.idleAI = idleAI;
         this.transitionAI = transition;
@@ -37,7 +37,7 @@ public class AIComponent extends Component {
      * @param entity associated entity
      */
     public AIComponent(@DSLContextMember(name = "entity") Entity entity) {
-        super(entity, AIComponent.class);
+        super(entity);
         idleAI = new RadiusWalk(5, 2);
         transitionAI = new RangeTransition(5f);
         fightAI = new CollideAI(2f);

--- a/game/src/ecs/components/ai/AITools.java
+++ b/game/src/ecs/components/ai/AITools.java
@@ -32,12 +32,12 @@ public class AITools {
         }
         PositionComponent pc =
                 (PositionComponent)
-                        entity.getComponent(PositionComponent.name)
+                        entity.getComponent(PositionComponent.class)
                                 .orElseThrow(
                                         () -> new MissingComponentException("PositionComponent"));
         VelocityComponent vc =
                 (VelocityComponent)
-                        entity.getComponent(VelocityComponent.name)
+                        entity.getComponent(VelocityComponent.class)
                                 .orElseThrow(
                                         () -> new MissingComponentException("VelocityComponent"));
         ILevel level = ECS.currentLevel;
@@ -142,7 +142,7 @@ public class AITools {
     public static GraphPath<Tile> calculatePathToRandomTileInRange(Entity entity, float radius) {
         Point point =
                 ((PositionComponent)
-                                entity.getComponent(PositionComponent.name)
+                                entity.getComponent(PositionComponent.class)
                                         .orElseThrow(
                                                 () ->
                                                         new MissingComponentException(
@@ -161,12 +161,12 @@ public class AITools {
     public static GraphPath<Tile> calculatePath(Entity from, Entity to) {
         PositionComponent fromPositionComponent =
                 (PositionComponent)
-                        from.getComponent(PositionComponent.name)
+                        from.getComponent(PositionComponent.class)
                                 .orElseThrow(
                                         () -> new MissingComponentException("PositionComponent"));
         PositionComponent positionComponent =
                 (PositionComponent)
-                        to.getComponent(PositionComponent.name)
+                        to.getComponent(PositionComponent.class)
                                 .orElseThrow(
                                         () -> new MissingComponentException("PositionComponent"));
         return calculatePath(fromPositionComponent.getPosition(), positionComponent.getPosition());
@@ -203,7 +203,7 @@ public class AITools {
 
         Point entity1Position =
                 ((PositionComponent)
-                                entity1.getComponent(PositionComponent.name)
+                                entity1.getComponent(PositionComponent.class)
                                         .orElseThrow(
                                                 () ->
                                                         new MissingComponentException(
@@ -211,7 +211,7 @@ public class AITools {
                         .getPosition();
         Point entity2Position =
                 ((PositionComponent)
-                                entity2.getComponent(PositionComponent.name)
+                                entity2.getComponent(PositionComponent.class)
                                         .orElseThrow(
                                                 () ->
                                                         new MissingComponentException(
@@ -240,7 +240,7 @@ public class AITools {
     public static boolean pathFinished(Entity entity, GraphPath<Tile> path) {
         PositionComponent pc =
                 (PositionComponent)
-                        entity.getComponent(PositionComponent.name)
+                        entity.getComponent(PositionComponent.class)
                                 .orElseThrow(
                                         () -> new MissingComponentException("PositionComponent"));
         ;

--- a/game/src/ecs/components/skill/SkillComponent.java
+++ b/game/src/ecs/components/skill/SkillComponent.java
@@ -15,7 +15,7 @@ public class SkillComponent extends Component {
      * @param entity associated entity
      */
     public SkillComponent(Entity entity) {
-        super(entity, name);
+        super(entity, SkillComponent.class);
         skillSet = new HashSet<>();
     }
 

--- a/game/src/ecs/components/skill/SkillComponent.java
+++ b/game/src/ecs/components/skill/SkillComponent.java
@@ -15,7 +15,7 @@ public class SkillComponent extends Component {
      * @param entity associated entity
      */
     public SkillComponent(Entity entity) {
-        super(entity, SkillComponent.class);
+        super(entity);
         skillSet = new HashSet<>();
     }
 

--- a/game/src/ecs/entities/Entity.java
+++ b/game/src/ecs/entities/Entity.java
@@ -13,7 +13,7 @@ import semanticAnalysis.types.DSLType;
 public class Entity {
     private static int nextId = 0;
     public final int id = nextId++;
-    private HashMap<String, Component> components;
+    private HashMap<Class, Component> components;
 
     public Entity() {
         components = new HashMap<>();
@@ -23,24 +23,29 @@ public class Entity {
     /**
      * Add a new component to this entity
      *
-     * @param name Name of the component
+     * @param klass Class of the component
      * @param component The component
      */
-    public void addComponent(String name, Component component) {
-        components.put(name, component);
+    public void addComponent(Class klass, Component component) {
+        components.put(klass, component);
     }
 
-    public void removeComponent(String name) {
-        components.remove(name);
+    /**
+     * Remove a component from this entity
+     *
+     * @param klass Class of the component
+     */
+    public void removeComponent(Class klass) {
+        components.remove(klass);
     }
 
     /**
      * Get the component
      *
-     * @param name Name of the component
+     * @param klass Class of the component
      * @return Optional that can contain the requested component
      */
-    public Optional<Component> getComponent(String name) {
-        return Optional.ofNullable(components.get(name));
+    public Optional<Component> getComponent(Class klass) {
+        return Optional.ofNullable(components.get(klass));
     }
 }

--- a/game/src/ecs/entities/Entity.java
+++ b/game/src/ecs/entities/Entity.java
@@ -23,11 +23,10 @@ public class Entity {
     /**
      * Add a new component to this entity
      *
-     * @param klass Class of the component
      * @param component The component
      */
-    public void addComponent(Class klass, Component component) {
-        components.put(klass, component);
+    public void addComponent(Component component) {
+        components.put(component.getClass(), component);
     }
 
     /**

--- a/game/src/ecs/systems/AISystem.java
+++ b/game/src/ecs/systems/AISystem.java
@@ -9,7 +9,7 @@ public class AISystem extends ECS_System {
     @Override
     public void update() {
         for (Entity entity : ECS.entities) {
-            entity.getComponent(AIComponent.name)
+            entity.getComponent(AIComponent.class)
                     .ifPresent(aiComponent -> ((AIComponent) aiComponent).execute());
         }
     }

--- a/game/src/ecs/systems/CollisionSystem.java
+++ b/game/src/ecs/systems/CollisionSystem.java
@@ -12,13 +12,13 @@ public class CollisionSystem extends ECS_System {
     public void update() {
         for (Entity entity : ECS.entities) {
 
-            entity.getComponent(HitboxComponent.name)
+            entity.getComponent(HitboxComponent.class)
                     .ifPresent(
                             hitbox1 -> {
                                 for (Entity entity2 : ECS.entities) {
                                     if (entity != entity2) {
 
-                                        entity2.getComponent(HitboxComponent.name)
+                                        entity2.getComponent(HitboxComponent.class)
                                                 .ifPresent(
                                                         hitbox2 -> {
                                                             if (checkForCollision(

--- a/game/src/ecs/systems/DrawSystem.java
+++ b/game/src/ecs/systems/DrawSystem.java
@@ -29,14 +29,14 @@ public class DrawSystem extends ECS_System {
     /** draw entities at their position */
     public void update() {
         for (Entity entity : ECS.entities) {
-            entity.getComponent(AnimationComponent.name)
+            entity.getComponent(AnimationComponent.class)
                     .ifPresent(
                             ac -> {
                                 final Animation animation =
                                         ((AnimationComponent) ac).getCurrentAnimation();
                                 PositionComponent positionComponent =
                                         (PositionComponent)
-                                                entity.getComponent(PositionComponent.name)
+                                                entity.getComponent(PositionComponent.class)
                                                         .orElseThrow(
                                                                 () ->
                                                                         new MissingComponentException(

--- a/game/src/ecs/systems/KeyboardSystem.java
+++ b/game/src/ecs/systems/KeyboardSystem.java
@@ -14,12 +14,12 @@ public class KeyboardSystem extends ECS_System {
     @Override
     public void update() {
         for (Entity entity : ECS.entities) {
-            entity.getComponent(PlayableComponent.name)
+            entity.getComponent(PlayableComponent.class)
                     .ifPresent(
                             pc -> {
                                 final VelocityComponent velocity =
                                         (VelocityComponent)
-                                                entity.getComponent(VelocityComponent.name)
+                                                entity.getComponent(VelocityComponent.class)
                                                         .orElseThrow(
                                                                 () ->
                                                                         new MissingComponentException(

--- a/game/src/ecs/systems/VelocitySystem.java
+++ b/game/src/ecs/systems/VelocitySystem.java
@@ -16,12 +16,12 @@ public class VelocitySystem extends ECS_System {
     public void update() {
         for (Entity entity : ECS.entities) {
 
-            entity.getComponent(VelocityComponent.name)
+            entity.getComponent(VelocityComponent.class)
                     .ifPresent(
                             vc -> {
                                 final PositionComponent position =
                                         (PositionComponent)
-                                                entity.getComponent(PositionComponent.name)
+                                                entity.getComponent(PositionComponent.class)
                                                         .orElseThrow(
                                                                 () ->
                                                                         new MissingComponentException(
@@ -50,13 +50,13 @@ public class VelocitySystem extends ECS_System {
     private void movementAnimation(Entity entity) {
         AnimationComponent ac =
                 (AnimationComponent)
-                        entity.getComponent(AnimationComponent.name)
+                        entity.getComponent(AnimationComponent.class)
                                 .orElseThrow(
                                         () -> new MissingComponentException("AnimationComponent"));
         Animation newCurrentAnimation;
         VelocityComponent vc =
                 (VelocityComponent)
-                        entity.getComponent(VelocityComponent.name)
+                        entity.getComponent(VelocityComponent.class)
                                 .orElseThrow(
                                         () -> new MissingComponentException("VelocityComponent"));
         float x = vc.getCurrentXVelocity();

--- a/game/src/mydungeon/ECS.java
+++ b/game/src/mydungeon/ECS.java
@@ -39,7 +39,7 @@ public class ECS extends Game {
         hero = new Hero(new Point(0, 0));
         heroPositionComponent =
                 (PositionComponent)
-                        hero.getComponent(PositionComponent.name)
+                        hero.getComponent(PositionComponent.class)
                                 .orElseThrow(
                                         () -> new MissingComponentException("PositionComponent"));
         levelAPI = new LevelAPI(batch, painter, new WallGenerator(new RandomWalkGenerator()), this);

--- a/game/test/ecs/EntityTest.java
+++ b/game/test/ecs/EntityTest.java
@@ -13,13 +13,12 @@ public class EntityTest {
 
     private Entity entity;
     private final Component testComponent = Mockito.mock(Component.class);
-    private final String componentName = "TestComponent";
 
     @Before
     public void setup() {
         ECS.entities.clear();
         entity = new Entity();
-        entity.addComponent(componentName, testComponent);
+        entity.addComponent(testComponent.getClass(), testComponent);
     }
 
     @Test
@@ -29,19 +28,19 @@ public class EntityTest {
 
     @Test
     public void addComponent() {
-        assertEquals(testComponent, entity.getComponent(componentName).get());
+        assertEquals(testComponent, entity.getComponent(testComponent.getClass()).get());
     }
 
     @Test
     public void addAlreadyExistingComponent() {
         Component newComponent = Mockito.mock(Component.class);
-        entity.addComponent(componentName, newComponent);
-        assertEquals(newComponent, entity.getComponent(componentName).get());
+        entity.addComponent(testComponent.getClass(), newComponent);
+        assertEquals(newComponent, entity.getComponent(testComponent.getClass()).get());
     }
 
     @Test
     public void removeComponent() {
-        entity.removeComponent(componentName);
-        assertTrue(entity.getComponent(componentName).isEmpty());
+        entity.removeComponent(testComponent.getClass());
+        assertTrue(entity.getComponent(testComponent.getClass()).isEmpty());
     }
 }

--- a/game/test/ecs/EntityTest.java
+++ b/game/test/ecs/EntityTest.java
@@ -18,7 +18,7 @@ public class EntityTest {
     public void setup() {
         ECS.entities.clear();
         entity = new Entity();
-        entity.addComponent(testComponent.getClass(), testComponent);
+        entity.addComponent(testComponent);
     }
 
     @Test
@@ -34,7 +34,7 @@ public class EntityTest {
     @Test
     public void addAlreadyExistingComponent() {
         Component newComponent = Mockito.mock(Component.class);
-        entity.addComponent(testComponent.getClass(), newComponent);
+        entity.addComponent(newComponent);
         assertEquals(newComponent, entity.getComponent(testComponent.getClass()).get());
     }
 

--- a/game/test/ecs/systems/AISystemTest.java
+++ b/game/test/ecs/systems/AISystemTest.java
@@ -21,7 +21,7 @@ public class AISystemTest {
         ECS.entities.clear();
         system = new AISystem();
         entity = new Entity();
-        entity.addComponent(AIComponent.class, aiComponent);
+        entity.addComponent(aiComponent);
     }
 
     @Test

--- a/game/test/ecs/systems/AISystemTest.java
+++ b/game/test/ecs/systems/AISystemTest.java
@@ -1,8 +1,9 @@
 package ecs.systems;
 
-import static org.mockito.Mockito.times;
+import static org.junit.Assert.assertEquals;
 
 import ecs.components.ai.AIComponent;
+import ecs.components.ai.transition.ITransition;
 import ecs.entities.Entity;
 import mydungeon.ECS;
 import org.junit.Before;
@@ -11,9 +12,9 @@ import org.mockito.Mockito;
 
 public class AISystemTest {
 
+    private int updateCounter;
     private AISystem system;
     private Entity entity;
-    private final AIComponent aiComponent = Mockito.mock(AIComponent.class);
 
     @Before
     public void setup() {
@@ -21,19 +22,28 @@ public class AISystemTest {
         ECS.entities.clear();
         system = new AISystem();
         entity = new Entity();
-        entity.addComponent(aiComponent);
+        AIComponent component = new AIComponent(entity);
+        component.setTransitionAI(
+                new ITransition() {
+                    @Override
+                    public boolean isInFightMode(Entity entity) {
+                        updateCounter++;
+                        return false;
+                    }
+                });
+        updateCounter = 0;
     }
 
     @Test
     public void update() {
         system.update();
-        Mockito.verify(aiComponent, times(1)).execute();
+        assertEquals(1, updateCounter);
     }
 
     @Test
     public void updateWithoutAIComponent() {
         entity.removeComponent(AIComponent.class);
         system.update();
-        Mockito.verify(aiComponent, times(0)).execute();
+        assertEquals(0, updateCounter);
     }
 }

--- a/game/test/ecs/systems/AISystemTest.java
+++ b/game/test/ecs/systems/AISystemTest.java
@@ -21,7 +21,7 @@ public class AISystemTest {
         ECS.entities.clear();
         system = new AISystem();
         entity = new Entity();
-        entity.addComponent(AIComponent.name, aiComponent);
+        entity.addComponent(AIComponent.class, aiComponent);
     }
 
     @Test
@@ -32,7 +32,7 @@ public class AISystemTest {
 
     @Test
     public void updateWithoutAIComponent() {
-        entity.removeComponent(AIComponent.name);
+        entity.removeComponent(AIComponent.class);
         system.update();
         Mockito.verify(aiComponent, times(0)).execute();
     }

--- a/game/test/ecs/systems/DrawSystemTest.java
+++ b/game/test/ecs/systems/DrawSystemTest.java
@@ -27,9 +27,8 @@ public class DrawSystemTest {
         ECS.entities.clear();
         drawSystem = new DrawSystem(painter);
         entity = new Entity();
-        entity.addComponent(AnimationComponent.class, new AnimationComponent(entity, animation));
-        entity.addComponent(
-                PositionComponent.class, new PositionComponent(entity, new Point(3, 3)));
+        new AnimationComponent(entity, animation);
+        new PositionComponent(entity, new Point(3, 3));
     }
 
     @Test

--- a/game/test/ecs/systems/DrawSystemTest.java
+++ b/game/test/ecs/systems/DrawSystemTest.java
@@ -27,8 +27,9 @@ public class DrawSystemTest {
         ECS.entities.clear();
         drawSystem = new DrawSystem(painter);
         entity = new Entity();
-        entity.addComponent(AnimationComponent.name, new AnimationComponent(entity, animation));
-        entity.addComponent(PositionComponent.name, new PositionComponent(entity, new Point(3, 3)));
+        entity.addComponent(AnimationComponent.class, new AnimationComponent(entity, animation));
+        entity.addComponent(
+                PositionComponent.class, new PositionComponent(entity, new Point(3, 3)));
     }
 
     @Test
@@ -41,14 +42,14 @@ public class DrawSystemTest {
 
     @Test
     public void updateWithoutPositionComponent() {
-        entity.removeComponent(PositionComponent.name);
+        entity.removeComponent(PositionComponent.class);
         Mockito.verifyNoMoreInteractions(painter);
         assertThrows(MissingComponentException.class, () -> drawSystem.update());
     }
 
     @Test
     public void updateWithoutAnimationComponent() {
-        entity.removeComponent(AnimationComponent.name);
+        entity.removeComponent(AnimationComponent.class);
         Mockito.verifyNoMoreInteractions(painter);
         drawSystem.update();
     }

--- a/game/test/ecs/systems/VelocitySystemTest.java
+++ b/game/test/ecs/systems/VelocitySystemTest.java
@@ -53,9 +53,9 @@ public class VelocitySystemTest {
                 new PositionComponent(entity, new Point(startXPosition, startYPosition));
         animationComponent = new AnimationComponent(entity, idleLeft, idleRight);
 
-        entity.addComponent(PositionComponent.name, positionComponent);
-        entity.addComponent(VelocityComponent.name, velocityComponent);
-        entity.addComponent(AnimationComponent.name, animationComponent);
+        entity.addComponent(PositionComponent.class, positionComponent);
+        entity.addComponent(VelocityComponent.class, velocityComponent);
+        entity.addComponent(AnimationComponent.class, animationComponent);
     }
 
     @Test
@@ -134,7 +134,7 @@ public class VelocitySystemTest {
 
     @Test
     public void updateWithoutVelocityComponent() {
-        entity.removeComponent(VelocityComponent.name);
+        entity.removeComponent(VelocityComponent.class);
         velocitySystem.update();
         assertEquals(startXPosition, positionComponent.getPosition().x, 0.001f);
         assertEquals(startYPosition, positionComponent.getPosition().y, 0.001f);
@@ -142,14 +142,14 @@ public class VelocitySystemTest {
 
     @Test
     public void updateWithoutPositionComponent() {
-        entity.removeComponent(PositionComponent.name);
+        entity.removeComponent(PositionComponent.class);
         assertThrows(MissingComponentException.class, () -> velocitySystem.update());
     }
 
     @Test
     public void updateWithoutAnimationComponent() {
         Mockito.when(tile.isAccessible()).thenReturn(true);
-        entity.removeComponent(AnimationComponent.name);
+        entity.removeComponent(AnimationComponent.class);
         assertThrows(MissingComponentException.class, () -> velocitySystem.update());
     }
 }

--- a/game/test/ecs/systems/VelocitySystemTest.java
+++ b/game/test/ecs/systems/VelocitySystemTest.java
@@ -52,10 +52,6 @@ public class VelocitySystemTest {
         positionComponent =
                 new PositionComponent(entity, new Point(startXPosition, startYPosition));
         animationComponent = new AnimationComponent(entity, idleLeft, idleRight);
-
-        entity.addComponent(PositionComponent.class, positionComponent);
-        entity.addComponent(VelocityComponent.class, velocityComponent);
-        entity.addComponent(AnimationComponent.class, animationComponent);
     }
 
     @Test


### PR DESCRIPTION
fixes #247  und #243 

- Remove static name in Components
- Benutze `.class` um Components zu identifizieren
- Tests angepasst
