### PR TITLE
[DSL] Instanziierung für AggregateTypeAdapter

### DIFF
--- a/doc/dsl/interpretation_laufzeit.md
+++ b/doc/dsl/interpretation_laufzeit.md
@@ -270,9 +270,9 @@ den Typadapter aufgerufen.
 
 Der Aufruf unterscheidet sich je nach Art der Typadaptierung:
 
-- für die einfache Typadaptierung wird die Builder-Methode mit dem internen Wert der
+- Für die einfache Typadaptierung wird die Builder-Methode mit dem internen Wert der
   `Value`-Instanz aufgerufen.
-- für die komplexe Typadaptierung baut der `TypeInstantiator` vorher die Parameter-Liste für
+- Für die komplexe Typadaptierung baut der `TypeInstantiator` vorher die Parameter-Liste für
   den Aufruf der Builder-Methode zusammen. Hierzu werden die Parameternamen der
   Builder-Methode im Kontext vom `MemorySpace` des `AggregateTypeAdapters` aufgelöst und an
   die entsprechende Stelle der Parameter-Liste eingefügt.

--- a/doc/dsl/interpretation_laufzeit.md
+++ b/doc/dsl/interpretation_laufzeit.md
@@ -266,13 +266,18 @@ die Klassen-Instanz übertragen, falls der Wert explizit per DSL gesetzt wurde (
 Falls der Datentyp eines Klassen-Members [adaptiert](typebuilding.md#typadaptierung) ist,
 wird nicht direkt der interne Wert der `Value`-Instanz in die Klasseninstanz übertragen. Als
 Zwischenschritt wird die [Builder-Methode](typebuilding.md#1-nur-ein-parameter-nötig) für
-den Typadapter aufgerufen. Das so erstellte Objekt wird in die Klasseninstanz übertragen.
+den Typadapter aufgerufen.
 
-NOTE: Hier scheint in `TypeInstantiator:150` noch was konzeptionell nicht ganz zu stimmen
-(Fix kommt mit [PR #272](https://github.com/Programmiermethoden/Dungeon/pull/272))
+Der Aufruf unterscheidet sich je nach Art der Typadaptierung:
 
-TODO:
-- Instanziierung von AggregateTypeAdapter (kommt mit [PR #272](https://github.com/Programmiermethoden/Dungeon/pull/272))
+- für die einfache Typadaptierung wird die Builder-Methode mit dem internen Wert der
+  `Value`-Instanz aufgerufen.
+- für die komplexe Typadaptierung baut der `TypeInstantiator` vorher die Parameter-Liste
+  für den Aufruf der Builder-Methode zusammen. Hierzu werden die Parameternamen der
+  Builder-Methode im Kontext vom `MemorySpace` des `AggregateTypeAdapters` aufgelöst und
+  an die entsprechende Stelle der Parameter-Liste eingefügt.
+
+Das so erstellte Objekt wird in die Klasseninstanz übertragen.
 
 **EncapsulatedObject**
 

--- a/doc/dsl/interpretation_laufzeit.md
+++ b/doc/dsl/interpretation_laufzeit.md
@@ -238,12 +238,12 @@ Die Instanziierung von Java-Klassen, welche mit `@DSLType` (siehe
 durchgeführt. Als Beispiel wird wieder die oben angeführte `game_object`-Definition
 herangezogen.
 
-![UML: Instanziierung von Java-Klasse](img/instantiate_java_class.png)
 Der `IMemorySpace` eines `AggregateValue` wird dem `TypeInstantiator` übergeben. Dieser
 erstellt eine Instanz der Java-Klasse, die dem Datentyp des `AggregateValue` zugrunde liegt.
 Im Fall der `velocity_component` `Value`-Instanz ist dies die Java-Klasse
 `VelocityComponent`. Das Sequenzdiagramm hierfür:
 
+![UML: Instanziierung von Java-Klasse](img/instantiate_java_class.png)
 
 Um die Java-Klasse zu instanziieren ruft der `TypeBuilder` den Konstruktor der Klasse per
 Reflection auf. Die Parameter für diesen Konstruktor-Aufruf liest der `TypeBuilder` aus dem
@@ -272,10 +272,10 @@ Der Aufruf unterscheidet sich je nach Art der Typadaptierung:
 
 - für die einfache Typadaptierung wird die Builder-Methode mit dem internen Wert der
   `Value`-Instanz aufgerufen.
-- für die komplexe Typadaptierung baut der `TypeInstantiator` vorher die Parameter-Liste
-  für den Aufruf der Builder-Methode zusammen. Hierzu werden die Parameternamen der
-  Builder-Methode im Kontext vom `MemorySpace` des `AggregateTypeAdapters` aufgelöst und
-  an die entsprechende Stelle der Parameter-Liste eingefügt.
+- für die komplexe Typadaptierung baut der `TypeInstantiator` vorher die Parameter-Liste für
+  den Aufruf der Builder-Methode zusammen. Hierzu werden die Parameternamen der
+  Builder-Methode im Kontext vom `MemorySpace` des `AggregateTypeAdapters` aufgelöst und an
+  die entsprechende Stelle der Parameter-Liste eingefügt.
 
 Das so erstellte Objekt wird in die Klasseninstanz übertragen.
 

--- a/doc/dsl/typebuilding.md
+++ b/doc/dsl/typebuilding.md
@@ -343,6 +343,46 @@ wie im folgenden Sequenzdiagramm zu erkennen:
 
 ![UML: Ablauf komplexe Typadaptierung](img/typeadapting_complex.png)
 
+```java
+// externer Datentyp, der in das DSL-Typsystem gebracht werden soll
+public class ExternalType {
+    int member1;
+    int member2;
+    String member3;
+
+    public ExternalType(int member1, int member2, String member3) {
+        this.member1 = member1;
+        this.member2 = member2;
+        this.member3 = member3;
+    }
+}
+
+// typebuilder für ExternalType
+public class ExternalTypeBuilderMultiParam {
+    @DSLTypeAdapter
+    public static ExternalType buildExternalType(
+            @DSLTypeMember(name = "number") int n,
+            @DSLTypeMember(name = "string") String str) {
+        return new ExternalType(n, 12, str);
+    }
+}
+```
+
+Der externe Datentyp kann in der DSL wie folgt verwendet werden:
+
+```
+game_object my_obj {
+    test_component_with_external_type {
+        member_external_type: external_type {
+            string: "Hello, World!",
+            number: 42
+        }
+    }
+}
+```
+
+**Beziehungen der Adapterklassen zum restlichen Typsystem**
+
 Das folgende UML Diagramm zeigt, in welcher Beziehung die beiden Adapterklassen
 `AdaptedType` und `AggregateTypeAdapter` zum Rest des Typsystems stehen:
 

--- a/doc/dsl/typebuilding.md
+++ b/doc/dsl/typebuilding.md
@@ -240,6 +240,7 @@ public class Component {
 
 Um diese Member, die einen externen Datentyp verwenden, trotzdem über die DSL konfigurierbar zu machen, kann
 ihr Datentyp 'adaptiert' werden.
+
 Hierzu kann eine statische Methode mit `@DSLTypeAdapter` markiert werden. Dabei muss über den `t`-Parameter
 definiert werden, welcher Java-Datentyp über die Methode adaptiert werden soll.
 

--- a/doc/dsl/typebuilding.md
+++ b/doc/dsl/typebuilding.md
@@ -376,6 +376,8 @@ folgenden Sequenzdiagramm zu erkennen:
 
 ![UML: Ablauf komplexe Typadaptierung](img/typeadapting_complex.png)
 
+**Beispiel:**
+
 Für einen Datentyp namens `ExternalType` könnte dies wie folgt aussehen:
 
 ```java

--- a/doc/dsl/typebuilding.md
+++ b/doc/dsl/typebuilding.md
@@ -4,10 +4,15 @@ title: "Typebuilding"
 
 ## Was bedeutet Typebuilding im Kontext der DSL?
 
-Das Dungeon Framework verwendet einen komponentenbasierten Ansatz (vgl. [ECS](./../game/ecs.md)), um Entitäten im
-Level zu definieren. Die DSL ermöglicht das Definieren von Enitäten in textueller Form (vgl. hierfür [Entitätsdefinition](./sprachkonzepte.md#entitätsdefinition)), indem für einen Entitätstypen festgelegt wird, welche Komponenten in ihm enthalten sein sollen. Hierbei können die Member der Komponenten konfiguriert werden.
+Das Dungeon Framework verwendet einen komponentenbasierten Ansatz (vgl.
+[ECS](./../game/ecs.md)), um Entitäten im Level zu definieren. Die DSL ermöglicht das
+Definieren von Enitäten in textueller Form (vgl. hierfür
+[Entitätsdefinition](./sprachkonzepte.md#entitätsdefinition)), indem für einen Entitätstypen
+festgelegt wird, welche Komponenten in ihm enthalten sein sollen. Hierbei können die Member
+der Komponenten konfiguriert werden.
 
-Ein Beispiel für einen Entitätstypen names `my_object`, der ein `PositionComponent` und ein `AnimationComponent` hat, könnte so aussehen:
+Ein Beispiel für einen Entitätstypen names `my_object`, der ein `PositionComponent` und ein
+`AnimationComponent` hat, könnte so aussehen:
 
 ```
 game_object my_object {
@@ -18,16 +23,16 @@ game_object my_object {
 }
 ```
 
-Diese Form der Entitätsdefinition erfordert eine Repräsentation der Komponententypen (welche als
-Java-Klassen im ECS definiert sind) im DSL Typsystem und eine Verbindung des
-DSL Typen mit der Java-Klasse, dessen DSL-Equivalent er ist.
-Das folgende Diagramm stellt dar, wie eine Java-Klasse auf der DSL-Seite als `AggregateType`
-dargestellt wird.
+Diese Form der Entitätsdefinition erfordert eine Repräsentation der Komponententypen (welche
+als Java-Klassen im ECS definiert sind) im DSL Typsystem und eine Verbindung des DSL Typen
+mit der Java-Klasse, dessen DSL-Equivalent er ist. Das folgende Diagramm stellt dar, wie
+eine Java-Klasse auf der DSL-Seite als `AggregateType` dargestellt wird.
 
 ![UML: Java-Klasse und DSL-Datentyp](./img/java_to_dsl_type.png)
 
-Um die DSL Typen, die auf diese Weise benötigt werden, nicht manuell implementieren zu müssen, übernimmt der `TypeBuiler` diese Aufgabe automatisch.
-Hierzu wird ein Annotation-basierter Ansatz verfolgt.
+Um die DSL Typen, die auf diese Weise benötigt werden, nicht manuell implementieren zu
+müssen, übernimmt der `TypeBuiler` diese Aufgabe automatisch. Hierzu wird ein
+Annotation-basierter Ansatz verfolgt.
 
 ## Beispiel(e) aus User-Sicht
 
@@ -47,16 +52,20 @@ public class ComponentClass {
 }
 ```
 
-Aus dieser Klasse kann mit der Methode `TypeBuilder::createTypeFromClass` ein DSL Typ erzeugt werden:
+Aus dieser Klasse kann mit der Methode `TypeBuilder::createTypeFromClass` ein DSL Typ
+erzeugt werden:
 
 ```java
 TypeBuilder tp = new TypeBuilder();
 AggregateType dslType = tp.createTypeFromClass(Scope.NULL, ComponentClass.class);
 ```
 
-Der `dslType` enthält drei Symbole, welche `member1`, `member2` und `member3` representieren, die in `ComponentClass` markiert sind.
-Die Datentypen sind `BuiltInType.intType`, `BuiltInType.stringType` und `BuiltInType.floatType` respektive.
-Der so erzeugte Datentyp kann (nachdem er über ein `IEnvironment` geladen wurde, siehe [Laden von Datentypen](#laden-von-datentypen)) wie folgt in einer Entitätsdefinition verwendet werden:
+Der `dslType` enthält drei Symbole, welche `member1`, `member2` und `member3`
+representieren, die in `ComponentClass` markiert sind. Die Datentypen sind
+`BuiltInType.intType`, `BuiltInType.stringType` und `BuiltInType.floatType` respektive. Der
+so erzeugte Datentyp kann (nachdem er über ein `IEnvironment` geladen wurde, siehe [Laden
+von Datentypen](#laden-von-datentypen)) wie folgt in einer Entitätsdefinition verwendet
+werden:
 
 ```
 game_ojbect my_obj {
@@ -70,7 +79,11 @@ game_ojbect my_obj {
 
 ### Typ- und Membernamen
 
-Standardmäßig konvertiert der `TypeBuilder` die Namen der Java-Klassen in [snake case](https://en.wikipedia.org//wiki/Snake_case), um ein zu den restlichen DSL Keywords konsistentes Namensschema zu verfolgen. Alternativ akzeptieren `DSLType` und `DSLTypeMember` einen `name`-Parameter, der dieses Standardverhalten überschreibt. Für die oben bereits genutzte `ComponentClass` könnte dies entsprechend verwendet werden:
+Standardmäßig konvertiert der `TypeBuilder` die Namen der Java-Klassen in [snake
+case](https://en.wikipedia.org//wiki/Snake_case), um ein zu den restlichen DSL Keywords
+konsistentes Namensschema zu verfolgen. Alternativ akzeptieren `DSLType` und `DSLTypeMember`
+einen `name`-Parameter, der dieses Standardverhalten überschreibt. Für die oben bereits
+genutzte `ComponentClass` könnte dies entsprechend verwendet werden:
 
 ```java
 @DSLType(name="my_component")
@@ -82,7 +95,8 @@ public class ComponentClass {
 }
 ```
 
-Der entsprechende Komponententyp könnte wie folgt in einer Entitätsdefinition verwendet werden:
+Der entsprechende Komponententyp könnte wie folgt in einer Entitätsdefinition verwendet
+werden:
 
 ```
 game_ojbect my_obj {
@@ -96,9 +110,13 @@ game_ojbect my_obj {
 
 ### Laden von Datentypen
 
-Der mit `TypeBuilder::createTypeFromClass` erzeugte Datentyp muss in die [DSL Pipeline](./interpretation_laufzeit.md#überblick-wie-funktioniert-die-interpretation-allgemein) integriert werden.
-Hierzu muss der DSL Typ über ein `IEnvironment` Objekt geladen werden. Die Standard `IEnvironment`-Implementierung ist das `GameEnvironment` ([GameEnvironment.java](./../../dsl/src/runtime/GameEnvironment.java)), welches
-bereits alle BuiltIn-Datentypen und standardmäßig verfügbaren komplexeren Datentypen (Komponenten-Datentypen) enthält.
+Der mit `TypeBuilder::createTypeFromClass` erzeugte Datentyp muss in die [DSL
+Pipeline](./interpretation_laufzeit.md#überblick-wie-funktioniert-die-interpretation-allgemein)
+integriert werden. Hierzu muss der DSL Typ über ein `IEnvironment` Objekt geladen werden.
+Die Standard `IEnvironment`-Implementierung ist das `GameEnvironment`
+([GameEnvironment.java](./../../dsl/src/runtime/GameEnvironment.java)), welches bereits alle
+BuiltIn-Datentypen und standardmäßig verfügbaren komplexeren Datentypen
+(Komponenten-Datentypen) enthält.
 
 ```java
 // DSL Datentyp erzeugen
@@ -134,30 +152,41 @@ var questConfig = interpreter.generateQuestConfig(ast);
 
 ### Einschränkungen
 
-Mit dem oben beschriebenen Mechanismus können DSL Datentypen aus Java-Klassen erstellt werden. Für beide Anwendungsfälle sind folgende Einschränkungen zu beachten:
+Mit dem oben beschriebenen Mechanismus können DSL Datentypen aus Java-Klassen erstellt
+werden. Für beide Anwendungsfälle sind folgende Einschränkungen zu beachten:
 
 **Einschränkungen Java-Klasse**
 
 Eine Java-Klasse, die mit `@DSLType` markiert wird, muss folgende Kriterien erfüllen:
-- sie muss über einen Default-Konstruktor ohne Parameter verfügen
-- falls sie über keinen Default-Konstruktor verfügt, muss sie über einen Konstruktor verfügen, dessen Parameter alle mit `@DSLContextMember` (siehe [Typinstanziierung](interpretation_laufzeit.md#typinstanziierung)) markiert sind
-- die Datentypen aller Member, die mit `@DSLTypeMember` markiert sind, müssen entweder Datentypen sein, die mit `@DSLType` markiert oder adaptiert sind, oder sich auf die `BuiltIn`-Datentypen zurückführen lassen (siehe [Typsystem](typsystem.md))
 
-Falls diese Kriterien nicht erfüllt sind, kann der `TypeInstantiator` keine Instanzen der Klasse anlegen. Für weitere Details siehe [Typinstanziierung](interpreation-laufzeit.md#typinstanziierung).
+- sie muss über einen Default-Konstruktor ohne Parameter verfügen
+- falls sie über keinen Default-Konstruktor verfügt, muss sie über einen Konstruktor
+  verfügen, dessen Parameter alle mit `@DSLContextMember` (siehe
+  [Typinstanziierung](interpretation_laufzeit.md#typinstanziierung)) markiert sind
+- die Datentypen aller Member, die mit `@DSLTypeMember` markiert sind, müssen entweder
+  Datentypen sein, die mit `@DSLType` markiert oder adaptiert sind, oder sich auf die
+  `BuiltIn`-Datentypen zurückführen lassen (siehe [Typsystem](typsystem.md))
+
+Falls diese Kriterien nicht erfüllt sind, kann der `TypeInstantiator` keine Instanzen der
+Klasse anlegen. Für weitere Details siehe
+[Typinstanziierung](interpreation-laufzeit.md#typinstanziierung).
 
 **Einschränkungen Java-Record**
 
 Ein Java-Record, der mit `DSLType` markiert ist, muss folgende Kriterien erfüllen:
+
 - alle Member des Records müssen mit `DSLTypeMember` markiert sein
-- die Datentypen aller Member müssen entweder Datentypen sein, die mit `@DSLType` markiert oder adaptiert sind, oder sich auf die `BuiltIn`-Datentypen zurückführen lassen (siehe [Typsystem](typsystem.md))
+- die Datentypen aller Member müssen entweder Datentypen sein, die mit `@DSLType`
+  markiert oder adaptiert sind, oder sich auf die `BuiltIn`-Datentypen zurückführen
+  lassen (siehe [Typsystem](typsystem.md))
 
 ### Was, wenn eine Klasse nicht ohne Parameter instanziiert werden kann?
 
-Falls es nicht möglich ist, eine Klasse sinnvoll ohne Parameter zu instanziieren,
-kann der Kontext-Mechanismus des `TypeBuilder`s genutzt werden. Dies ist beispielsweise für
-die `Component`-Klassen des ECS der Fall, da diese zwingend eine Referenz auf
-die Entität benötigen, von der die Komponente ein Teil sein soll. Siehe hierzu folgendes
-Beispiel aus dem `PositionComponent`:
+Falls es nicht möglich ist, eine Klasse sinnvoll ohne Parameter zu instanziieren, kann der
+Kontext-Mechanismus des `TypeBuilder`s genutzt werden. Dies ist beispielsweise für die
+`Component`-Klassen des ECS der Fall, da diese zwingend eine Referenz auf die Entität
+benötigen, von der die Komponente ein Teil sein soll. Siehe hierzu folgendes Beispiel aus
+dem `PositionComponent`:
 
 ```java
 public PositionComponent(Entity entity) {
@@ -167,28 +196,29 @@ public PositionComponent(Entity entity) {
 }
 ```
 
-**Wichtige Anmerkung: Die Verwendung des `TypeBuilder`-Kontextes setzt (aktuell) zwingend voraus,
-dass die Instanziierung einem hierarchischen Muster folgt.**
+**Wichtige Anmerkung: Die Verwendung des `TypeBuilder`-Kontextes setzt (aktuell) zwingend
+voraus, dass die Instanziierung einem hierarchischen Muster folgt.**
 
-Ein Beispiel hierfür:
-für eine `game_object`-Definition per DSL wird zuerst die entsprechende `Entity`-Instanz erzeugt, bevor
-die konfigurierten `Component`-Klassen instanziiert werden. Hierarchisch ist die `Entity`-Instanziierung
-also der `Component`-Instanziierung übergeordnet. Nur in diesem Fall kann der im Folgenden beschriebene
-Mechanismus verwendet werden. **Das beschriebene Beispiel ist aktuell der einzige Anwendungsfall, in dem
-der `TypeBuilder`-Kontext verwendet wird.**
+Ein Beispiel hierfür: für eine `game_object`-Definition per DSL wird zuerst die
+entsprechende `Entity`-Instanz erzeugt, bevor die konfigurierten `Component`-Klassen
+instanziiert werden. Hierarchisch ist die `Entity`-Instanziierung also der
+`Component`-Instanziierung übergeordnet. Nur in diesem Fall kann der im Folgenden
+beschriebene Mechanismus verwendet werden. **Das beschriebene Beispiel ist aktuell der
+einzige Anwendungsfall, in dem der `TypeBuilder`-Kontext verwendet wird.**
 
-Auf den Kontext des `TypeBuilder`s kann über die Annotationen `DSLContextPush` und `DSLContextMember`
-zugegriffen werden. Dies ermöglicht, dass der `TypeBuilder` über alle nötigen Informationen
-verfügt, um auch einen Konstruktor mit Parametern aufzurufen (vgl.
+Auf den Kontext des `TypeBuilder`s kann über die Annotationen `DSLContextPush` und
+`DSLContextMember` zugegriffen werden. Dies ermöglicht, dass der `TypeBuilder` über alle
+nötigen Informationen verfügt, um auch einen Konstruktor mit Parametern aufzurufen (vgl.
 hierzu [Einschränkungen Java-Klasse](#einschränkungen)).
 
-Eine mit `DSLType` markierte Klasse (z.B. `Entity`) kann mit `DSLContextPush` markiert werden.
-Hierdurch wird bei der Instanziierung einer `Entity`
-(vgl. [Typinstanziierung](interpretation_laufzeit.md#typinstanziierung)) die erstellte Instanz
-zum Kontext des `TypeBuilder`s hinzugefügt (als "Kontextmember").
-Der Name des hinzugefügten Kontextmembers muss über das `name`-Attribut der
-`DSLContextPush`-Annotation festgelegt werden. Über diesen Namen kann der `TypeBuilder` auf
-die erstellte Instanz zugreifen. Das folgende Beispiel zeigt diese Verwendung in der `Entity`-Klasse:
+
+Eine mit `DSLType` markierte Klasse (z.B. `Entity`) kann mit `DSLContextPush` markiert
+werden. Hierdurch wird bei der Instanziierung einer `Entity` (vgl.
+[Typinstanziierung](interpretation_laufzeit.md#typinstanziierung)) die erstellte Instanz zum
+Kontext des `TypeBuilder`s hinzugefügt (als “Kontextmember”). Der Name des hinzugefügten
+Kontextmembers muss über das `name`-Attribut der `DSLContextPush`-Annotation festgelegt
+werden. Über diesen Namen kann der `TypeBuilder` auf die erstellte Instanz zugreifen. Das
+folgende Beispiel zeigt diese Verwendung in der `Entity`-Klasse:
 
 ```java
 @DSLType(name = "game_object")
@@ -200,11 +230,10 @@ public class Entity {
 ```
 
 Mit der `DSLContextMember` Annotation kann ein Konstruktorparameter markiert werden, den der
-`TypeBuiler` aus dem Kontext lesen soll.
-Hierzu muss der `DSLContextMember` der Name des Kontextmembers an das `name`-Attribut übergeben
-werden.
-Dieser Wert muss dem Wert entsprechen, der auch der `DSLContextPush`-Annotation für
-die Erstellung des Kontextmembers übergeben wurde.
+`TypeBuiler` aus dem Kontext lesen soll. Hierzu muss der `DSLContextMember` der Name des
+Kontextmembers an das `name`-Attribut übergeben werden. Dieser Wert muss dem Wert
+entsprechen, der auch der `DSLContextPush`-Annotation für die Erstellung des Kontextmembers
+übergeben wurde.
 
 ```java
 public PositionComponent(@DSLContextMember(name = "entity") Entity entity) {
@@ -216,18 +245,21 @@ public PositionComponent(@DSLContextMember(name = "entity") Entity entity) {
 
 ## Typadaptierung
 
-Einige Komponenten des ECS (bspw. `AnimationComponent`) verwenden für ihre Member Datentypen, die außerhalb
-des `Dungeon`-Projekts definiert sind (im Folgenden "externe Datentypen"). Ein Beispiel hierfür ist die
-im `PM Dungeon` definierte `Animation`-Klasse, die für Member des `AnimationComponent` verwendet werden.
+Einige Komponenten des ECS (bspw. `AnimationComponent`) verwenden für ihre Member
+Datentypen, die außerhalb des `Dungeon`-Projekts definiert sind (im Folgenden “externe
+Datentypen”). Ein Beispiel hierfür ist die im `PM Dungeon` definierte `Animation`-Klasse,
+die für Member des `AnimationComponent` verwendet werden.
 
 Da die Definition eines externen Datentyps außerhalb des `Dungeon`-Projekts liegt, kann die
-entsprechende Klasse nicht mit der `DSLType`-Annotation markiert werden. Das hat zur Folge, dass der bisher
-beschriebene Mechanismus des Typebuildings nicht für externe Datentypen genutzt werden kann. Dies verhindert
-die direkte Abbildung dieser externen Datentypen im DSL Typsystem. Daraus folgt, dass ein Member einer mit
-`@DSLType` markierten Klasse, nicht ohne Weiteres über die DSL konfigurierbar ist, wenn er einen externen
-Datentyp verwendet.
+entsprechende Klasse nicht mit der `DSLType`-Annotation markiert werden. Das hat zur Folge,
+dass der bisher beschriebene Mechanismus des Typebuildings nicht für externe Datentypen
+genutzt werden kann. Dies verhindert die direkte Abbildung dieser externen Datentypen im DSL
+Typsystem. Daraus folgt, dass ein Member einer mit `@DSLType` markierten Klasse, nicht ohne
+Weiteres über die DSL konfigurierbar ist, wenn er einen externen Datentyp verwendet.
 
-Ein Beispiel ist im folgenden Snippet zu sehen. Hier verwendet `member2` einen Datentyp aus einer externen Bibliothek.
+Ein Beispiel ist im folgenden Snippet zu sehen. Hier verwendet `member2` einen Datentyp aus
+einer externen Bibliothek.
+
 ```java
 import some.external.library.ExternalType;
 
@@ -238,15 +270,16 @@ public class Component {
 }
 ```
 
-Um diese Member, die einen externen Datentyp verwenden, trotzdem über die DSL konfigurierbar zu machen, kann
-ihr Datentyp 'adaptiert' werden.
+Um diese Member, die einen externen Datentyp verwenden, trotzdem über die DSL konfigurierbar
+zu machen, kann ihr Datentyp ‘adaptiert’ werden.
 
-Hierzu kann eine statische Methode mit `@DSLTypeAdapter` markiert werden. Dabei muss über den `t`-Parameter
-definiert werden, welcher Java-Datentyp über die Methode adaptiert werden soll.
+Hierzu kann eine statische Methode mit `@DSLTypeAdapter` markiert werden.
+Über den Rückgabewert der Methode wird definiert, welcher Java-Datentyp über
+die Methode adaptiert werden soll.
 
-Das weitere Vorgehen für die Typadaptierung unterscheidet zwischen zwei Fällen
-1. es ist nur ein Parameter nötig, um eine Instanz des zu adaptierenden Datentypen zu erzeugen
-2. es sind mehr als ein Parameter nötig, um eine Instanz des zu adaptierenden Datentypen zu erzeugen
+Das weitere Vorgehen für die Typadaptierung unterscheidet zwischen zwei Fällen 1. es ist nur
+ein Parameter nötig, um eine Instanz des zu adaptierenden Datentypen zu erzeugen 2. es sind
+mehr als ein Parameter nötig, um eine Instanz des zu adaptierenden Datentypen zu erzeugen
 
 ### 1. Nur ein Parameter nötig
 
@@ -261,21 +294,21 @@ public class ExternalTypeBuilder {
 }
 ```
 
-Die Klasse, in der die so markierte Builder-Methode definiert ist, muss im `TypeBuilder` über
-die `registerTypeAdapter`-Methode registriert werden.
+Die Klasse, in der die so markierte Builder-Methode definiert ist, muss im `TypeBuilder`
+über die `registerTypeAdapter`-Methode registriert werden.
 
 ```java
 TypeBuilder tb = new TypeBuilder();
 tb.registerTypeAdapter(ExternalTypeBuilder.class, Scope.NULL);
 ```
 
-Für alle standardmäßig verfügbaren adaptierten Datentypen ist dies
-bereits im `GameEnvironment` ([GameEnvironment.java](./../../dsl/src/runtime/GameEnvironment.java))
-in der Methode `registerDefaultTypeAdapters` implementiert.
+Für alle standardmäßig verfügbaren adaptierten Datentypen ist dies bereits im
+`GameEnvironment` ([GameEnvironment.java](./../../dsl/src/runtime/GameEnvironment.java)) in
+der Methode `registerDefaultTypeAdapters` implementiert.
 
-Für die Konfiguration des Members wird der Datentyp des Parameters der Builder-Methode verwendet.
-Für die oben definierte Methode `buildExternalType` ist das `String`. Die Konfiguration per DSL
-würde wie folgt aussehen:
+Für die Konfiguration des Members wird der Datentyp des Parameters der Builder-Methode
+verwendet. Für die oben definierte Methode `buildExternalType` ist das `String`. Die
+Konfiguration per DSL würde wie folgt aussehen:
 
 ```
 game_object my_obj {
@@ -288,10 +321,11 @@ game_object my_obj {
 
 ### 2. Mehr als ein Parameter nötig
 
-Die Builder-Methode für Datentypen zu deren Instanziierung mehr als ein Parameter nötig ist, wird ähnlich
-markiert, wie Builder-Methoden mit einem einzigen Parameter. Allerdings besteht die Möglichkeit, die Parameter
-der Builder-Methode mit der `DSLTypeMember`-Annotation zu markieren und so den Namen, der für die
-Repräsentation dieses Parameters in der DSL verwendet werden soll, vorzugeben.
+Die Builder-Methode für Datentypen zu deren Instanziierung mehr als ein Parameter nötig ist,
+wird ähnlich markiert, wie Builder-Methoden mit einem einzigen Parameter. Allerdings besteht
+die Möglichkeit, die Parameter der Builder-Methode mit der `DSLTypeMember`-Annotation zu
+markieren und so den Namen, der für die Repräsentation dieses Parameters in der DSL
+verwendet werden soll, vorzugeben.
 
 ```java
 public class ExternalTypeBuilder {
@@ -321,25 +355,24 @@ game_object my_obj {
 
 ### Typebuilding
 
-Der grobe Ablauf des Typebuildings, welches vom GameEnvironment für alle
-standardmäßig verfügbaren Datentypen ausgeführt wird, ist im folgenden
-Sequenzdiagramm abgebildet:
+Der grobe Ablauf des Typebuildings, welches vom GameEnvironment für alle standardmäßig
+verfügbaren Datentypen ausgeführt wird, ist im folgenden Sequenzdiagramm abgebildet:
 
 ![UML: Ablauf Typebuilding](./img/typebuilding.png)
 
 ### Typadaptierung
 
-Der Ablauf der Typadaptierung unterscheidet sich abhängig von der Menge der benötigten Parameter
-(analog zu der Beschreibung in [Typadaptierung](#typadaptierung)).
+Der Ablauf der Typadaptierung unterscheidet sich abhängig von der Menge der benötigten
+Parameter (analog zu der Beschreibung in [Typadaptierung](#typadaptierung)).
 
-Der Ablauf für den Fall, dass nur ein Parameter zur Instanziierung nötig ist,
-kann dem folgenden Sequenzdiagramm entnommen werden:
+Der Ablauf für den Fall, dass nur ein Parameter zur Instanziierung nötig ist, kann dem
+folgenden Sequenzdiagramm entnommen werden:
 
 ![UML: Ablauf einfache Typadaptierung](img/typeadapting.png)
 
-Für den Fall, dass mehr als ein Parameter zur Instanziierung nötig ist, ähnelt
-die Erstellung des `AggregateTypeAdapter` dem normalen [Typebuilding](#typebuilding),
-wie im folgenden Sequenzdiagramm zu erkennen:
+Für den Fall, dass mehr als ein Parameter zur Instanziierung nötig ist, ähnelt die
+Erstellung des `AggregateTypeAdapter` dem normalen [Typebuilding](#typebuilding), wie im
+folgenden Sequenzdiagramm zu erkennen:
 
 ![UML: Ablauf komplexe Typadaptierung](img/typeadapting_complex.png)
 

--- a/doc/dsl/typebuilding.md
+++ b/doc/dsl/typebuilding.md
@@ -343,6 +343,8 @@ wie im folgenden Sequenzdiagramm zu erkennen:
 
 ![UML: Ablauf komplexe Typadaptierung](img/typeadapting_complex.png)
 
+Für einen Datentyp namens `ExternalType` könnte dies wie folgt aussehen:
+
 ```java
 // externer Datentyp, der in das DSL-Typsystem gebracht werden soll
 public class ExternalType {
@@ -359,7 +361,7 @@ public class ExternalType {
 
 // typebuilder für ExternalType
 public class ExternalTypeBuilderMultiParam {
-    @DSLTypeAdapter
+    @DSLTypeAdapter(name = "external_type")
     public static ExternalType buildExternalType(
             @DSLTypeMember(name = "number") int n,
             @DSLTypeMember(name = "string") String str) {
@@ -368,7 +370,8 @@ public class ExternalTypeBuilderMultiParam {
 }
 ```
 
-Der externe Datentyp kann in der DSL wie folgt verwendet werden:
+Der externe Datentyp kann in der DSL, mit dem in der `DSLTypeAdapter`-Annotation
+konfigurierten Namen, wie folgt verwendet werden:
 
 ```
 game_object my_obj {

--- a/dsl/src/interpreter/DSLInterpreter.java
+++ b/dsl/src/interpreter/DSLInterpreter.java
@@ -260,7 +260,6 @@ public class DSLInterpreter implements AstVisitor<Object> {
         this.memoryStack.pop();
 
         return instance;
-
     }
 
     /**
@@ -408,7 +407,7 @@ public class DSLInterpreter implements AstVisitor<Object> {
         var type = this.symbolTable().getGlobalScope().resolve(node.getIdName());
         assert type instanceof AggregateType;
 
-        var value = (AggregateValue)instantiate((AggregateType) type);
+        var value = (AggregateValue) instantiate((AggregateType) type);
 
         // interpret the property definitions
         this.memoryStack.push(value.getMemorySpace());

--- a/dsl/src/interpreter/DSLInterpreter.java
+++ b/dsl/src/interpreter/DSLInterpreter.java
@@ -106,12 +106,22 @@ public class DSLInterpreter implements AstVisitor<Object> {
         // datatype definition, because it is part of the definition
         // evaluate rhs and store the value in the member of
         // the prototype
-        Prototype componentPrototype = new Prototype((AggregateType) componentSymbol.getDataType());
+        AggregateType prototypesType = (AggregateType) componentSymbol.getDataType();
+        Prototype componentPrototype = new Prototype(prototypesType);
         for (var propDef : node.getPropertyDefinitionNodes()) {
             var propertyDefNode = (PropertyDefNode) propDef;
             var rhsValue = (Value) propertyDefNode.getStmtNode().accept(this);
 
+            // get type of lhs (the assignee)
+            var propName = propertyDefNode.getIdName();
+            var propertiesType = prototypesType.resolve(propName).getDataType();
+
+            // clone value
             Value value = (Value) rhsValue.clone();
+
+            // promote value to property's datatype
+            // TODO: typechecking must be performed before this
+            value.setDataType((IType)propertiesType);
 
             // indicate, that the value is "dirty", which means it was set
             // explicitly and needs to be set in the java object corresponding

--- a/dsl/src/interpreter/DSLInterpreter.java
+++ b/dsl/src/interpreter/DSLInterpreter.java
@@ -111,9 +111,7 @@ public class DSLInterpreter implements AstVisitor<Object> {
             var propertyDefNode = (PropertyDefNode) propDef;
             var rhsValue = (Value) propertyDefNode.getStmtNode().accept(this);
 
-            // TODO: this fails for adapted types
-            var propertySymbol = symbolTable().getSymbolsForAstNode(propDef).get(0);
-            Value value = new Value(propertySymbol.getDataType(), rhsValue.getInternalObject());
+            Value value = (Value)rhsValue.clone();
 
             // indicate, that the value is "dirty", which means it was set
             // explicitly and needs to be set in the java object corresponding

--- a/dsl/src/interpreter/DSLInterpreter.java
+++ b/dsl/src/interpreter/DSLInterpreter.java
@@ -121,7 +121,7 @@ public class DSLInterpreter implements AstVisitor<Object> {
 
             // promote value to property's datatype
             // TODO: typechecking must be performed before this
-            value.setDataType((IType)propertiesType);
+            value.setDataType((IType) propertiesType);
 
             // indicate, that the value is "dirty", which means it was set
             // explicitly and needs to be set in the java object corresponding

--- a/dsl/src/interpreter/DSLInterpreter.java
+++ b/dsl/src/interpreter/DSLInterpreter.java
@@ -403,6 +403,24 @@ public class DSLInterpreter implements AstVisitor<Object> {
     }
 
     @Override
+    public Object visit(AggregateValueDefinitionNode node) {
+        // create instance of dsl data type
+        var type = this.symbolTable().getGlobalScope().resolve(node.getIdName());
+        assert type instanceof AggregateType;
+
+        var value = (AggregateValue)instantiate((AggregateType) type);
+
+        // interpret the property definitions
+        this.memoryStack.push(value.getMemorySpace());
+        for (var member : node.getPropertyDefinitionNodes()) {
+            member.accept(this);
+        }
+        this.memoryStack.pop();
+
+        return value;
+    }
+
+    @Override
     public Object visit(PropertyDefNode node) {
         var value = (Value) node.getStmtNode().accept(this);
         var propertyName = node.getIdName();

--- a/dsl/src/interpreter/DSLInterpreter.java
+++ b/dsl/src/interpreter/DSLInterpreter.java
@@ -111,7 +111,7 @@ public class DSLInterpreter implements AstVisitor<Object> {
             var propertyDefNode = (PropertyDefNode) propDef;
             var rhsValue = (Value) propertyDefNode.getStmtNode().accept(this);
 
-            Value value = (Value)rhsValue.clone();
+            Value value = (Value) rhsValue.clone();
 
             // indicate, that the value is "dirty", which means it was set
             // explicitly and needs to be set in the java object corresponding

--- a/dsl/src/interpreter/DSLInterpreter.java
+++ b/dsl/src/interpreter/DSLInterpreter.java
@@ -247,6 +247,22 @@ public class DSLInterpreter implements AstVisitor<Object> {
         return null;
     }
 
+    protected Value instantiate(AggregateType type) {
+        AggregateValue instance = new AggregateValue(type, currentMemorySpace());
+
+        IMemorySpace memorySpace = instance.getMemorySpace();
+        this.memoryStack.push(memorySpace);
+        for (var member : type.getSymbols()) {
+            // check, if type defines default for member
+            var defaultValue = createDefaultValue(member.getDataType());
+            memorySpace.bindValue(member.getName(), defaultValue);
+        }
+        this.memoryStack.pop();
+
+        return instance;
+
+    }
+
     /**
      * Instantiate a dsl prototype (which is an aggregate type with defaults) as a new Value
      *

--- a/dsl/src/runtime/AggregateValue.java
+++ b/dsl/src/runtime/AggregateValue.java
@@ -52,4 +52,9 @@ public class AggregateValue extends Value {
     public Set<Map.Entry<String, Value>> getValueSet() {
         return this.getMemorySpace().getValueSet();
     }
+
+    @Override
+    public Object clone() {
+        return this;
+    }
 }

--- a/dsl/src/runtime/GameEnvironment.java
+++ b/dsl/src/runtime/GameEnvironment.java
@@ -26,8 +26,8 @@ public class GameEnvironment implements IEvironment {
     protected final TypeBuilder typeBuilder;
 
     // TODO: also make HashMaps
-    protected final ArrayList<IType> builtInTypes;
-    protected final ArrayList<Symbol> nativeFunctions;
+    protected final ArrayList<IType> BUILT_IN_TYPES;
+    protected final ArrayList<Symbol> NATIVE_FUNCTIONS;
 
     protected final HashMap<String, IType> loadedTypes = new HashMap<>();
     protected final HashMap<String, Symbol> loadedFunctions = new HashMap<>();
@@ -48,8 +48,8 @@ public class GameEnvironment implements IEvironment {
         this.symbolTable = new SymbolTable(this.globalScope);
 
         // create built in types and native functions
-        this.builtInTypes = buildBuiltInTypes();
-        this.nativeFunctions = buildNativeFunctions();
+        this.BUILT_IN_TYPES = buildBuiltInTypes();
+        this.NATIVE_FUNCTIONS = buildNativeFunctions();
 
         bindBuiltIns();
         registerDefaultTypeAdapters();
@@ -62,29 +62,29 @@ public class GameEnvironment implements IEvironment {
     }
 
     protected void bindBuiltIns() {
-        for (IType type : builtInTypes) {
+        for (IType type : BUILT_IN_TYPES) {
             globalScope.bind((Symbol) type);
         }
 
-        for (Symbol func : nativeFunctions) {
+        for (Symbol func : NATIVE_FUNCTIONS) {
             globalScope.bind(func);
         }
     }
 
     @Override
     public IType[] getTypes() {
-        var typesArray = new IType[builtInTypes.size() + loadedTypes.size()];
+        var typesArray = new IType[BUILT_IN_TYPES.size() + loadedTypes.size()];
         var combinedList = new ArrayList<IType>();
-        combinedList.addAll(builtInTypes);
+        combinedList.addAll(BUILT_IN_TYPES);
         combinedList.addAll(loadedTypes.values());
         return combinedList.toArray(typesArray);
     }
 
     @Override
     public Symbol[] getFunctions() {
-        var funcArray = new Symbol[nativeFunctions.size() + loadedFunctions.size()];
+        var funcArray = new Symbol[NATIVE_FUNCTIONS.size() + loadedFunctions.size()];
         var combinedList = new ArrayList<Symbol>();
-        combinedList.addAll(nativeFunctions);
+        combinedList.addAll(NATIVE_FUNCTIONS);
         combinedList.addAll(loadedFunctions.values());
         return combinedList.toArray(funcArray);
     }

--- a/dsl/src/runtime/GameEnvironment.java
+++ b/dsl/src/runtime/GameEnvironment.java
@@ -96,7 +96,10 @@ public class GameEnvironment implements IEvironment {
                 continue;
             }
             if (loadedTypes.containsKey(type.getName())) {
-                continue;
+                throw new RuntimeException(
+                        "A type with the name '"
+                                + type.getName()
+                                + "' is already loaded in the environment!");
             }
             loadedTypes.put(type.getName(), type);
             this.globalScope.bind((Symbol) type);

--- a/dsl/src/runtime/GameEnvironment.java
+++ b/dsl/src/runtime/GameEnvironment.java
@@ -23,11 +23,11 @@ import java.util.List;
 public class GameEnvironment implements IEvironment {
     // TODO: the type builder should also be part of some 'type factory' to
     //  avoid having only one builder for game Environments
-    protected static final TypeBuilder typeBuilder = new TypeBuilder();
+    protected final TypeBuilder typeBuilder;
 
     // TODO: also make HashMaps
-    protected static final ArrayList<IType> BUILT_IN_TYPES = buildBuiltInTypes();
-    protected static final ArrayList<Symbol> NATIVE_FUNCTIONS = buildNativeFunctions();
+    protected final ArrayList<IType> builtInTypes;
+    protected final ArrayList<Symbol> nativeFunctions;
 
     protected final HashMap<String, IType> loadedTypes = new HashMap<>();
     protected final HashMap<String, Symbol> loadedFunctions = new HashMap<>();
@@ -43,43 +43,48 @@ public class GameEnvironment implements IEvironment {
      * functions
      */
     public GameEnvironment() {
+        this.typeBuilder = new TypeBuilder();
         this.globalScope = new Scope();
         this.symbolTable = new SymbolTable(this.globalScope);
+
+        // create built in types and native functions
+        this.builtInTypes = buildBuiltInTypes();
+        this.nativeFunctions = buildNativeFunctions();
 
         bindBuiltIns();
         registerDefaultTypeAdapters();
     }
 
-    protected static void registerDefaultTypeAdapters() {
+    protected void registerDefaultTypeAdapters() {
         /* The DrawComponent was fundamentally refactort and the DSL is not yet updated.
          * see https://github.com/Programmiermethoden/Dungeon/pull/687 for more information*/
         // typeBuilder.registerTypeAdapter(AnimationBuilder.class, Scope.NULL);
     }
 
     protected void bindBuiltIns() {
-        for (IType type : BUILT_IN_TYPES) {
+        for (IType type : builtInTypes) {
             globalScope.bind((Symbol) type);
         }
 
-        for (Symbol func : NATIVE_FUNCTIONS) {
+        for (Symbol func : nativeFunctions) {
             globalScope.bind(func);
         }
     }
 
     @Override
     public IType[] getTypes() {
-        var typesArray = new IType[BUILT_IN_TYPES.size() + loadedTypes.size()];
+        var typesArray = new IType[builtInTypes.size() + loadedTypes.size()];
         var combinedList = new ArrayList<IType>();
-        combinedList.addAll(BUILT_IN_TYPES);
+        combinedList.addAll(builtInTypes);
         combinedList.addAll(loadedTypes.values());
         return combinedList.toArray(typesArray);
     }
 
     @Override
     public Symbol[] getFunctions() {
-        var funcArray = new Symbol[NATIVE_FUNCTIONS.size() + loadedFunctions.size()];
+        var funcArray = new Symbol[nativeFunctions.size() + loadedFunctions.size()];
         var combinedList = new ArrayList<Symbol>();
-        combinedList.addAll(NATIVE_FUNCTIONS);
+        combinedList.addAll(nativeFunctions);
         combinedList.addAll(loadedFunctions.values());
         return combinedList.toArray(funcArray);
     }
@@ -122,7 +127,7 @@ public class GameEnvironment implements IEvironment {
         return this.globalScope;
     }
 
-    private static ArrayList<IType> buildBuiltInTypes() {
+    private ArrayList<IType> buildBuiltInTypes() {
         ArrayList<IType> types = new ArrayList<>();
 
         types.add(BuiltInType.noType);

--- a/dsl/src/runtime/Value.java
+++ b/dsl/src/runtime/Value.java
@@ -14,7 +14,7 @@ import semanticanalysis.types.IType;
 public class Value implements IClonable {
     public static Value NONE = new Value(null, null, false);
 
-    protected final IType dataType;
+    protected IType dataType;
     protected Object value;
     protected final boolean isMutable;
     protected boolean dirty;
@@ -50,6 +50,10 @@ public class Value implements IClonable {
      */
     public IType getDataType() {
         return dataType;
+    }
+
+    public void setDataType(IType type) {
+        this.dataType = type;
     }
 
     /**

--- a/dsl/src/semanticanalysis/SemanticAnalyzer.java
+++ b/dsl/src/semanticanalysis/SemanticAnalyzer.java
@@ -272,22 +272,34 @@ public class SemanticAnalyzer implements AstVisitor<Void> {
     public Void visit(AggregateValueDefinitionNode node) {
         // push datatype of component
         // resolve in current scope, which will be datatype of game object definition
-        var memberSymbol = currentScope().resolve(node.getIdName());
-        if (memberSymbol == Symbol.NULL) {
-            errorStringBuilder.append("Could not resolve Component with name " + node.getIdName());
-        } else {
-            var typeSymbol = memberSymbol.getDataType();
-            // TODO: errorhandling
-            if (typeSymbol == Symbol.NULL || typeSymbol == null) {
-                errorStringBuilder.append("Could not resolve type " + "TODO");
-            } else {
-                scopeStack.push((AggregateType) typeSymbol);
+        IType membersType;
+        String valueName = node.getIdName();
 
-                for (var propertyDef : node.getPropertyDefinitionNodes()) {
-                    propertyDef.accept(this);
-                }
-                scopeStack.pop();
+        // TODO: for an anonymous object (inline defined aggregate value), the memberSymbol will be
+        // Symbol.NULL
+        //  could just resolve the name as a datatype and resolve any member in it..
+        //  but this is not really clean. Should make this explicit at a higher level
+
+        // get the type of the aggregate value
+        var memberSymbol = currentScope().resolve(valueName);
+        if (memberSymbol == Symbol.NULL) {
+            var type = this.environment.getGlobalScope().resolve(valueName);
+            assert type instanceof AggregateType;
+            membersType = (IType) type;
+        } else {
+            membersType = memberSymbol.getDataType();
+        }
+
+        // TODO: errorhandling
+        if (membersType == Symbol.NULL || membersType == null) {
+            errorStringBuilder.append("Could not resolve type " + "TODO");
+        } else {
+            // visit all property-definitions of the aggregate value definition
+            scopeStack.push((AggregateType) membersType);
+            for (var propertyDef : node.getPropertyDefinitionNodes()) {
+                propertyDef.accept(this);
             }
+            scopeStack.pop();
         }
 
         return null;

--- a/dsl/src/semanticanalysis/types/AdaptedType.java
+++ b/dsl/src/semanticanalysis/types/AdaptedType.java
@@ -1,15 +1,14 @@
 package semanticanalysis.types;
 
 import semanticanalysis.IScope;
+import semanticanalysis.Symbol;
 
 import java.lang.reflect.Method;
 
 /** This is used to adapt a type, which only requires a single parameter for construction */
-public class AdaptedType implements IType {
-    final String name;
+public class AdaptedType extends Symbol implements IType {
     final Class<?> originType;
     final BuiltInType buildParameterType;
-    final IScope parentScope;
 
     // TODO: this is only a temporary solution
     final Method builderMethod;
@@ -29,7 +28,7 @@ public class AdaptedType implements IType {
     }
 
     public IScope getParentScope() {
-        return parentScope;
+        return this.scope;
     }
 
     public Class<?> getOriginType() {
@@ -46,8 +45,7 @@ public class AdaptedType implements IType {
             Class<?> originType,
             BuiltInType buildParameterType,
             Method builderMethod) {
-        this.name = name;
-        this.parentScope = parentScope;
+        super(name, parentScope, null);
         this.originType = originType;
         this.buildParameterType = buildParameterType;
         this.builderMethod = builderMethod;

--- a/dsl/src/semanticanalysis/types/AggregateTypeAdapter.java
+++ b/dsl/src/semanticanalysis/types/AggregateTypeAdapter.java
@@ -4,8 +4,6 @@ import semanticanalysis.IScope;
 
 import java.lang.reflect.Method;
 
-import java.lang.reflect.Method;
-
 public class AggregateTypeAdapter extends AggregateType {
 
     final Method builderMethod;

--- a/dsl/src/semanticanalysis/types/AggregateTypeAdapter.java
+++ b/dsl/src/semanticanalysis/types/AggregateTypeAdapter.java
@@ -4,6 +4,8 @@ import semanticanalysis.IScope;
 
 import java.lang.reflect.Method;
 
+import java.lang.reflect.Method;
+
 public class AggregateTypeAdapter extends AggregateType {
 
     final Method builderMethod;

--- a/dsl/src/semanticanalysis/types/AggregateTypeAdapter.java
+++ b/dsl/src/semanticanalysis/types/AggregateTypeAdapter.java
@@ -8,6 +8,10 @@ public class AggregateTypeAdapter extends AggregateType {
 
     final Method builderMethod;
 
+    public Method getBuilderMethod() {
+        return builderMethod;
+    }
+
     public AggregateTypeAdapter(
             String name, IScope parentScope, Class<?> originType, Method builderMethod) {
         super(name, parentScope, originType);

--- a/dsl/src/semanticanalysis/types/DSLTypeAdapter.java
+++ b/dsl/src/semanticanalysis/types/DSLTypeAdapter.java
@@ -8,4 +8,9 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
 public @interface DSLTypeAdapter {
+    /**
+     * The name to use for the corresponding DSL data type. If it is not set, the class name of the
+     * return type of the marked method will be converted by {@link TypeBuilder}
+     */
+    String name() default "";
 }

--- a/dsl/src/semanticanalysis/types/DSLTypeAdapter.java
+++ b/dsl/src/semanticanalysis/types/DSLTypeAdapter.java
@@ -8,5 +8,4 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
 public @interface DSLTypeAdapter {
-    Class<?> t();
 }

--- a/dsl/src/semanticanalysis/types/TypeBuilder.java
+++ b/dsl/src/semanticanalysis/types/TypeBuilder.java
@@ -141,8 +141,15 @@ public class TypeBuilder {
                 }
                 this.typeAdapters.put(forType, method);
 
+                var annotation = method.getAnnotation(DSLTypeAdapter.class);
+                String dslTypeName =
+                        annotation.name().equals("")
+                                ? convertToDSLName(forType.getSimpleName())
+                                : annotation.name();
+
                 // create adapterType
-                var adapterType = createAdapterType(forType, method, parentScope);
+                var adapterType = createAdapterType(forType, dslTypeName, method, parentScope);
+
                 this.javaTypeToDSLType.put(forType, adapterType);
 
                 return true;
@@ -151,8 +158,8 @@ public class TypeBuilder {
         return true;
     }
 
-    public IType createAdapterType(Class<?> forType, Method adapterMethod, IScope parentScope) {
-        String dslTypeName = convertToDSLName(forType.getSimpleName());
+    public IType createAdapterType(
+            Class<?> forType, String dslTypeName, Method adapterMethod, IScope parentScope) {
         // get parameters, if only one: PODType, otherwise: AggregateType
         if (adapterMethod.getParameterCount() == 0) {
             // TODO: handle

--- a/dsl/src/semanticanalysis/types/TypeBuilder.java
+++ b/dsl/src/semanticanalysis/types/TypeBuilder.java
@@ -135,8 +135,7 @@ public class TypeBuilder {
         for (var method : adapterClass.getDeclaredMethods()) {
             if (method.isAnnotationPresent(DSLTypeAdapter.class)
                     && Modifier.isStatic(method.getModifiers())) {
-                var annotation = method.getAnnotation(DSLTypeAdapter.class);
-                var forType = annotation.t();
+                var forType = method.getReturnType();
                 if (this.typeAdapters.containsKey(forType)) {
                     return false;
                 }

--- a/dsl/src/semanticanalysis/types/TypeInstantiator.java
+++ b/dsl/src/semanticanalysis/types/TypeInstantiator.java
@@ -2,6 +2,7 @@ package semanticanalysis.types;
 
 import static semanticanalysis.types.TypeBuilder.convertToDSLName;
 
+import runtime.AggregateValue;
 import runtime.IMemorySpace;
 import runtime.Value;
 

--- a/dsl/src/semanticanalysis/types/TypeInstantiator.java
+++ b/dsl/src/semanticanalysis/types/TypeInstantiator.java
@@ -148,9 +148,8 @@ public class TypeInstantiator {
                     if (fieldValue != Value.NONE && fieldValue.isDirty()) {
                         var internalValue = fieldValue.getInternalObject();
 
-                        // TODO: should this not be done at the toplevel of instantiation? not only
-                        // one level down?
-                        if (fieldValue.getDataType().getTypeKind().equals(IType.Kind.PODAdapted)) {
+                        var fieldsDataType = fieldValue.getDataType();
+                        if (fieldsDataType.getTypeKind().equals(IType.Kind.PODAdapted)) {
                             // call builder -> the type instantiator needs a reference to the
                             // builder or to the
                             // builder methods
@@ -158,13 +157,12 @@ public class TypeInstantiator {
                             var method = adaptedType.getBuilderMethod();
 
                             internalValue = method.invoke(null, internalValue);
-                        } else if (fieldValue
-                                .getDataType()
+                        } else if (fieldsDataType
                                 .getTypeKind()
                                 .equals(IType.Kind.AggregateAdapted)) {
                             // call builder -> store values from memory space in order of parameters
                             // of builder-method
-                            var adaptedType = (AggregateTypeAdapter) fieldValue.getDataType();
+                            var adaptedType = (AggregateTypeAdapter) fieldsDataType;
                             var method = adaptedType.getBuilderMethod();
                             var aggregateFieldValue = (AggregateValue) fieldValue;
 

--- a/dsl/src/semanticanalysis/types/TypeInstantiator.java
+++ b/dsl/src/semanticanalysis/types/TypeInstantiator.java
@@ -157,6 +157,26 @@ public class TypeInstantiator {
                             var method = adaptedType.getBuilderMethod();
 
                             internalValue = method.invoke(null, internalValue);
+                        } else if (fieldValue
+                                .getDataType()
+                                .getTypeKind()
+                                .equals(IType.Kind.AggregateAdapted)) {
+                            // call builder -> store values from memory space in order of parameters
+                            // of builder-method
+                            var adaptedType = (AggregateTypeAdapter) fieldValue.getDataType();
+                            var method = adaptedType.getBuilderMethod();
+                            var aggregateFieldValue = (AggregateValue) fieldValue;
+
+                            var parameters = new ArrayList<>(method.getParameterCount());
+                            for (var parameter : method.getParameters()) {
+                                var memberName = TypeBuilder.getDSLName(parameter);
+                                var memberValue =
+                                        aggregateFieldValue.getMemorySpace().resolve(memberName);
+                                var internalObject = memberValue.getInternalObject();
+                                parameters.add(internalObject);
+                            }
+
+                            internalValue = method.invoke(null, parameters.toArray());
                         }
 
                         field.setAccessible(true);

--- a/dsl/test/interpreter/CustomQuestConfig.java
+++ b/dsl/test/interpreter/CustomQuestConfig.java
@@ -1,0 +1,2 @@
+package interpreter;public class CustomQuestConfig {
+}

--- a/dsl/test/interpreter/CustomQuestConfig.java
+++ b/dsl/test/interpreter/CustomQuestConfig.java
@@ -1,2 +1,9 @@
-package interpreter;public class CustomQuestConfig {
-}
+package interpreter;
+
+import interpreter.mockecs.Entity;
+
+import semanticanalysis.types.DSLType;
+import semanticanalysis.types.DSLTypeMember;
+
+@DSLType(name = "quest_config")
+public record CustomQuestConfig(@DSLTypeMember Entity entity) {}

--- a/dsl/test/interpreter/TestDSLInterpreter.java
+++ b/dsl/test/interpreter/TestDSLInterpreter.java
@@ -219,7 +219,7 @@ public class TestDSLInterpreter {
 
         @Override
         protected void bindBuiltIns() {
-            for (IType type : builtInTypes) {
+            for (IType type : BUILT_IN_TYPES) {
                 // load custom QuestConfig
                 if (!type.getName().equals("quest_config")
                         && !type.getName().equals("game_object")) {
@@ -229,9 +229,9 @@ public class TestDSLInterpreter {
 
             var questConfigType =
                     this.getTypeBuilder().createTypeFromClass(Scope.NULL, CustomQuestConfig.class);
-            loadTypes(new semanticanalysis.types.IType[] {questConfigType});
+            loadTypes(List.of(new IType[]{questConfigType}));
 
-            for (Symbol func : nativeFunctions) {
+            for (Symbol func : NATIVE_FUNCTIONS) {
                 globalScope.bind(func);
             }
         }
@@ -399,9 +399,9 @@ public class TestDSLInterpreter {
                         .createTypeFromClass(Scope.NULL, TestComponentWithExternalType.class);
         var externalType = env.getTypeBuilder().createTypeFromClass(Scope.NULL, ExternalType.class);
         env.loadTypes(
-                new semanticanalysis.types.IType[] {
-                    entityType, testCompType, externalComponentType, externalType
-                });
+            List.of(new IType[]{
+                entityType, testCompType, externalComponentType, externalType
+            }));
 
         var typesToLoad =
                 new semanticanalysis.types.IType[] {

--- a/dsl/test/interpreter/TestDSLInterpreter.java
+++ b/dsl/test/interpreter/TestDSLInterpreter.java
@@ -211,6 +211,31 @@ public class TestDSLInterpreter {
     @DSLType(name = "quest_config")
     public record CustomQuestConfig(@DSLTypeMember Entity entity) {}
 
+    class TestEnvironment extends GameEnvironment {
+        public TestEnvironment() {
+            super();
+        }
+
+        @Override
+        protected void bindBuiltIns() {
+            for (IType type : builtInTypes) {
+                // load custom QuestConfig
+                if (!type.getName().equals("quest_config")
+                        && !type.getName().equals("game_object")) {
+                    globalScope.bind((Symbol) type);
+                }
+            }
+
+            var questConfigType =
+                    this.getTypeBuilder().createTypeFromClass(Scope.NULL, CustomQuestConfig.class);
+            loadTypes(new semanticAnalysis.types.IType[] {questConfigType});
+
+            for (Symbol func : nativeFunctions) {
+                globalScope.bind(func);
+            }
+        }
+    }
+
     @Test
     public void aggregateTypeInstancing() {
         String program =

--- a/dsl/test/interpreter/TestDSLInterpreter.java
+++ b/dsl/test/interpreter/TestDSLInterpreter.java
@@ -18,6 +18,7 @@ import runtime.*;
 
 import semanticanalysis.Scope;
 import semanticanalysis.SemanticAnalyzer;
+import semanticanalysis.Symbol;
 import semanticanalysis.types.*;
 
 import java.io.ByteArrayOutputStream;
@@ -228,7 +229,7 @@ public class TestDSLInterpreter {
 
             var questConfigType =
                     this.getTypeBuilder().createTypeFromClass(Scope.NULL, CustomQuestConfig.class);
-            loadTypes(new semanticAnalysis.types.IType[] {questConfigType});
+            loadTypes(new semanticanalysis.types.IType[] {questConfigType});
 
             for (Symbol func : nativeFunctions) {
                 globalScope.bind(func);
@@ -396,6 +397,11 @@ public class TestDSLInterpreter {
         var externalComponentType =
                 env.getTypeBuilder()
                         .createTypeFromClass(Scope.NULL, TestComponentWithExternalType.class);
+        var externalType = env.getTypeBuilder().createTypeFromClass(Scope.NULL, ExternalType.class);
+        env.loadTypes(
+                new semanticanalysis.types.IType[] {
+                    entityType, testCompType, externalComponentType, externalType
+                });
 
         var typesToLoad =
                 new semanticanalysis.types.IType[] {

--- a/dsl/test/interpreter/TestDSLInterpreter.java
+++ b/dsl/test/interpreter/TestDSLInterpreter.java
@@ -398,4 +398,62 @@ public class TestDSLInterpreter {
         ExternalType externalTypeMember = internalObject.getMemberExternalType();
         Assert.assertEquals("Hello, World!", externalTypeMember.member3);
     }
+
+    @Test
+    public void adaptedInstancingMultiParam() {
+        String program =
+                """
+        game_object my_obj {
+            test_component1 {
+                member1: 42,
+                member2: 12
+            },
+            test_component_with_external_type {
+                member_external_type: external_type { string: "Hello, World!", number: 42 }
+            }
+        }
+
+        quest_config config {
+            entity: my_obj
+        }
+        """;
+
+        // setup test type system
+        var env = new TestEnvironment();
+        var entityType = env.getTypeBuilder().createTypeFromClass(new Scope(), Entity.class);
+        var testCompType =
+                env.getTypeBuilder().createTypeFromClass(new Scope(), TestComponent1.class);
+
+        env.getTypeBuilder().registerTypeAdapter(ExternalTypeBuilderMultiParam.class, Scope.NULL);
+        var externalComponentType =
+                env.getTypeBuilder()
+                        .createTypeFromClass(Scope.NULL, TestComponentWithExternalType.class);
+        var adapterType = env.getTypeBuilder().createTypeFromClass(Scope.NULL, ExternalType.class);
+        env.loadTypes(
+                List.of(
+                        new IType[] {
+                            entityType, testCompType, externalComponentType, adapterType
+                        }));
+
+        SemanticAnalyzer symbolTableParser = new SemanticAnalyzer();
+        symbolTableParser.setup(env);
+        var ast = Helpers.getASTFromString(program);
+        symbolTableParser.walk(ast);
+
+        DSLInterpreter interpreter = new DSLInterpreter();
+        interpreter.initializeRuntime(env);
+
+        interpreter.generateQuestConfig(ast);
+
+        var globalMs = interpreter.getGlobalMemorySpace();
+        AggregateValue config = (AggregateValue) (globalMs.resolve("config"));
+        AggregateValue myObj = (AggregateValue) config.getMemorySpace().resolve("entity");
+        AggregateValue component =
+                (AggregateValue)
+                        myObj.getMemorySpace().resolve("test_component_with_external_type");
+        var internalObject = (TestComponentWithExternalType) component.getInternalObject();
+        ExternalType externalTypeMember = internalObject.getMemberExternalType();
+        Assert.assertEquals("Hello, World!", externalTypeMember.member3);
+        Assert.assertEquals(42, externalTypeMember.member1);
+    }
 }

--- a/dsl/test/interpreter/TestEnvironment.java
+++ b/dsl/test/interpreter/TestEnvironment.java
@@ -9,6 +9,7 @@ import semanticanalysis.types.IType;
 import java.util.List;
 
 public class TestEnvironment extends GameEnvironment {
+
     public TestEnvironment() {
         super();
     }
@@ -23,9 +24,7 @@ public class TestEnvironment extends GameEnvironment {
         }
 
         var questConfigType =
-                this.getTypeBuilder()
-                        .createTypeFromClass(
-                                Scope.NULL, TestDSLInterpreter.CustomQuestConfig.class);
+                this.getTypeBuilder().createTypeFromClass(Scope.NULL, CustomQuestConfig.class);
         var typesToLoad = new semanticanalysis.types.IType[] {questConfigType};
         loadTypes(List.of(typesToLoad));
 

--- a/dsl/test/interpreter/mockecs/ExternalTypeBuilder.java
+++ b/dsl/test/interpreter/mockecs/ExternalTypeBuilder.java
@@ -3,7 +3,7 @@ package interpreter.mockecs;
 import semanticanalysis.types.DSLTypeAdapter;
 
 public class ExternalTypeBuilder {
-    @DSLTypeAdapter(t = ExternalType.class)
+    @DSLTypeAdapter
     public static ExternalType buildExternalType(String str) {
         return new ExternalType(42, 12, str);
     }

--- a/dsl/test/interpreter/mockecs/ExternalTypeBuilderMultiParam.java
+++ b/dsl/test/interpreter/mockecs/ExternalTypeBuilderMultiParam.java
@@ -4,7 +4,7 @@ import semanticanalysis.types.DSLTypeAdapter;
 import semanticanalysis.types.DSLTypeMember;
 
 public class ExternalTypeBuilderMultiParam {
-    @DSLTypeAdapter(t = ExternalType.class)
+    @DSLTypeAdapter
     public static ExternalType buildExternalType(
             @DSLTypeMember(name = "number") int n, @DSLTypeMember(name = "string") String str) {
         return new ExternalType(n, 12, str);

--- a/dsl/test/interpreter/mockecs/OtherExternalType.java
+++ b/dsl/test/interpreter/mockecs/OtherExternalType.java
@@ -1,0 +1,13 @@
+package interpreter.mockecs;
+
+public class OtherExternalType {
+    public int member1;
+    public int member2;
+    public String member3;
+
+    public OtherExternalType(int member1, int member2, String member3) {
+        this.member1 = member1;
+        this.member2 = member2;
+        this.member3 = member3;
+    }
+}

--- a/dsl/test/interpreter/mockecs/OtherExternalTypeBuilderMultiParam.java
+++ b/dsl/test/interpreter/mockecs/OtherExternalTypeBuilderMultiParam.java
@@ -4,9 +4,9 @@ import semanticanalysis.types.DSLTypeAdapter;
 import semanticanalysis.types.DSLTypeMember;
 
 public class OtherExternalTypeBuilderMultiParam {
-    @DSLTypeAdapter
-    public static ExternalType buildExternalType(
-        @DSLTypeMember(name = "number") int n, @DSLTypeMember(name = "string") String str) {
-        return new ExternalType(n, 12, str);
+    @DSLTypeAdapter(name = "external_type")
+    public static OtherExternalType buildExternalType(
+            @DSLTypeMember(name = "number") int n, @DSLTypeMember(name = "string") String str) {
+        return new OtherExternalType(n, 12, str);
     }
 }

--- a/dsl/test/interpreter/mockecs/OtherExternalTypeBuilderMultiParam.java
+++ b/dsl/test/interpreter/mockecs/OtherExternalTypeBuilderMultiParam.java
@@ -1,0 +1,12 @@
+package interpreter.mockecs;
+
+import semanticanalysis.types.DSLTypeAdapter;
+import semanticanalysis.types.DSLTypeMember;
+
+public class OtherExternalTypeBuilderMultiParam {
+    @DSLTypeAdapter
+    public static ExternalType buildExternalType(
+        @DSLTypeMember(name = "number") int n, @DSLTypeMember(name = "string") String str) {
+        return new ExternalType(n, 12, str);
+    }
+}

--- a/dsl/test/runtime/TestGameEnvironment.java
+++ b/dsl/test/runtime/TestGameEnvironment.java
@@ -1,2 +1,34 @@
-package runtime;public class TestGameEnvironment {
+package runtime;
+
+import interpreter.mockecs.*;
+
+import org.junit.Test;
+
+import semanticanalysis.Scope;
+import semanticanalysis.types.IType;
+
+import java.util.List;
+
+public class TestGameEnvironment {
+    @Test(expected = RuntimeException.class)
+    public void adaptedInstancingNameClash() {
+        var env = new GameEnvironment();
+
+        // ExternalTypeBuilderMultiParam and OtherExternalTypeBuilderMultiParam are using the same
+        // name for type reference in the DSL typesystem (the name-attribute is used to force
+        // OtherExternalType to be references as 'external_type`) -> this should trigger an
+        // exception
+        env.getTypeBuilder().registerTypeAdapter(ExternalTypeBuilderMultiParam.class, Scope.NULL);
+        var adapterType = env.getTypeBuilder().createTypeFromClass(Scope.NULL, ExternalType.class);
+
+        env.getTypeBuilder()
+                .registerTypeAdapter(OtherExternalTypeBuilderMultiParam.class, Scope.NULL);
+        var otherAdapterType =
+                env.getTypeBuilder().createTypeFromClass(Scope.NULL, OtherExternalType.class);
+
+        var externalComponentType =
+                env.getTypeBuilder()
+                        .createTypeFromClass(Scope.NULL, TestComponentWithExternalType.class);
+        env.loadTypes(List.of(new IType[] {externalComponentType, adapterType, otherAdapterType}));
+    }
 }

--- a/dsl/test/runtime/TestGameEnvironment.java
+++ b/dsl/test/runtime/TestGameEnvironment.java
@@ -1,0 +1,2 @@
+package runtime;public class TestGameEnvironment {
+}

--- a/dsl/test/semanticanalysis/types/RecordBuilder.java
+++ b/dsl/test/semanticanalysis/types/RecordBuilder.java
@@ -1,7 +1,7 @@
 package semanticanalysis.types;
 
 public class RecordBuilder {
-    @DSLTypeAdapter(t = TestRecordComponent.class)
+    @DSLTypeAdapter
     public static TestRecordComponent buildTestRecord(String param) {
         return new TestRecordComponent(42, param);
     }

--- a/dsl/test/semanticanalysis/types/TestTypeBuilder.java
+++ b/dsl/test/semanticanalysis/types/TestTypeBuilder.java
@@ -7,12 +7,12 @@ import dslToGame.graph.Graph;
 import interpreter.mockecs.ExternalType;
 import interpreter.mockecs.ExternalTypeBuilderMultiParam;
 
-import java.lang.reflect.InvocationTargetException;
-
 import org.junit.Test;
 
 import semanticanalysis.Scope;
 import semanticanalysis.Symbol;
+
+import java.lang.reflect.InvocationTargetException;
 
 public class TestTypeBuilder {
     @Test

--- a/dsl/test/semanticanalysis/types/TestTypeBuilder.java
+++ b/dsl/test/semanticanalysis/types/TestTypeBuilder.java
@@ -7,12 +7,12 @@ import dslToGame.graph.Graph;
 import interpreter.mockecs.ExternalType;
 import interpreter.mockecs.ExternalTypeBuilderMultiParam;
 
+import java.lang.reflect.InvocationTargetException;
+
 import org.junit.Test;
 
 import semanticanalysis.Scope;
 import semanticanalysis.Symbol;
-
-import java.lang.reflect.InvocationTargetException;
 
 public class TestTypeBuilder {
     @Test


### PR DESCRIPTION
Fixes #268 

- [x] erweitert `TypeInstantiator::instantiate` und reiche Werte aus `IMemorySpace` an Builder-Methode weiter
- [x] Tests
- [x] Dokumentation erweitert -> erfordert erstmal den die Basisdokumentation der Interpretation und Laufzeit, die durch #328 hinzugefügt wird