### PR TITLE
[GAME] Pause-Menü

### DIFF
--- a/game/src/hud/PauseMenu.java
+++ b/game/src/hud/PauseMenu.java
@@ -1,9 +1,13 @@
 package hud;
 
 import basiselements.Removable;
+import basiselements.hud.FontBuilder;
+import basiselements.hud.LabelStyleBuilder;
 import basiselements.hud.ScreenText;
+import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.scenes.scene2d.Actor;
+import com.badlogic.gdx.utils.Align;
 import controller.ScreenController;
 import tools.Constants;
 import tools.Point;
@@ -18,12 +22,20 @@ public class PauseMenu<T extends Actor & Removable> extends ScreenController<T> 
     /** Creates a new PauseMenu with a given Spritebatch */
     public PauseMenu(SpriteBatch batch) {
         super(batch);
-        add(
-                (T)
-                        new ScreenText(
-                                "Paused",
-                                new Point(Constants.WINDOW_WIDTH / 2, Constants.WINDOW_HEIGHT / 2),
-                                1));
+        ScreenText screenText =
+                new ScreenText(
+                        "Paused",
+                        new Point(0, 0),
+                        3,
+                        new LabelStyleBuilder(FontBuilder.DEFAULT_FONT)
+                                .setFontcolor(Color.RED)
+                                .build());
+        screenText.setFontScale(3);
+        screenText.setPosition(
+                (Constants.WINDOW_WIDTH) / 2f - screenText.getWidth(),
+                (Constants.WINDOW_HEIGHT) / 1.5f + screenText.getHeight(),
+                Align.center | Align.bottom);
+        add((T) screenText);
         hideMenu();
     }
 

--- a/game/src/hud/PauseMenu.java
+++ b/game/src/hud/PauseMenu.java
@@ -1,0 +1,39 @@
+package hud;
+
+import basiselements.Removable;
+import basiselements.hud.ScreenText;
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.badlogic.gdx.scenes.scene2d.Actor;
+import controller.ScreenController;
+import tools.Constants;
+import tools.Point;
+
+public class PauseMenu<T extends Actor & Removable> extends ScreenController<T> {
+
+    /** Creates a new PauseMenu with a new Spritebatch */
+    public PauseMenu() {
+        this(new SpriteBatch());
+    }
+
+    /** Creates a new PauseMenu with a given Spritebatch */
+    public PauseMenu(SpriteBatch batch) {
+        super(batch);
+        add(
+                (T)
+                        new ScreenText(
+                                "Paused",
+                                new Point(Constants.WINDOW_WIDTH / 2, Constants.WINDOW_HEIGHT / 2),
+                                1));
+        hideMenu();
+    }
+
+    /** shows the Menu */
+    public void showMenu() {
+        this.forEach((Actor s) -> s.setVisible(true));
+    }
+
+    /** hides the Menu */
+    public void hideMenu() {
+        this.forEach((Actor s) -> s.setVisible(false));
+    }
+}

--- a/game/src/mydungeon/ECS.java
+++ b/game/src/mydungeon/ECS.java
@@ -9,6 +9,7 @@ import ecs.components.PositionComponent;
 import ecs.entities.Entity;
 import ecs.entities.Hero;
 import ecs.systems.*;
+import hud.PauseMenu;
 import interpreter.DSLInterpreter;
 import java.util.*;
 import level.LevelAPI;
@@ -27,7 +28,7 @@ public class ECS extends Game {
     public static SystemController systems;
 
     public static ILevel currentLevel;
-
+    private static PauseMenu pauseMenu;
     private PositionComponent heroPositionComponent;
     public static Hero hero;
 
@@ -36,6 +37,8 @@ public class ECS extends Game {
         controller.clear();
         systems = new SystemController();
         controller.add(systems);
+        pauseMenu = new PauseMenu();
+        controller.add(pauseMenu);
         hero = new Hero(new Point(0, 0));
         heroPositionComponent =
                 (PositionComponent)
@@ -73,10 +76,16 @@ public class ECS extends Game {
         setupDSLInput();
     }
 
+    static boolean paused = false;
     /** Toggle between pause and run */
     public static void togglePause() {
+        paused = !paused;
         if (systems != null) {
-            systems.forEach(s -> s.toggleRun());
+            systems.forEach(ECS_System::toggleRun);
+        }
+        if (pauseMenu != null) {
+            if (paused) pauseMenu.showMenu();
+            else pauseMenu.hideMenu();
         }
     }
 


### PR DESCRIPTION
fixes #114 

Ich hatte nochmal kontrolliert, ob es möglich wäre, das UI ins ECS zu übernehmen. Da es sicher schöner wäre.
Es gibt so ein paar Punkte, wo sich das UI grundsätzlich unterscheidet.
- Das UI nutzt nicht das Weltkoordinatensystem
- Das UI nutzt nicht das Point als aktuelle Position, da die darunter liegenden UI Elemente von libgdx stammen.
- Und manche Komponenten könnten verwirrend sein, warum beim UI sie nichts machen etc.

In diesem PR soll eine visuelle Unterstützung gegeben werden, ob das Spiel aktuell läuft oder eben nicht.
