### PR TITLE
[DSL] Grammatik für Funktionsdefinitionen erweitern

### DIFF
--- a/dsl/src/antlr/DungeonDSL.g4
+++ b/dsl/src/antlr/DungeonDSL.g4
@@ -49,7 +49,7 @@ fragment STRING_ESCAPE_SEQ
 // - proper stmt definition
 
 program : definition* EOF
-        //| fn_def
+        // | fn_def
         //| stmt
         ;
 
@@ -57,6 +57,32 @@ definition
         : dot_def
         | object_def
         | game_obj_def
+        | fn_def
+        ;
+
+fn_def
+    : 'fn' ID '(' param_def_list? ')' ret_type_def? '{' stmt_list? '}'
+    ;
+
+stmt
+    : primary ';'
+    ;
+
+stmt_list
+    : stmt stmt_list
+    ;
+
+ret_type_def
+    : '->' type_id=ID
+    ;
+
+param_def
+    : typde_id=ID param_id=ID
+    ;
+
+param_def_list
+        : param_def ',' param_def_list
+        | param_def
         ;
 
 game_obj_def

--- a/dsl/src/antlr/DungeonDSL.g4
+++ b/dsl/src/antlr/DungeonDSL.g4
@@ -49,7 +49,6 @@ fragment STRING_ESCAPE_SEQ
 // - proper stmt definition
 
 program : definition* EOF
-        // | fn_def
         //| stmt
         ;
 

--- a/dsl/src/antlr/DungeonDSL.g4
+++ b/dsl/src/antlr/DungeonDSL.g4
@@ -70,6 +70,7 @@ stmt
 
 stmt_list
     : stmt stmt_list
+    | stmt
     ;
 
 ret_type_def

--- a/dsl/src/antlr/DungeonDSL.g4
+++ b/dsl/src/antlr/DungeonDSL.g4
@@ -74,7 +74,7 @@ stmt_list
     ;
 
 ret_type_def
-    : '->' type_id=ID
+    : ARROW type_id=ID
     ;
 
 param_def

--- a/dsl/src/parser/DungeonASTConverter.java
+++ b/dsl/src/parser/DungeonASTConverter.java
@@ -77,6 +77,42 @@ public class DungeonASTConverter implements antlr.main.DungeonDSLListener {
     public void exitDefinition(DungeonDSLParser.DefinitionContext ctx) {}
 
     @Override
+    public void enterFn_def(DungeonDSLParser.Fn_defContext ctx) {}
+
+    @Override
+    public void exitFn_def(DungeonDSLParser.Fn_defContext ctx) {}
+
+    @Override
+    public void enterStmt(DungeonDSLParser.StmtContext ctx) {}
+
+    @Override
+    public void exitStmt(DungeonDSLParser.StmtContext ctx) {}
+
+    @Override
+    public void enterStmt_list(DungeonDSLParser.Stmt_listContext ctx) {}
+
+    @Override
+    public void exitStmt_list(DungeonDSLParser.Stmt_listContext ctx) {}
+
+    @Override
+    public void enterRet_type_def(DungeonDSLParser.Ret_type_defContext ctx) {}
+
+    @Override
+    public void exitRet_type_def(DungeonDSLParser.Ret_type_defContext ctx) {}
+
+    @Override
+    public void enterParam_def(DungeonDSLParser.Param_defContext ctx) {}
+
+    @Override
+    public void exitParam_def(DungeonDSLParser.Param_defContext ctx) {}
+
+    @Override
+    public void enterParam_def_list(DungeonDSLParser.Param_def_listContext ctx) {}
+
+    @Override
+    public void exitParam_def_list(DungeonDSLParser.Param_def_listContext ctx) {}
+
+    @Override
     public void enterGame_obj_def(DungeonDSLParser.Game_obj_defContext ctx) {}
 
     @Override

--- a/dsl/test/parser/TestDungeonASTConverter.java
+++ b/dsl/test/parser/TestDungeonASTConverter.java
@@ -230,7 +230,7 @@ public class TestDungeonASTConverter {
                     prop2: "Hello, World!"
                 },
                 complex_component2 {
-                    prop3: fn(test),
+                    prop3: func(test),
                     prop4: "42"
                 }
             }


### PR DESCRIPTION
Fixes #343

Erweitert die Grammatik um Funktionsdefinitionen mit optionalen Parametern, optionalem Rückgabewert und Funktionsrumpf.

Note:
Die Deklaration des Rückgabetyps ist optional. Um allerdings ein einheitliches Bild der Funktionsdefinitionen zu schaffen, wird der Rückgabetyp hinter dem `fn` Keyword, dem Funktionsnamen und den Klammern (also dem, was es immer gibt) deklariert.

Also:
```
fn test_func() {
...
}

fn test_func_ret() -> int {
...
}
```

statt 

```
fn test_func() {
...
}

fn int test_func_ret() {
...
}
```