### PR TITLE
[DSL] AST für Funktionsdefinition erstellen

### DIFF
--- a/dsl/src/parser/AST/AstVisitor.java
+++ b/dsl/src/parser/AST/AstVisitor.java
@@ -146,6 +146,16 @@ public interface AstVisitor<T> {
     }
 
     /**
+     * Visitor method for ParamDefNodes
+     *
+     * @param node Node to visit
+     * @return T
+     */
+    default T visit(ParamDefNode node) {
+        return null;
+    }
+
+    /**
      * Visitor method for GameObjectDefinitionNodes
      *
      * @param node Node to visit

--- a/dsl/src/parser/AST/FuncDefNode.java
+++ b/dsl/src/parser/AST/FuncDefNode.java
@@ -1,0 +1,86 @@
+package parser.AST;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class FuncDefNode extends Node {
+    public final int idIdx = 0;
+    public final int paramListIdx = 1;
+    public final int retTypeIdx = 2;
+    public final int stmtListIdx = 3;
+
+    /**
+     * Getter for the AstNode corresponding to the identifier of the defined function
+     *
+     * @return AstNode corresponding to the identifier of the defined function
+     */
+    public Node getId() {
+        return this.getChild(idIdx);
+    }
+
+    /**
+     * Getter for the name of the defined function
+     *
+     * @return Name of the defined function as String
+     */
+    public String getIdName() {
+                            return ((IdNode) this.getChild(idIdx)).getName();
+        }
+
+    /**
+     * Getter for the AstNode corresponding to the return type of the function definition
+     *
+     * @return AstNode corresponding to the return type of the function definition
+     */
+    public Node getRetTypeId() {
+        return this.getChild(retTypeIdx);
+    }
+
+    /**
+     * Getter for the name of return type of the function definition
+     *
+     * @return Name of the return type as String
+     */
+    public String getRetTypeName() {
+        return ((IdNode) this.getChild(retTypeIdx)).getName();
+    }
+
+    /**
+     * Getter for the AstNodes corresponding to the stmts of the function definition
+     *
+     * @return List of the AstNodes corresponding to the stmts of the function definition
+     */
+    public List<Node> getStmts() {
+        return this.children.get(stmtListIdx).getChildren();
+    }
+
+
+    /**
+     * Getter for the AstNodes corresponding to the parameters of the function call
+     *
+     * @return List of the AstNodes corresponding to the parameters of the function call
+     */
+    public List<Node> getParameters() {
+                                    return this.children.get(paramListIdx).getChildren();
+                                                                                         }
+
+    /**
+     * Constructor
+     *
+     * @param id The AstNode corresponding to the identifier of the called function
+     * @param paramList The AstNode corresponding to the parameter list of the function call
+     */
+    public FuncDefNode(Node id, Node paramList, Node retType, Node stmtList) {
+        super(Type.FuncDef, new ArrayList<>(4));
+
+        this.children.add(id);
+        this.children.add(paramList);
+        this.children.add(retType);
+        this.children.add(stmtList);
+    }
+
+    @Override
+    public <T> T accept(AstVisitor<T> visitor) {
+                                             return visitor.visit(this);
+        }
+}

--- a/dsl/src/parser/AST/FuncDefNode.java
+++ b/dsl/src/parser/AST/FuncDefNode.java
@@ -24,8 +24,8 @@ public class FuncDefNode extends Node {
      * @return Name of the defined function as String
      */
     public String getIdName() {
-                            return ((IdNode) this.getChild(idIdx)).getName();
-        }
+        return ((IdNode) this.getChild(idIdx)).getName();
+    }
 
     /**
      * Getter for the AstNode corresponding to the return type of the function definition
@@ -54,15 +54,14 @@ public class FuncDefNode extends Node {
         return this.children.get(stmtListIdx).getChildren();
     }
 
-
     /**
      * Getter for the AstNodes corresponding to the parameters of the function call
      *
      * @return List of the AstNodes corresponding to the parameters of the function call
      */
     public List<Node> getParameters() {
-                                    return this.children.get(paramListIdx).getChildren();
-                                                                                         }
+        return this.children.get(paramListIdx).getChildren();
+    }
 
     /**
      * Constructor
@@ -81,6 +80,6 @@ public class FuncDefNode extends Node {
 
     @Override
     public <T> T accept(AstVisitor<T> visitor) {
-                                             return visitor.visit(this);
-        }
+        return visitor.visit(this);
+    }
 }

--- a/dsl/src/parser/AST/Node.java
+++ b/dsl/src/parser/AST/Node.java
@@ -43,7 +43,9 @@ public class Node {
         FuncCall,
         ParamList,
         ParamDefList,
-        StmtList, FuncDef, ParamDef
+        StmtList,
+        FuncDef,
+        ParamDef
     }
 
     public static Node NONE = new Node(Type.NONE, new ArrayList<>());

--- a/dsl/src/parser/AST/Node.java
+++ b/dsl/src/parser/AST/Node.java
@@ -41,7 +41,9 @@ public class Node {
         Identifier,
         TypeSpecifier,
         FuncCall,
-        ParamList
+        ParamList,
+        ParamDefList,
+        StmtList, FuncDef, ParamDef
     }
 
     public static Node NONE = new Node(Type.NONE, new ArrayList<>());

--- a/dsl/src/parser/AST/ParamDefNode.java
+++ b/dsl/src/parser/AST/ParamDefNode.java
@@ -6,7 +6,7 @@ public class ParamDefNode extends Node {
     public final int typeIdIdx = 0;
     public final int idIdx = 1;
 
-    public Node getTypeIdNode(){
+    public Node getTypeIdNode() {
         return getChild(typeIdIdx);
     }
 
@@ -18,7 +18,7 @@ public class ParamDefNode extends Node {
         return ((IdNode) getIdNode()).getName();
     }
 
-    public Node getIdNode(){
+    public Node getIdNode() {
         return getChild(idIdx);
     }
 

--- a/dsl/src/parser/AST/ParamDefNode.java
+++ b/dsl/src/parser/AST/ParamDefNode.java
@@ -1,0 +1,35 @@
+package parser.AST;
+
+import java.util.ArrayList;
+
+public class ParamDefNode extends Node {
+    public final int typeIdIdx = 0;
+    public final int idIdx = 1;
+
+    public Node getTypeIdNode(){
+        return getChild(typeIdIdx);
+    }
+
+    public String getTypeName() {
+        return ((IdNode) getTypeIdNode()).getName();
+    }
+
+    public String getIdName() {
+        return ((IdNode) getIdNode()).getName();
+    }
+
+    public Node getIdNode(){
+        return getChild(idIdx);
+    }
+
+    public ParamDefNode(Node typeIdNode, Node idNode) {
+        super(Type.ParamDef, new ArrayList<>(2));
+        this.children.add(typeIdNode);
+        this.children.add(idNode);
+    }
+
+    @Override
+    public <T> T accept(AstVisitor<T> visitor) {
+        return visitor.visit(this);
+    }
+}

--- a/dsl/src/parser/DungeonASTConverter.java
+++ b/dsl/src/parser/DungeonASTConverter.java
@@ -80,37 +80,135 @@ public class DungeonASTConverter implements antlr.main.DungeonDSLListener {
     public void enterFn_def(DungeonDSLParser.Fn_defContext ctx) {}
 
     @Override
-    public void exitFn_def(DungeonDSLParser.Fn_defContext ctx) {}
+    public void exitFn_def(DungeonDSLParser.Fn_defContext ctx) {
+        // pop everything (depending on ctx) and create fnDefNode
+        Node stmtList = Node.NONE;
+        if (ctx.stmt_list() != null) {
+            // no stmt list
+            stmtList = astStack.pop();
+        }
+
+        Node retType = Node.NONE;
+        if (ctx.ret_type_def() != null) {
+            retType = astStack.pop();
+        }
+
+        Node paramDefList = Node.NONE;
+        if (ctx.param_def_list() != null) {
+            paramDefList = astStack.pop();
+        }
+
+        Node functionName = astStack.pop();
+
+        var funcDefNode = new FuncDefNode(functionName, paramDefList, retType, stmtList);
+        astStack.push(funcDefNode);
+    }
 
     @Override
     public void enterStmt(DungeonDSLParser.StmtContext ctx) {}
 
     @Override
-    public void exitStmt(DungeonDSLParser.StmtContext ctx) {}
+    public void exitStmt(DungeonDSLParser.StmtContext ctx) {
+        // just let it bubble up, we don't need to store the information, that it is a stmt
+    }
 
     @Override
     public void enterStmt_list(DungeonDSLParser.Stmt_listContext ctx) {}
 
     @Override
-    public void exitStmt_list(DungeonDSLParser.Stmt_listContext ctx) {}
+    public void exitStmt_list(DungeonDSLParser.Stmt_listContext ctx) {
+        // condense to actual list of stmt's
+
+        // condense down to list of param def nodes
+        if (ctx.stmt_list() == null) {
+            // trivial stmt definition list (one stmt)
+            var innerStmt = astStack.pop();
+
+            var list = new ArrayList<Node>(1);
+            list.add(innerStmt);
+
+            var stmtList = new Node(Node.Type.StmtList, list);
+            astStack.push(stmtList);
+        } else {
+            // rhs componentDefList is on stack
+            var rhsList = astStack.pop();
+            assert (rhsList.type == Node.Type.StmtList);
+
+            var leftStmt = astStack.pop();
+            //assert (leftStmt.type == Node.Type.ParamDef);
+
+            var childList = new ArrayList<Node>(rhsList.getChildren().size() + 1);
+            childList.add(leftStmt);
+            childList.addAll(rhsList.getChildren());
+
+            var stmtList = new Node(Node.Type.StmtList, childList);
+            astStack.push(stmtList);
+        }
+    }
 
     @Override
     public void enterRet_type_def(DungeonDSLParser.Ret_type_defContext ctx) {}
 
     @Override
-    public void exitRet_type_def(DungeonDSLParser.Ret_type_defContext ctx) {}
+    public void exitRet_type_def(DungeonDSLParser.Ret_type_defContext ctx) {
+        Node retTypeId = astStack.pop();
+
+        // remove the arrow
+        astStack.pop();
+        astStack.push(retTypeId);
+    }
 
     @Override
     public void enterParam_def(DungeonDSLParser.Param_defContext ctx) {}
 
     @Override
-    public void exitParam_def(DungeonDSLParser.Param_defContext ctx) {}
+    public void exitParam_def(DungeonDSLParser.Param_defContext ctx) {
+        // topmost id on stack: id of parameter
+        var id = astStack.pop();
+        assert id.type == Node.Type.Identifier;
+
+        // after that: type id
+        var typeId = astStack.pop();
+        assert typeId.type == Node.Type.Identifier;
+
+        var paramNode = new ParamDefNode(typeId, id);
+        astStack.push(paramNode);
+    }
 
     @Override
-    public void enterParam_def_list(DungeonDSLParser.Param_def_listContext ctx) {}
+    public void enterParam_def_list(DungeonDSLParser.Param_def_listContext ctx) {
+
+    }
 
     @Override
-    public void exitParam_def_list(DungeonDSLParser.Param_def_listContext ctx) {}
+    public void exitParam_def_list(DungeonDSLParser.Param_def_listContext ctx) {
+        // condense down to list of param def nodes
+        if (ctx.param_def_list() == null) {
+            // trivial parameter definition list
+            var innerParamDef = astStack.pop();
+            assert (innerParamDef.type == Node.Type.ParamDef);
+
+            var list = new ArrayList<Node>(1);
+            list.add(innerParamDef);
+
+            var paramDefList = new Node(Node.Type.ParamDefList, list);
+            astStack.push(paramDefList);
+        } else {
+            // rhs componentDefList is on stack
+            var rhsList = astStack.pop();
+            assert (rhsList.type == Node.Type.ParamDefList);
+
+            var leftParamDef = astStack.pop();
+            assert (leftParamDef.type == Node.Type.ParamDef);
+
+            var childList = new ArrayList<Node>(rhsList.getChildren().size() + 1);
+            childList.add(leftParamDef);
+            childList.addAll(rhsList.getChildren());
+
+            var paramDefList = new Node(Node.Type.ParamDefList, childList);
+            astStack.push(paramDefList);
+        }
+    }
 
     @Override
     public void enterGame_obj_def(DungeonDSLParser.Game_obj_defContext ctx) {}

--- a/dsl/src/parser/DungeonASTConverter.java
+++ b/dsl/src/parser/DungeonASTConverter.java
@@ -135,7 +135,7 @@ public class DungeonASTConverter implements antlr.main.DungeonDSLListener {
             assert (rhsList.type == Node.Type.StmtList);
 
             var leftStmt = astStack.pop();
-            //assert (leftStmt.type == Node.Type.ParamDef);
+            // assert (leftStmt.type == Node.Type.ParamDef);
 
             var childList = new ArrayList<Node>(rhsList.getChildren().size() + 1);
             childList.add(leftStmt);
@@ -176,9 +176,7 @@ public class DungeonASTConverter implements antlr.main.DungeonDSLListener {
     }
 
     @Override
-    public void enterParam_def_list(DungeonDSLParser.Param_def_listContext ctx) {
-
-    }
+    public void enterParam_def_list(DungeonDSLParser.Param_def_listContext ctx) {}
 
     @Override
     public void exitParam_def_list(DungeonDSLParser.Param_def_listContext ctx) {

--- a/dsl/src/parser/DungeonASTConverter.java
+++ b/dsl/src/parser/DungeonASTConverter.java
@@ -118,8 +118,6 @@ public class DungeonASTConverter implements antlr.main.DungeonDSLListener {
     @Override
     public void exitStmt_list(DungeonDSLParser.Stmt_listContext ctx) {
         // condense to actual list of stmt's
-
-        // condense down to list of param def nodes
         if (ctx.stmt_list() == null) {
             // trivial stmt definition list (one stmt)
             var innerStmt = astStack.pop();
@@ -130,12 +128,11 @@ public class DungeonASTConverter implements antlr.main.DungeonDSLListener {
             var stmtList = new Node(Node.Type.StmtList, list);
             astStack.push(stmtList);
         } else {
-            // rhs componentDefList is on stack
+            // rhs stmt list is on stack
             var rhsList = astStack.pop();
             assert (rhsList.type == Node.Type.StmtList);
 
             var leftStmt = astStack.pop();
-            // assert (leftStmt.type == Node.Type.ParamDef);
 
             var childList = new ArrayList<Node>(rhsList.getChildren().size() + 1);
             childList.add(leftStmt);
@@ -192,7 +189,7 @@ public class DungeonASTConverter implements antlr.main.DungeonDSLListener {
             var paramDefList = new Node(Node.Type.ParamDefList, list);
             astStack.push(paramDefList);
         } else {
-            // rhs componentDefList is on stack
+            // rhs paramDefList is on stack
             var rhsList = astStack.pop();
             assert (rhsList.type == Node.Type.ParamDefList);
 

--- a/dsl/test/parser/TestDungeonASTConverter.java
+++ b/dsl/test/parser/TestDungeonASTConverter.java
@@ -300,7 +300,27 @@ public class TestDungeonASTConverter {
     }
 
     @Test
-    public void funcDef() {
+    public void funcDefMinimal() {
+        String program = """
+        fn test_func() { }
+        """;
+
+        var ast = Helpers.getASTFromString(program);
+        var funcDefNode = (FuncDefNode) ast.getChild(0);
+
+        assertEquals(Node.Type.FuncDef, funcDefNode.type);
+        assertEquals("test_func", funcDefNode.getIdName());
+        assertEquals(Node.NONE, funcDefNode.getRetTypeId());
+
+        var parameters = funcDefNode.getParameters();
+        assertEquals(0, parameters.size());
+
+        var stmts = funcDefNode.getStmts();
+        assertEquals(0, stmts.size());
+    }
+
+    @Test
+    public void funcDefFull() {
         String program =
                 """
         fn test_func(int param1, float param2, string param3) -> ret_type {

--- a/dsl/test/parser/TestDungeonASTConverter.java
+++ b/dsl/test/parser/TestDungeonASTConverter.java
@@ -299,11 +299,10 @@ public class TestDungeonASTConverter {
         assertEquals(stmtNode.type, Node.Type.AggregateValueDefinition);
     }
 
-
     @Test
     public void funcDef() {
         String program =
-            """
+                """
         fn test_func(int param1, float param2, string param3) -> ret_type {
             print("hello");
         }
@@ -320,12 +319,12 @@ public class TestDungeonASTConverter {
         for (var parameter : parameters) {
             assertEquals(Node.Type.ParamDef, parameter.type);
         }
-        assertEquals("param1", ((ParamDefNode)parameters.get(0)).getIdName());
-        assertEquals("param2", ((ParamDefNode)parameters.get(1)).getIdName());
-        assertEquals("param3", ((ParamDefNode)parameters.get(2)).getIdName());
-        assertEquals("int", ((ParamDefNode)parameters.get(0)).getTypeName());
-        assertEquals("float", ((ParamDefNode)parameters.get(1)).getTypeName());
-        assertEquals("string", ((ParamDefNode)parameters.get(2)).getTypeName());
+        assertEquals("param1", ((ParamDefNode) parameters.get(0)).getIdName());
+        assertEquals("param2", ((ParamDefNode) parameters.get(1)).getIdName());
+        assertEquals("param3", ((ParamDefNode) parameters.get(2)).getIdName());
+        assertEquals("int", ((ParamDefNode) parameters.get(0)).getTypeName());
+        assertEquals("float", ((ParamDefNode) parameters.get(1)).getTypeName());
+        assertEquals("string", ((ParamDefNode) parameters.get(2)).getTypeName());
 
         var stmts = funcDefNode.getStmts();
         assertEquals(Node.Type.FuncCall, stmts.get(0).type);

--- a/dsl/test/parser/TestDungeonASTConverter.java
+++ b/dsl/test/parser/TestDungeonASTConverter.java
@@ -1,6 +1,7 @@
 package parser;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 
 import helpers.Helpers;
 import org.junit.Test;
@@ -296,5 +297,39 @@ public class TestDungeonASTConverter {
         var propertyDef = (PropertyDefNode) componentDef.getPropertyDefinitionNodes().get(0);
         var stmtNode = propertyDef.getStmtNode();
         assertEquals(stmtNode.type, Node.Type.AggregateValueDefinition);
+    }
+
+
+    @Test
+    public void funcDef() {
+        String program =
+            """
+        fn test_func(int param1, float param2, string param3) -> ret_type {
+            print("hello");
+        }
+        """;
+
+        var ast = Helpers.getASTFromString(program);
+        var funcDefNode = (FuncDefNode) ast.getChild(0);
+
+        assertEquals(Node.Type.FuncDef, funcDefNode.type);
+        assertEquals("test_func", funcDefNode.getIdName());
+        assertEquals("ret_type", funcDefNode.getRetTypeName());
+
+        var parameters = funcDefNode.getParameters();
+        for (var parameter : parameters) {
+            assertEquals(Node.Type.ParamDef, parameter.type);
+        }
+        assertEquals("param1", ((ParamDefNode)parameters.get(0)).getIdName());
+        assertEquals("param2", ((ParamDefNode)parameters.get(1)).getIdName());
+        assertEquals("param3", ((ParamDefNode)parameters.get(2)).getIdName());
+        assertEquals("int", ((ParamDefNode)parameters.get(0)).getTypeName());
+        assertEquals("float", ((ParamDefNode)parameters.get(1)).getTypeName());
+        assertEquals("string", ((ParamDefNode)parameters.get(2)).getTypeName());
+
+        var stmts = funcDefNode.getStmts();
+        assertEquals(Node.Type.FuncCall, stmts.get(0).type);
+
+        assertNotEquals(Node.NONE, funcDefNode);
     }
 }


### PR DESCRIPTION
Fixes #344 

Fügt Klassen für nötige AST-Knoten (`ParamDefNode` und `FuncDefNode`) hinzu.
Implementiert Zusammenfassung von Knoten in DungeonASTConverter.
Fügt zwei Testfälle für AST-Konvertierung von Funktionsdefinitionen hinzu.