### PR TITLE
[GAME] add Skill Cool Down

### DIFF
--- a/game/src/ecs/components/skill/Skill.java
+++ b/game/src/ecs/components/skill/Skill.java
@@ -1,22 +1,21 @@
 package ecs.components.skill;
 
 import ecs.entities.Entity;
-import graphic.Animation;
+import tools.Constants;
 
 public class Skill {
 
-    private boolean active;
-    private Animation animation;
     private ISkillFunction skillFunction;
+    private int coolDownInFrames;
+    private int currentCoolDownInFrames;
 
     /**
-     * @param animation Animation of this skill
      * @param skillFunction Function of this skill
      */
-    public Skill(Animation animation, ISkillFunction skillFunction) {
-        this.animation = animation;
+    public Skill(ISkillFunction skillFunction, float coolDownInSeconds) {
         this.skillFunction = skillFunction;
-        active = true;
+        this.coolDownInFrames = (int) (coolDownInSeconds * Constants.FRAME_RATE);
+        this.currentCoolDownInFrames = 0;
     }
 
     /**
@@ -25,24 +24,26 @@ public class Skill {
      * @param entity entity which uses the skill
      */
     public void execute(Entity entity) {
-        if (active) {
+        if (!isOnCoolDown()) {
             skillFunction.execute(entity);
+            activateCoolDown();
         }
     }
 
-    /** Toggle the active state of this skill */
-    public void toggleActive() {
-        active = !active;
-    }
-
     /**
-     * @return if this skill is currently active or not
+     * @return true if cool down is not 0, else false
      */
-    public boolean getActive() {
-        return active;
+    public boolean isOnCoolDown() {
+        return currentCoolDownInFrames > 0;
     }
 
-    public Animation getAnimation() {
-        return animation;
+    /** activate cool down */
+    public void activateCoolDown() {
+        currentCoolDownInFrames = coolDownInFrames;
+    }
+
+    /** reduces the current cool down by frame */
+    public void reduceCoolDown() {
+        currentCoolDownInFrames = Math.max(0, --currentCoolDownInFrames);
     }
 }

--- a/game/test/ecs/components/SkillTest.java
+++ b/game/test/ecs/components/SkillTest.java
@@ -5,55 +5,49 @@ import static org.junit.Assert.*;
 import ecs.components.skill.ISkillFunction;
 import ecs.components.skill.Skill;
 import ecs.entities.Entity;
-import graphic.Animation;
-import org.junit.Before;
+import org.junit.After;
 import org.junit.Test;
-import org.mockito.Mockito;
+import tools.Constants;
 
 public class SkillTest {
 
     private static int value = 0;
+    private final int baseCoolDownInSeconds = 2;
 
     private Entity entity;
     private Skill skill;
     private ISkillFunction skillFunction = entity -> value++;
-    private Animation animation = Mockito.mock(Animation.class);
 
-    @Before
-    public void setup() {
-        entity = new Entity();
-        skill = new Skill(animation, skillFunction);
+    @After
+    public void cleanup() {
+        value = 0;
     }
 
     @Test
-    public void execute_active() {
-        value = 0;
+    public void execute() {
+        // setup
+        entity = new Entity();
+        skill = new Skill(skillFunction, baseCoolDownInSeconds);
+
+        // test first execution
+        assertFalse(skill.isOnCoolDown());
         skill.execute(entity);
         assertEquals(1, value);
-    }
 
-    @Test
-    public void execute_inactive() {
-        value = 0;
-        skill.toggleActive();
-        assertFalse(skill.getActive());
+        // should not execute on cool down
+        assertTrue(skill.isOnCoolDown());
         skill.execute(entity);
-        assertEquals(0, value);
-    }
+        assertEquals(1, value);
 
-    @Test
-    public void toogle() {
-        assertTrue(skill.getActive());
-        skill.toggleActive();
-        ;
-        assertFalse(skill.getActive());
-        skill.toggleActive();
-        ;
-        assertTrue(skill.getActive());
-    }
+        // reduce cool down to 0
+        for (int i = 0; i < (baseCoolDownInSeconds * Constants.FRAME_RATE); i++) {
+            assertTrue(skill.isOnCoolDown());
+            skill.reduceCoolDown();
+        }
 
-    @Test
-    public void getAnimation() {
-        assertEquals(animation, skill.getAnimation());
+        // execution after cool down is over
+        assertFalse(skill.isOnCoolDown());
+        skill.execute(entity);
+        assertEquals(2, value);
     }
 }


### PR DESCRIPTION
fixes #221 
 - Cool Down in Skill implementiert
     - Cool Down wird im ctor in Sekunden angegeben und nach Frames umgerechnet
     - ´coolDownInFrames´ ist die Anzahl der Frames, die der Cool Down hat
     - ´currentCoolDownInFrames´ ist die verbleibende Anzahl an Frames 
     - [wie von @cagix angemerkt](https://github.com/Programmiermethoden/Dungeon/issues/221#issuecomment-1437329283): jeder Skill gehört zu einer Entität und daher wird der Cool Down im Skill gespeichert
 - Tests angepasst
 - YAGNI unnötige Methoden weggeworfen (wie im Meeting besprochen)

Fehlend:
- [ ] Dokumentation