### PR TITLE
[GAME] fix getRandomTile mögliche Endlosschleife

### DIFF
--- a/game/src/level/elements/ILevel.java
+++ b/game/src/level/elements/ILevel.java
@@ -211,4 +211,28 @@ public interface ILevel extends ITileable {
             level.setEndTile(newTile);
         }
     }
+
+    @Override
+    default Tile getRandomTile(LevelElement elementType) {
+        return switch (elementType) {
+            case SKIP -> getSkipTiles().size() > 0
+                    ? getSkipTiles().get(RANDOM.nextInt(getSkipTiles().size()))
+                    : null;
+            case FLOOR -> getFloorTiles().size() > 0
+                    ? getFloorTiles().get(RANDOM.nextInt(getFloorTiles().size()))
+                    : null;
+            case WALL -> getWallTiles().size() > 0
+                    ? getWallTiles().get(RANDOM.nextInt(getWallTiles().size()))
+                    : null;
+            case HOLE -> getHoleTiles().size() > 0
+                    ? getHoleTiles().get(RANDOM.nextInt(getHoleTiles().size()))
+                    : null;
+            case EXIT -> getExitTiles().size() > 0
+                    ? getExitTiles().get(RANDOM.nextInt(getExitTiles().size()))
+                    : null;
+            case DOOR -> getDoorTiles().size() > 0
+                    ? getDoorTiles().get(RANDOM.nextInt(getDoorTiles().size()))
+                    : null;
+        };
+    }
 }

--- a/game/src/level/elements/ITileable.java
+++ b/game/src/level/elements/ITileable.java
@@ -83,14 +83,8 @@ public interface ITileable extends IPathable {
      * @param elementType Type of the Tile
      * @return A random Tile of the given Type
      */
-    default Tile getRandomTile(LevelElement elementType) {
-        Tile randomTile = getRandomTile();
-        if (randomTile.getLevelElement() == elementType) {
-            return randomTile;
-        } else {
-            return getRandomTile(elementType);
-        }
-    }
+    Tile getRandomTile(LevelElement elementType);
+
     /**
      * Get the position of a random Tile as Point
      *

--- a/game/test/level/TileLevelTest.java
+++ b/game/test/level/TileLevelTest.java
@@ -164,6 +164,22 @@ public class TileLevelTest {
 
     @Test
     public void test_getRandomTile_WithElementType() {
+        LevelElement[][] layout = new LevelElement[3][3];
+        for (int x = 0; x < 3; x++) {
+            for (int y = 0; y < 3; y++) {
+                if (x < 2) {
+                    layout[y][x] = LevelElement.FLOOR;
+                } else {
+                    layout[y][x] = LevelElement.WALL;
+                }
+            }
+        }
+        layout[2][1] = LevelElement.EXIT;
+
+        TileLevel tileLevel = new TileLevel(layout, DesignLabel.DEFAULT);
+        Tile endTile = tileLevel.getEndTile();
+        Tile startTile = tileLevel.getStartTile();
+
         Point randomWallPoint = tileLevel.getRandomTilePoint(LevelElement.WALL);
         assertNotNull(randomWallPoint);
         Tile randomWall = tileLevel.getTileAt(randomWallPoint.toCoordinate());
@@ -180,6 +196,22 @@ public class TileLevelTest {
 
     @Test
     public void test_getRandomTilePoint_WithElementType() {
+        LevelElement[][] layout = new LevelElement[3][3];
+        for (int x = 0; x < 3; x++) {
+            for (int y = 0; y < 3; y++) {
+                if (x < 2) {
+                    layout[y][x] = LevelElement.FLOOR;
+                } else {
+                    layout[y][x] = LevelElement.WALL;
+                }
+            }
+        }
+        layout[2][1] = LevelElement.EXIT;
+
+        TileLevel tileLevel = new TileLevel(layout, DesignLabel.DEFAULT);
+        Tile endTile = tileLevel.getEndTile();
+        Tile startTile = tileLevel.getStartTile();
+
         Point randomWallPoint = tileLevel.getRandomTilePoint(LevelElement.WALL);
         Point randomFloorPoint = tileLevel.getRandomTilePoint(LevelElement.FLOOR);
         Tile randomWall = tileLevel.getTileAt(randomWallPoint.toCoordinate());


### PR DESCRIPTION
#312 

getRandomTile war möglich eine Endlosschleife zu sein.

Gründe für die Schleife:
- ElementTyp nicht vorhanden 
- Random gibt nur Felder zurück, welche nicht vom Typ sind.

Zum Lösen wurde die Suche nach einem Tile mit einem bestimmten Elementtyp von ITileable nach ILevel bewegt.
Dann wurde die speziellen Listen benutzt, um das Tile zu suchen. Außerdem wurde eine Kontrolle eingeführt, ob es überhaupt ein Tile des Types gibt.