### PR TITLE
[GAME] Change Exit/StartTile

### DIFF
--- a/game/src/level/elements/ILevel.java
+++ b/game/src/level/elements/ILevel.java
@@ -82,28 +82,7 @@ public interface ILevel extends ITileable {
      *
      * @param tile tile to add
      */
-    default void addTile(Tile tile) {
-        switch (tile.getLevelElement()) {
-            case SKIP -> {
-                addSkipTile((SkipTile) tile);
-            }
-            case FLOOR -> {
-                addFloorTile((FloorTile) tile);
-            }
-            case WALL -> {
-                addWallTile((WallTile) tile);
-            }
-            case HOLE -> {
-                addHoleTile((HoleTile) tile);
-            }
-            case EXIT -> {
-                addExitTile((ExitTile) tile);
-            }
-            case DOOR -> {
-                addDoorTile((DoorTile) tile);
-            }
-        }
-    }
+    void addTile(Tile tile);
 
     /**
      * Removes tile from the level
@@ -199,13 +178,7 @@ public interface ILevel extends ITileable {
                         changeInto,
                         tile.getDesignLabel(),
                         level);
-        // newTile.setIndex(tile.getIndex());
         level.addTile(newTile);
-        // level.addConnectionsToNeighbours(newTile);
-        // for (Connection<Tile> neighbor : newTile.getConnections().items) {
-        //    Tile n = neighbor.getToNode();
-        //    n.addConnection(newTile);
-        // }
         level.getLayout()[tile.getCoordinate().y][tile.getCoordinate().x] = newTile;
         if (changeInto == LevelElement.EXIT) {
             level.setEndTile(newTile);

--- a/game/src/level/elements/TileLevel.java
+++ b/game/src/level/elements/TileLevel.java
@@ -241,10 +241,12 @@ public class TileLevel implements ILevel {
             case EXIT -> addExitTile((ExitTile) tile);
             case DOOR -> addDoorTile((DoorTile) tile);
         }
-        this.addConnectionsToNeighbours(tile);
-        for (Connection<Tile> neighbor : tile.getConnections().items) {
-            Tile n = neighbor.getToNode();
-            n.addConnection(tile);
+        if(tile.isAccessible()){
+            this.addConnectionsToNeighbours(tile);
+            for (Connection<Tile> neighbor : tile.getConnections().items) {
+                Tile n = neighbor.getToNode();
+                n.addConnection(tile);
+            }
         }
 
         nodeCount++;

--- a/game/src/level/elements/TileLevel.java
+++ b/game/src/level/elements/TileLevel.java
@@ -1,5 +1,6 @@
 package level.elements;
 
+import com.badlogic.gdx.ai.pfa.Connection;
 import java.util.ArrayList;
 import java.util.List;
 import level.elements.astar.TileHeuristic;
@@ -212,7 +213,40 @@ public class TileLevel implements ILevel {
                 doorTiles.remove(tile);
             }
         }
+        // remove all connections to the removed Tile
+        tile.getConnections()
+                .forEach(
+                        x ->
+                                x.getToNode()
+                                        .getConnections()
+                                        .forEach(
+                                                y -> {
+                                                    if (y.getToNode() == tile)
+                                                        x.getToNode()
+                                                                .getConnections()
+                                                                .removeValue(y, true);
+                                                }));
+
         nodeCount--;
+    }
+
+    @Override
+    public void addTile(Tile tile) {
+        switch (tile.getLevelElement()) {
+            case SKIP -> addSkipTile((SkipTile) tile);
+            case FLOOR -> addFloorTile((FloorTile) tile);
+            case WALL -> addWallTile((WallTile) tile);
+            case HOLE -> addHoleTile((HoleTile) tile);
+            case EXIT -> addExitTile((ExitTile) tile);
+            case DOOR -> addDoorTile((DoorTile) tile);
+        }
+        this.addConnectionsToNeighbours(tile);
+        for (Connection<Tile> neighbor : tile.getConnections().items) {
+            Tile n = neighbor.getToNode();
+            n.addConnection(tile);
+        }
+
+        nodeCount++;
     }
 
     @Override

--- a/game/src/level/elements/TileLevel.java
+++ b/game/src/level/elements/TileLevel.java
@@ -148,10 +148,11 @@ public class TileLevel implements ILevel {
 
     @Override
     public void addExitTile(ExitTile tile) {
-        if (exitTiles.isEmpty()) {
-            setEndTile(tile);
+        if (getEndTile() != null) {
+            changeTileElementType(getEndTile(), LevelElement.FLOOR);
         }
         exitTiles.add(tile);
+        setEndTile(tile);
     }
 
     @Override

--- a/game/src/level/elements/TileLevel.java
+++ b/game/src/level/elements/TileLevel.java
@@ -227,8 +227,8 @@ public class TileLevel implements ILevel {
                                                                 .getConnections()
                                                                 .removeValue(y, true);
                                                 }));
-
-        nodeCount--;
+        // TODO better fix
+        if (tile.isAccessible()) nodeCount--;
     }
 
     @Override
@@ -241,15 +241,15 @@ public class TileLevel implements ILevel {
             case EXIT -> addExitTile((ExitTile) tile);
             case DOOR -> addDoorTile((DoorTile) tile);
         }
-        if(tile.isAccessible()){
+        if (tile.isAccessible()) {
             this.addConnectionsToNeighbours(tile);
             for (Connection<Tile> neighbor : tile.getConnections().items) {
                 Tile n = neighbor.getToNode();
                 n.addConnection(tile);
             }
+            // TODO Better fix
+            nodeCount++;
         }
-
-        nodeCount++;
     }
 
     @Override


### PR DESCRIPTION
#308 

Start und Endtile waren bekannt dafür Probleme zu machen, wenn sie abgeändert wurden. Dies war aber bei allen Tiles so. Es wurden Verbindungen nicht entfernt sowie wurden dem neuen Tile nicht zugewiesen wurde.

Der Nodecount darf auch nur abgeändert werden, wenn es sich wirklich um einen Knoten der für das Pfadfinden handelt. 