### PR TITLE
[REPO] add Codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,7 +8,7 @@
 /dsl/ @malt-r @Programmiermethoden/dungeon
 
 #dsl connector owner
-/dsl-connector/ @malt-r @AMatutat
+/dsl-connector/ @malt-r @AMatutat @Programmiermethoden/dungeon
 
 #doc folder
 /doc/ @Programmiermethoden/dungeon

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,3 +10,5 @@
 #dsl connector owner
 /dsl-connector/ @malt-r @AMatutat
 
+#doc folder
+/doc/ @Programmiermethoden/dungeon

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,11 +2,11 @@
 * @cagix
 
 # game owner
-/game/ @AMatutat @cagix
+/game/ @AMatutat
 
 # dsl owner
-/dsl/ @malt-r @cagix
+/dsl/ @malt-r
 
 #dsl connector owner
-/dsl-connector/ @malt-r @AMatutat @cagix
+/dsl-connector/ @malt-r @AMatutat
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,7 @@
 * @cagix
 
 # game owner
-/game/ @AMatutat
+/game/ @AMatutat @codr
 
 # dsl owner
 /dsl/ @malt-r

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,12 @@
+# global owner
+* @cagix
+
+# game owner
+/game/ @AMatutat @cagix
+
+# dsl owner
+/dsl/ @malt-r @cagix
+
+#dsl connector owner
+/dsl-connector/ @malt-r @AMatutat @cagix
+

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,7 @@
 * @cagix
 
 # game owner
-/game/ @AMatutat @codr
+/game/ @AMatutat @Programmiermethoden/codrs
 
 # dsl owner
 /dsl/ @malt-r

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,7 +5,7 @@
 /game/ @AMatutat @Programmiermethoden/codrs
 
 # dsl owner
-/dsl/ @malt-r
+/dsl/ @malt-r @Programmiermethoden/dungeon
 
 #dsl connector owner
 /dsl-connector/ @malt-r @AMatutat


### PR DESCRIPTION
fixes #480 

- Hinzufügen von Code-Owners
   - Cagix ist global owner
   - malte ist owner der `dsl`
   - andre und @Programmiermethoden/codrs sind owner des `game`
   - ander und malte sind owner des `dsl-connector`
   - Anmerkung: Als global owner ist cagix **nicht** owner von `game`, `dsl` und `dsl-connector`
- [ ] Repo Settings einstellen
  - enable: Require review from Code Owners
  - disable: Require approvals
- [ ] Test Repo entfernen