### PR TITLE
[GAME] add better level size generation options

### DIFF
--- a/game/src/level/LevelAPI.java
+++ b/game/src/level/LevelAPI.java
@@ -11,6 +11,7 @@ import level.elements.tile.Tile;
 import level.generator.IGenerator;
 import level.tools.DesignLabel;
 import level.tools.LevelElement;
+import level.tools.LevelSize;
 
 /** Manages the level. */
 public class LevelAPI {
@@ -38,22 +39,39 @@ public class LevelAPI {
         this.onLevelLoader = onLevelLoader;
     }
 
-    /** Load a new level. */
-    public void loadLevel() {
-        currentLevel = gen.getLevel();
+    /**
+     * Load a new Level
+     *
+     * @param size The size that the level should have
+     * @param label The design that the level should have
+     */
+    public void loadLevel(LevelSize size, DesignLabel label) {
+        currentLevel = gen.getLevel(label, size);
         onLevelLoader.onLevelLoad();
-
         levelAPI_logger.info("A new level was loaded.");
     }
 
     /**
-     * Load a new level
+     * Load a new level with random size and the given desing
      *
      * @param designLabel The design that the level should have
      */
     public void loadLevel(DesignLabel designLabel) {
-        currentLevel = gen.getLevel(designLabel);
-        onLevelLoader.onLevelLoad();
+        loadLevel(LevelSize.randomSize(), designLabel);
+    }
+
+    /**
+     * Load a new level with the given size and a random desing
+     *
+     * @param size wanted size of the level
+     */
+    public void loadLevel(LevelSize size) {
+        loadLevel(size, DesignLabel.randomDesign());
+    }
+
+    /** Load a new level with random size and random design. */
+    public void loadLevel() {
+        loadLevel(LevelSize.randomSize(), DesignLabel.randomDesign());
     }
 
     /** Draw level */

--- a/game/src/starter/Game.java
+++ b/game/src/starter/Game.java
@@ -34,11 +34,15 @@ import level.elements.tile.Tile;
 import level.generator.IGenerator;
 import level.generator.postGeneration.WallGenerator;
 import level.generator.randomwalk.RandomWalkGenerator;
+import level.tools.LevelSize;
 import tools.Constants;
 import tools.Point;
 
 /** The heart of the framework. From here all strings are pulled. */
 public class Game extends ScreenAdapter implements IOnLevelLoader {
+
+    private final LevelSize LEVELSIZE = LevelSize.SMALL;
+
     /**
      * The batch is necessary to draw ALL the stuff. Every object that uses draw need to know the
      * batch.
@@ -89,7 +93,7 @@ public class Game extends ScreenAdapter implements IOnLevelLoader {
                                 .orElseThrow(
                                         () -> new MissingComponentException("PositionComponent"));
         levelAPI = new LevelAPI(batch, painter, new WallGenerator(new RandomWalkGenerator()), this);
-        levelAPI.loadLevel();
+        levelAPI.loadLevel(LEVELSIZE);
 
         new VelocitySystem();
         new DrawSystem(painter);
@@ -109,7 +113,7 @@ public class Game extends ScreenAdapter implements IOnLevelLoader {
             gameLogger.info("Entity '" + entity.getClass().getSimpleName() + "' was deleted.");
         }
         entitiesToRemove.clear();
-        if (isOnEndTile()) levelAPI.loadLevel();
+        if (isOnEndTile()) levelAPI.loadLevel(LEVELSIZE);
         if (Gdx.input.isKeyJustPressed(Input.Keys.P)) togglePause();
     }
 

--- a/game/test/level/TileLevelAPITest.java
+++ b/game/test/level/TileLevelAPITest.java
@@ -1,6 +1,7 @@
 package level;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.times;
@@ -20,6 +21,7 @@ import level.generator.IGenerator;
 import level.tools.Coordinate;
 import level.tools.DesignLabel;
 import level.tools.LevelElement;
+import level.tools.LevelSize;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -61,9 +63,9 @@ public class TileLevelAPITest {
 
     @Test
     public void test_loadLevel() {
-        when(generator.getLevel()).thenReturn(level);
-        api.loadLevel();
-        verify(generator).getLevel();
+        when(generator.getLevel(Mockito.any(), Mockito.any())).thenReturn(level);
+        api.loadLevel(LevelSize.SMALL, DesignLabel.DEFAULT);
+        verify(generator).getLevel(DesignLabel.DEFAULT, LevelSize.SMALL);
         Mockito.verifyNoMoreInteractions(generator);
         verify(onLevelLoader).onLevelLoad();
         Mockito.verifyNoMoreInteractions(onLevelLoader);
@@ -71,10 +73,32 @@ public class TileLevelAPITest {
     }
 
     @Test
-    public void test_loadLevel_withDesign() {
-        when(generator.getLevel(DesignLabel.DEFAULT)).thenReturn(level);
+    public void test_loadLevel_noParameter() {
+        when(generator.getLevel(Mockito.any(), Mockito.any())).thenReturn(level);
+        api.loadLevel();
+        verify(generator).getLevel(Mockito.any(), Mockito.any());
+        Mockito.verifyNoMoreInteractions(generator);
+        verify(onLevelLoader).onLevelLoad();
+        Mockito.verifyNoMoreInteractions(onLevelLoader);
+        assertEquals(level, api.getCurrentLevel());
+    }
+
+    @Test
+    public void test_loadLevel_withDesign_noSize() {
+        when(generator.getLevel(eq(DesignLabel.DEFAULT), any())).thenReturn(level);
         api.loadLevel(DesignLabel.DEFAULT);
-        verify(generator).getLevel(DesignLabel.DEFAULT);
+        verify(generator).getLevel(eq(DesignLabel.DEFAULT), any());
+        Mockito.verifyNoMoreInteractions(generator);
+        verify(onLevelLoader).onLevelLoad();
+        Mockito.verifyNoMoreInteractions(onLevelLoader);
+        assertEquals(level, api.getCurrentLevel());
+    }
+
+    @Test
+    public void test_loadLevel_noDesign_WithSize() {
+        when(generator.getLevel(any(), eq(LevelSize.SMALL))).thenReturn(level);
+        api.loadLevel(LevelSize.SMALL);
+        verify(generator).getLevel(any(), eq(LevelSize.SMALL));
         Mockito.verifyNoMoreInteractions(generator);
         verify(onLevelLoader).onLevelLoad();
         Mockito.verifyNoMoreInteractions(onLevelLoader);


### PR DESCRIPTION
fixes #492 

- `LevelAPI` um Parametisierte `loadLevel` Methoden erweitert
- `Game` lädt in der default Konfiguration nun immer kleine Level (ist besser zum testen)


