### PR TITLE
[Game] Tilelevel verhalten aufräumen

### DIFF
--- a/game/src/level/elements/ILevel.java
+++ b/game/src/level/elements/ILevel.java
@@ -21,11 +21,15 @@ public interface ILevel extends ITileable {
 
     /** Mark a random tile as end */
     default void setRandomEnd() {
-        Tile newEnd = getRandomTile(LevelElement.FLOOR);
-        while (newEnd == getStartTile()) {
-            newEnd = getRandomTile(LevelElement.FLOOR);
+        List<FloorTile> floorTiles = getFloorTiles();
+        if (floorTiles.size() <= 1) {
+            // not enough Tiles for startTile and ExitTile
+            return;
         }
-        changeTileElementType(newEnd, LevelElement.EXIT);
+        int startTileIndex = floorTiles.indexOf(getStartTile());
+        int index = RANDOM.nextInt(floorTiles.size() - 1);
+        changeTileElementType(
+                floorTiles.get(index < startTileIndex ? index : index + 1), LevelElement.EXIT);
     }
 
     /**

--- a/game/src/level/elements/ILevel.java
+++ b/game/src/level/elements/ILevel.java
@@ -176,10 +176,9 @@ public interface ILevel extends ITileable {
                         TileTextureFactory.findTexturePath(tile, getLayout(), changeInto),
                         tile.getCoordinate(),
                         changeInto,
-                        tile.getDesignLabel(),
-                        level);
-        level.addTile(newTile);
+                        tile.getDesignLabel());
         level.getLayout()[tile.getCoordinate().y][tile.getCoordinate().x] = newTile;
+        level.addTile(newTile);
         if (changeInto == LevelElement.EXIT) {
             level.setEndTile(newTile);
         }

--- a/game/src/level/elements/ILevel.java
+++ b/game/src/level/elements/ILevel.java
@@ -29,13 +29,6 @@ public interface ILevel extends ITileable {
     }
 
     /**
-     * Set the end tile.
-     *
-     * @param end The end tile.
-     */
-    void setEndTile(Tile end);
-
-    /**
      * Add floor tile to level.
      *
      * @param tile new floor tile
@@ -179,9 +172,6 @@ public interface ILevel extends ITileable {
                         tile.getDesignLabel());
         level.getLayout()[tile.getCoordinate().y][tile.getCoordinate().x] = newTile;
         level.addTile(newTile);
-        if (changeInto == LevelElement.EXIT) {
-            level.setEndTile(newTile);
-        }
     }
 
     @Override

--- a/game/src/level/elements/ITileable.java
+++ b/game/src/level/elements/ITileable.java
@@ -50,20 +50,6 @@ public interface ITileable extends IPathable {
      * @return The start tile.
      */
     Tile getStartTile();
-    /**
-     * Checks if the passed entity is on the tile to the next level.
-     *
-     * @param entity entity to check for.
-     * @return if the passed entity is on the tile to the next level
-     */
-    default boolean isOnEndTile(Entity entity) {
-        if (getEndTile() == null) {
-            return false;
-        }
-        PositionComponent pc =
-                (PositionComponent) entity.getComponent(PositionComponent.class).get();
-        return pc.getPosition().toCoordinate().equals(getEndTile().getCoordinate());
-    }
 
     /**
      * Returns the tile the given entity is standing on.

--- a/game/src/level/elements/TileLevel.java
+++ b/game/src/level/elements/TileLevel.java
@@ -18,7 +18,6 @@ import level.tools.TileTextureFactory;
 public class TileLevel implements ILevel {
     protected final TileHeuristic tileHeuristic = new TileHeuristic();
     protected Tile startTile;
-    protected Tile endTile;
     protected int nodeCount = 0;
     protected Tile[][] layout;
 
@@ -245,11 +244,14 @@ public class TileLevel implements ILevel {
 
     @Override
     public Tile getEndTile() {
-        return endTile;
+        return exitTiles.size() > 0 ? exitTiles.get(0) : null;
     }
 
     @Override
     public void setEndTile(Tile end) {
-        endTile = end;
+        exitTiles.clear();
+        if (end != null) {
+            exitTiles.add((ExitTile) end);
+        }
     }
 }

--- a/game/src/level/elements/TileLevel.java
+++ b/game/src/level/elements/TileLevel.java
@@ -74,8 +74,7 @@ public class TileLevel implements ILevel {
                                 new TileTextureFactory.LevelPart(
                                         layout[y][x], designLabel, layout, coordinate));
                 tileLayout[y][x] =
-                        TileFactory.createTile(
-                                texturePath, coordinate, layout[y][x], designLabel, this);
+                        TileFactory.createTile(texturePath, coordinate, layout[y][x], designLabel);
             }
         }
         return tileLayout;

--- a/game/src/level/elements/TileLevel.java
+++ b/game/src/level/elements/TileLevel.java
@@ -149,7 +149,6 @@ public class TileLevel implements ILevel {
     public List<FloorTile> getFloorTiles() {
         return floorTiles;
     }
-    ;
 
     @Override
     public List<WallTile> getWallTiles() {

--- a/game/src/level/elements/TileLevel.java
+++ b/game/src/level/elements/TileLevel.java
@@ -39,9 +39,9 @@ public class TileLevel implements ILevel {
      */
     public TileLevel(Tile[][] layout) {
         this.layout = layout;
-        makeConnections();
-        // setRandomEnd();
-        setRandomStart();
+        putTilesInLists();
+        if (exitTiles.size() == 0) setRandomEnd();
+        if (startTile == null) setRandomStart();
     }
 
     /**
@@ -51,10 +51,15 @@ public class TileLevel implements ILevel {
      * @param designLabel The design the level should have
      */
     public TileLevel(LevelElement[][] layout, DesignLabel designLabel) {
-        this.layout = convertLevelElementToTile(layout, designLabel);
-        makeConnections();
-        // setRandomEnd();
-        setRandomStart();
+        this(convertLevelElementToTile(layout, designLabel));
+    }
+
+    private void putTilesInLists() {
+        for (int y = 0; y < layout.length; y++) {
+            for (int x = 0; x < layout[0].length; x++) {
+                addTile(layout[y][x]);
+            }
+        }
     }
 
     /**
@@ -64,7 +69,8 @@ public class TileLevel implements ILevel {
      * @param designLabel The selected Design for the Tiles
      * @return The converted Tile[][]
      */
-    protected Tile[][] convertLevelElementToTile(LevelElement[][] layout, DesignLabel designLabel) {
+    private static Tile[][] convertLevelElementToTile(
+            LevelElement[][] layout, DesignLabel designLabel) {
         Tile[][] tileLayout = new Tile[layout.length][layout[0].length];
         for (int y = 0; y < layout.length; y++) {
             for (int x = 0; x < layout[0].length; x++) {
@@ -88,24 +94,6 @@ public class TileLevel implements ILevel {
     @Override
     public TileHeuristic getTileHeuristic() {
         return tileHeuristic;
-    }
-
-    /** Connect each tile with its neighbour tiles. */
-    protected void makeConnections() {
-        for (int x = 0; x < layout[0].length; x++) {
-            for (Tile[] tiles : layout) {
-                if (tiles[x].getLevel() == null) {
-                    tiles[x].setLevel(this);
-                }
-                if (endTile == null && tiles[x].getLevelElement() == LevelElement.EXIT) {
-                    setEndTile(tiles[x]);
-                }
-                if (tiles[x].isAccessible()) {
-                    tiles[x].setIndex(nodeCount++);
-                    addConnectionsToNeighbours(tiles[x]);
-                }
-            }
-        }
     }
 
     /**

--- a/game/src/level/elements/TileLevel.java
+++ b/game/src/level/elements/TileLevel.java
@@ -3,9 +3,6 @@ package level.elements;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-
-import com.badlogic.gdx.ai.pfa.Connection;
-import com.badlogic.gdx.utils.Array;
 import level.elements.astar.TileConnection;
 import level.elements.astar.TileHeuristic;
 import level.elements.tile.*;
@@ -110,8 +107,11 @@ public class TileLevel implements ILevel {
                     new Coordinate(
                             checkTile.getCoordinate().x + v.x, checkTile.getCoordinate().y + v.y);
             Tile t = getTileAt(c);
-            if (t != null && t.isAccessible() &&
-                !checkTile.getConnections().contains(new TileConnection(checkTile,t),false)) {
+            if (t != null
+                    && t.isAccessible()
+                    && !checkTile
+                            .getConnections()
+                            .contains(new TileConnection(checkTile, t), false)) {
                 checkTile.addConnection(t);
             }
         }
@@ -195,7 +195,9 @@ public class TileLevel implements ILevel {
                 .forEach(
                         x ->
                                 x.getToNode()
-                                        .getConnections().removeValue(new TileConnection(x.getToNode(), tile),false));
+                                        .getConnections()
+                                        .removeValue(
+                                                new TileConnection(x.getToNode(), tile), false));
         if (tile.isAccessible()) removeIndex(tile.getIndex());
     }
 
@@ -218,10 +220,14 @@ public class TileLevel implements ILevel {
         }
         if (tile.isAccessible()) {
             this.addConnectionsToNeighbours(tile);
-            tile.getConnections().forEach(x -> {
-                if(!x.getToNode().getConnections().contains(new TileConnection(x.getToNode(),tile), false))
-                    x.getToNode().addConnection(tile);
-            });
+            tile.getConnections()
+                    .forEach(
+                            x -> {
+                                if (!x.getToNode()
+                                        .getConnections()
+                                        .contains(new TileConnection(x.getToNode(), tile), false))
+                                    x.getToNode().addConnection(tile);
+                            });
             tile.setIndex(nodeCount++);
         }
         tile.setLevel(this);

--- a/game/src/level/elements/TileLevel.java
+++ b/game/src/level/elements/TileLevel.java
@@ -196,7 +196,8 @@ public class TileLevel implements ILevel {
                                         .forEach(
                                                 y -> { // alle verbindungen ausgehend
                                                     if (y.getToNode() == tile)
-                                                        y.getFromNode().getConnections()
+                                                        y.getFromNode()
+                                                                .getConnections()
                                                                 .removeValue(y, true);
                                                 }));
         if (tile.isAccessible()) removeIndex(tile.getIndex());

--- a/game/src/level/elements/TileLevel.java
+++ b/game/src/level/elements/TileLevel.java
@@ -138,7 +138,6 @@ public class TileLevel implements ILevel {
             changeTileElementType(getEndTile(), LevelElement.FLOOR);
         }
         exitTiles.add(tile);
-        setEndTile(tile);
     }
 
     @Override
@@ -223,9 +222,9 @@ public class TileLevel implements ILevel {
         if (tile.isAccessible()) {
             this.addConnectionsToNeighbours(tile);
             tile.getConnections().forEach(x -> x.getToNode().addConnection(tile));
-
             tile.setIndex(nodeCount++);
         }
+        tile.setLevel(this);
     }
 
     @Override
@@ -246,13 +245,5 @@ public class TileLevel implements ILevel {
     @Override
     public Tile getEndTile() {
         return exitTiles.size() > 0 ? exitTiles.get(0) : null;
-    }
-
-    @Override
-    public void setEndTile(Tile end) {
-        exitTiles.clear();
-        if (end != null) {
-            exitTiles.add((ExitTile) end);
-        }
     }
 }

--- a/game/src/level/elements/TileLevel.java
+++ b/game/src/level/elements/TileLevel.java
@@ -39,8 +39,8 @@ public class TileLevel implements ILevel {
     public TileLevel(Tile[][] layout) {
         this.layout = layout;
         putTilesInLists();
-        if (exitTiles.size() == 0) setRandomEnd();
         if (startTile == null) setRandomStart();
+        if (exitTiles.size() == 0) setRandomEnd();
     }
 
     /**

--- a/game/src/level/elements/astar/TileConnection.java
+++ b/game/src/level/elements/astar/TileConnection.java
@@ -46,4 +46,9 @@ public class TileConnection implements Connection<Tile> {
     public Tile getToNode() {
         return to;
     }
+
+    @Override
+    public boolean equals(Object obj) {
+        return obj.getClass() == TileConnection.class && ((TileConnection)obj).from == from && ((TileConnection)obj).to == to;
+    }
 }

--- a/game/src/level/elements/astar/TileConnection.java
+++ b/game/src/level/elements/astar/TileConnection.java
@@ -49,6 +49,8 @@ public class TileConnection implements Connection<Tile> {
 
     @Override
     public boolean equals(Object obj) {
-        return obj.getClass() == TileConnection.class && ((TileConnection)obj).from == from && ((TileConnection)obj).to == to;
+        return obj.getClass() == TileConnection.class
+                && ((TileConnection) obj).from == from
+                && ((TileConnection) obj).to == to;
     }
 }

--- a/game/src/level/elements/tile/TileFactory.java
+++ b/game/src/level/elements/tile/TileFactory.java
@@ -7,41 +7,36 @@ import level.tools.LevelElement;
 
 public class TileFactory {
 
-    public static Tile createTile(
+    private static Tile createTile(
             String texturePath,
             Coordinate coordinate,
             LevelElement elementType,
             DesignLabel designLabel,
             ILevel level) {
-        switch (elementType) {
-            case FLOOR -> {
-                FloorTile tile = new FloorTile(texturePath, coordinate, designLabel, level);
-                level.addFloorTile(tile);
-                return tile;
-            }
-            case WALL -> {
-                WallTile tile = new WallTile(texturePath, coordinate, designLabel, level);
-                level.addWallTile(tile);
-                return tile;
-            }
-            case HOLE -> {
-                HoleTile tile = new HoleTile(texturePath, coordinate, designLabel, level);
-                level.addHoleTile(tile);
-                return tile;
-            }
-            case DOOR -> {
-                DoorTile tile = new DoorTile(texturePath, coordinate, designLabel, level);
-                level.addDoorTile(tile);
-                return tile;
-            }
-            case EXIT -> {
-                ExitTile tile = new ExitTile(texturePath, coordinate, designLabel, level);
-                level.addExitTile(tile);
-                return tile;
-            }
-        }
-        SkipTile tile = new SkipTile(texturePath, coordinate, designLabel, level);
-        level.addSkipTile(tile);
-        return tile;
+        return switch (elementType) {
+            case FLOOR -> new FloorTile(texturePath, coordinate, designLabel, level);
+            case WALL -> new WallTile(texturePath, coordinate, designLabel, level);
+            case HOLE -> new HoleTile(texturePath, coordinate, designLabel, level);
+            case DOOR -> new DoorTile(texturePath, coordinate, designLabel, level);
+            case EXIT -> new ExitTile(texturePath, coordinate, designLabel, level);
+            case SKIP -> new SkipTile(texturePath, coordinate, designLabel, level);
+        };
+    }
+
+    /**
+     * creates a new Tile which can then be added to the level
+     *
+     * @param texturePath the path to the texture
+     * @param coordinate the position of the newly created Tile
+     * @param elementType the type of the new Tile
+     * @param designLabel the label for reasons
+     * @return the newly created Tile
+     */
+    public static Tile createTile(
+            String texturePath,
+            Coordinate coordinate,
+            LevelElement elementType,
+            DesignLabel designLabel) {
+        return createTile(texturePath, coordinate, elementType, designLabel, null);
     }
 }

--- a/game/test/level/TileLevelTest.java
+++ b/game/test/level/TileLevelTest.java
@@ -130,6 +130,22 @@ public class TileLevelTest {
         assertSame(layout[0][1], layout[0][2].getConnections().first().getToNode());
     }
 
+    @Test
+    public void test_levelCTOR_LevelElements_tileTypeLists(){
+        LevelElement[][] elementsLayout =
+            new LevelElement[][] {
+                {LevelElement.FLOOR, LevelElement.FLOOR, LevelElement.EXIT, LevelElement.SKIP},
+                {LevelElement.WALL, LevelElement.WALL, LevelElement.SKIP, LevelElement.SKIP},
+                {LevelElement.DOOR, LevelElement.DOOR, LevelElement.HOLE, LevelElement.HOLE},
+            };
+        TileLevel tileLevel = new TileLevel(elementsLayout, DesignLabel.DEFAULT);
+        assertEquals(2,tileLevel.getFloorTiles().size());
+        assertEquals(2,tileLevel.getDoorTiles().size());
+        assertEquals(2,tileLevel.getHoleTiles().size());
+        assertEquals(2,tileLevel.getWallTiles().size());
+        assertEquals(3,tileLevel.getSkipTiles().size());
+    }
+
 
     @Test
     public void test_findPath_onlyOnePathPossible() {

--- a/game/test/level/TileLevelTest.java
+++ b/game/test/level/TileLevelTest.java
@@ -146,6 +146,68 @@ public class TileLevelTest {
         assertEquals(3,tileLevel.getSkipTiles().size());
     }
 
+    @Test
+    public void test_nodeCount_NoAccessible(){
+        LevelElement[][] elementsLayout =
+            new LevelElement[][] {
+                {LevelElement.WALL, LevelElement.WALL, LevelElement.WALL, LevelElement.WALL},
+            };
+        TileLevel tileLevel = new TileLevel(elementsLayout, DesignLabel.DEFAULT);
+        assertEquals(0,tileLevel.getNodeCount());
+    }
+
+    @Test
+    public void test_nodeCount_OneAccessible(){
+        LevelElement[][] elementsLayout =
+            new LevelElement[][] {
+                {LevelElement.FLOOR, LevelElement.WALL, LevelElement.WALL, LevelElement.WALL},
+            };
+        TileLevel tileLevel = new TileLevel(elementsLayout, DesignLabel.DEFAULT);
+        assertEquals(1,tileLevel.getNodeCount());
+    }
+
+    @Test
+    public void test_nodeCount_FourAccessible(){
+        LevelElement[][] elementsLayout =
+            new LevelElement[][] {
+                {LevelElement.FLOOR, LevelElement.FLOOR, LevelElement.FLOOR, LevelElement.FLOOR},
+            };
+        TileLevel tileLevel = new TileLevel(elementsLayout, DesignLabel.DEFAULT);
+        assertEquals(4,tileLevel.getNodeCount());
+    }
+
+    @Test
+    public void test_setRandomEnd(){
+        LevelElement[][] elementsLayout =
+            new LevelElement[][] {
+                {LevelElement.EXIT, LevelElement.FLOOR, LevelElement.FLOOR, LevelElement.FLOOR},
+            };
+        TileLevel tileLevel = new TileLevel(elementsLayout, DesignLabel.DEFAULT);
+        Tile oldEndTile = tileLevel.getEndTile();
+        assertNotSame(tileLevel.getStartTile(),tileLevel.getEndTile());
+        assertNotSame(oldEndTile, tileLevel.getEndTile());
+    }
+    @Test
+    public void test_setRandomEnd_NoFreeFloors(){
+        LevelElement[][] elementsLayout =
+            new LevelElement[][] {
+                {LevelElement.FLOOR},
+            };
+        TileLevel tileLevel = new TileLevel(elementsLayout, DesignLabel.DEFAULT);
+        assertNotSame(tileLevel.getStartTile(),tileLevel.getEndTile());
+        assertNull(tileLevel.getEndTile());
+    }
+    @Test
+    public void test_setRandomEnd_NoFloors(){
+        LevelElement[][] elementsLayout =
+            new LevelElement[][] {
+                {LevelElement.WALL},
+            };
+        TileLevel tileLevel = new TileLevel(elementsLayout, DesignLabel.DEFAULT);
+        tileLevel.setRandomEnd();
+        assertNull(tileLevel.getEndTile());
+    }
+
 
     @Test
     public void test_findPath_onlyOnePathPossible() {
@@ -310,24 +372,6 @@ public class TileLevelTest {
         Tile randomFloor = tileLevel.getTileAt(randomFloorPoint.toCoordinate());
         assertEquals(LevelElement.WALL, randomWall.getLevelElement());
         assertEquals(LevelElement.FLOOR, randomFloor.getLevelElement());
-    }
-
-    @Test
-    public void test_getLayout_from_TileLayout() {
-        Tile[][] tileLayout =
-                new Tile[][] {
-                    new Tile[] {
-                        new WallTile("", new Coordinate(0, 0), DesignLabel.DEFAULT, null),
-                        new FloorTile("", new Coordinate(1, 0), DesignLabel.DEFAULT, null),
-                    },
-                    new Tile[] {
-                        new FloorTile("", new Coordinate(0, 1), DesignLabel.DEFAULT, null),
-                        new WallTile("", new Coordinate(1, 1), DesignLabel.DEFAULT, null),
-                    }
-                };
-
-        var level = new TileLevel(tileLayout);
-        assertArrayEquals(tileLayout, level.getLayout());
     }
 
     @Test

--- a/game/test/level/TileLevelTest.java
+++ b/game/test/level/TileLevelTest.java
@@ -687,4 +687,26 @@ public class TileLevelTest {
                 .forEachOrdered(x -> assertEquals(counter.getAndIncrement(), x.getIndex()));
         assertEquals(2, counter.get());
     }
+
+    @Test
+    public void test_changeTileElementType_notOnLevel() {
+        LevelElement[][] layout =
+                new LevelElement[][] {
+                    new LevelElement[] {LevelElement.FLOOR, LevelElement.FLOOR, LevelElement.FLOOR}
+                };
+        TileLevel level = new TileLevel(layout, DesignLabel.DEFAULT);
+        level.changeTileElementType(
+                TileFactory.createTile(
+                        "", new Coordinate(1, 0), LevelElement.FLOOR, DesignLabel.DEFAULT),
+                LevelElement.WALL);
+        assertEquals(3, level.getNodeCount());
+        AtomicInteger counter = new AtomicInteger();
+        Arrays.stream(level.getLayout())
+                .flatMap(Arrays::stream)
+                .sorted(Comparator.comparingInt(Tile::getIndex))
+                .filter(Tile::isAccessible)
+                .forEachOrdered(x -> assertEquals(counter.getAndIncrement(), x.getIndex()));
+        assertNotEquals(LevelElement.WALL, level.getTileAt(new Coordinate(1, 0)).getLevelElement());
+        assertEquals(3, counter.get());
+    }
 }

--- a/game/test/level/TileLevelTest.java
+++ b/game/test/level/TileLevelTest.java
@@ -20,6 +20,47 @@ import tools.Point;
 public class TileLevelTest {
 
     @Test
+    public void test_levelCTOR_Tiles() {
+        Tile[][] tileLayout =
+            new Tile[][] {
+                {
+                    new WallTile("", new Coordinate(0, 0), DesignLabel.DEFAULT, null),
+                    new FloorTile("", new Coordinate(1, 0), DesignLabel.DEFAULT, null)
+                },
+                {
+                    new WallTile("", new Coordinate(0, 1), DesignLabel.DEFAULT, null),
+                    new ExitTile("", new Coordinate(1, 1), DesignLabel.DEFAULT, null)
+                }
+            };
+        TileLevel tileLevel = new TileLevel(tileLayout);
+        Tile[][] layout = tileLevel.getLayout();
+        assertArrayEquals(tileLayout, layout);
+    }
+
+    @Test
+    public void test_levelCTOR_TilesNoExit() {
+        Tile[][] tileLayout =
+            new Tile[][] {
+                {
+                    new WallTile("", new Coordinate(0, 0), DesignLabel.DEFAULT, null),
+                    new FloorTile("", new Coordinate(1, 0), DesignLabel.DEFAULT, null)
+                },
+                {
+                    new WallTile("", new Coordinate(0, 1), DesignLabel.DEFAULT, null),
+                    new FloorTile("", new Coordinate(1, 1), DesignLabel.DEFAULT, null)
+                }
+            };
+        TileLevel tileLevel = new TileLevel(tileLayout);
+        Tile[][] layout = tileLevel.getLayout();
+        assertSame(tileLayout[0][0], layout[0][0]);
+        assertSame(tileLayout[1][0], layout[1][0]);
+        assertTrue(
+            "Es muss mindestens einen Ausgang geben!",
+            layout[0][1].getLevelElement() == LevelElement.EXIT
+                || layout[1][1].getLevelElement() == LevelElement.EXIT);
+    }
+
+    @Test
     public void test_levelCTOR_LevelElements() {
         LevelElement[][] elementsLayout =
                 new LevelElement[][] {
@@ -43,46 +84,52 @@ public class TileLevelTest {
         Tile[][] layout = tileLevel.getLayout();
         assertSame(elementsLayout[0][0], layout[0][0].getLevelElement());
         assertSame(elementsLayout[1][0], layout[1][0].getLevelElement());
-        assertTrue("Es muss mindestens einen Ausgang geben!", layout[0][1].getLevelElement() == LevelElement.EXIT ||  layout[1][1].getLevelElement() == LevelElement.EXIT);
+        assertTrue(
+            "Es muss mindestens einen Ausgang geben!",
+            layout[0][1].getLevelElement() == LevelElement.EXIT
+                || layout[1][1].getLevelElement() == LevelElement.EXIT);
     }
 
     @Test
-    public void test_levelCTOR_Tiles() {
-        Tile[][] tileLayout =
-            new Tile[][] {
-                {
-                    new WallTile("", new Coordinate(0, 0), DesignLabel.DEFAULT, null),
-                    new FloorTile("", new Coordinate(1, 0), DesignLabel.DEFAULT, null)
-                },
-                {
-                    new WallTile("", new Coordinate(0, 1), DesignLabel.DEFAULT, null),
-                    new ExitTile("", new Coordinate(1, 1), DesignLabel.DEFAULT, null)
-                }
+    public void test_levelCTOR_LevelElementsNoFloors() {
+        LevelElement[][] elementsLayout =
+            new LevelElement[][] {
+                {LevelElement.WALL, LevelElement.WALL}, {LevelElement.WALL, LevelElement.WALL}
             };
-        TileLevel tileLevel = new TileLevel(tileLayout);
-        Tile[][] layout = tileLevel.getLayout();
-        assertArrayEquals(tileLayout,layout);
+
+        TileLevel level = new TileLevel(elementsLayout, DesignLabel.DEFAULT);
+        assertNull(level.getStartTile());
+        assertNull(level.getEndTile());
     }
 
     @Test
-    public void test_levelCTOR_TilesNoExit() {
-        Tile[][] tileLayout =
-                new Tile[][] {
-                    {
-                        new WallTile("", new Coordinate(0, 0), DesignLabel.DEFAULT, null),
-                        new FloorTile("", new Coordinate(1, 0), DesignLabel.DEFAULT, null)
-                    },
-                    {
-                        new WallTile("", new Coordinate(0, 1), DesignLabel.DEFAULT, null),
-                        new FloorTile("", new Coordinate(1, 1), DesignLabel.DEFAULT, null)
-                    }
-                };
-        TileLevel tileLevel = new TileLevel(tileLayout);
-        Tile[][] layout = tileLevel.getLayout();
-        assertSame(tileLayout[0][0], layout[0][0]);
-        assertSame(tileLayout[1][0], layout[1][0]);
-        assertTrue("Es muss mindestens einen Ausgang geben!", layout[0][1].getLevelElement() == LevelElement.EXIT ||  layout[1][1].getLevelElement() == LevelElement.EXIT);
+    public void test_levelCTOR_LevelElementsEnoughFloorsForStartButNotExit() {
+        LevelElement[][] elementsLayout =
+            new LevelElement[][] {
+                {LevelElement.WALL, LevelElement.FLOOR}, {LevelElement.WALL, LevelElement.WALL}
+            };
+
+        TileLevel level = new TileLevel(elementsLayout, DesignLabel.DEFAULT);
+        assertNotNull(level.getStartTile());
+        assertNull(level.getEndTile());
     }
+    @Test
+    public void test_levelCTOR_LevelElements_connections(){
+        LevelElement[][] elementsLayout =
+            new LevelElement[][] {
+                {LevelElement.FLOOR, LevelElement.FLOOR, LevelElement.EXIT}
+        };
+        TileLevel tileLevel = new TileLevel(elementsLayout, DesignLabel.DEFAULT);
+        Tile[][] layout = tileLevel.getLayout();
+        assertEquals(1, layout[0][0].getConnections().size);
+        assertSame(layout[0][1], layout[0][0].getConnections().first().getToNode());
+        assertEquals(2, layout[0][1].getConnections().size);
+        assertSame(layout[0][0], layout[0][1].getConnections().get(0).getToNode());
+        assertSame(layout[0][2], layout[0][1].getConnections().get(1).getToNode());
+        assertEquals(1, layout[0][2].getConnections().size);
+        assertSame(layout[0][1], layout[0][2].getConnections().first().getToNode());
+    }
+
 
     @Test
     public void test_findPath_onlyOnePathPossible() {

--- a/game/test/level/TileLevelTest.java
+++ b/game/test/level/TileLevelTest.java
@@ -7,9 +7,11 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.concurrent.atomic.AtomicInteger;
 import level.elements.TileLevel;
+import level.elements.astar.TileConnection;
 import level.elements.tile.ExitTile;
 import level.elements.tile.FloorTile;
 import level.elements.tile.Tile;
+import level.elements.tile.TileFactory;
 import level.elements.tile.WallTile;
 import level.tools.Coordinate;
 import level.tools.DesignLabel;
@@ -22,16 +24,16 @@ public class TileLevelTest {
     @Test
     public void test_levelCTOR_Tiles() {
         Tile[][] tileLayout =
-            new Tile[][] {
-                {
-                    new WallTile("", new Coordinate(0, 0), DesignLabel.DEFAULT, null),
-                    new FloorTile("", new Coordinate(1, 0), DesignLabel.DEFAULT, null)
-                },
-                {
-                    new WallTile("", new Coordinate(0, 1), DesignLabel.DEFAULT, null),
-                    new ExitTile("", new Coordinate(1, 1), DesignLabel.DEFAULT, null)
-                }
-            };
+                new Tile[][] {
+                    {
+                        new WallTile("", new Coordinate(0, 0), DesignLabel.DEFAULT, null),
+                        new FloorTile("", new Coordinate(1, 0), DesignLabel.DEFAULT, null)
+                    },
+                    {
+                        new WallTile("", new Coordinate(0, 1), DesignLabel.DEFAULT, null),
+                        new ExitTile("", new Coordinate(1, 1), DesignLabel.DEFAULT, null)
+                    }
+                };
         TileLevel tileLevel = new TileLevel(tileLayout);
         Tile[][] layout = tileLevel.getLayout();
         assertArrayEquals(tileLayout, layout);
@@ -40,24 +42,24 @@ public class TileLevelTest {
     @Test
     public void test_levelCTOR_TilesNoExit() {
         Tile[][] tileLayout =
-            new Tile[][] {
-                {
-                    new WallTile("", new Coordinate(0, 0), DesignLabel.DEFAULT, null),
-                    new FloorTile("", new Coordinate(1, 0), DesignLabel.DEFAULT, null)
-                },
-                {
-                    new WallTile("", new Coordinate(0, 1), DesignLabel.DEFAULT, null),
-                    new FloorTile("", new Coordinate(1, 1), DesignLabel.DEFAULT, null)
-                }
-            };
+                new Tile[][] {
+                    {
+                        new WallTile("", new Coordinate(0, 0), DesignLabel.DEFAULT, null),
+                        new FloorTile("", new Coordinate(1, 0), DesignLabel.DEFAULT, null)
+                    },
+                    {
+                        new WallTile("", new Coordinate(0, 1), DesignLabel.DEFAULT, null),
+                        new FloorTile("", new Coordinate(1, 1), DesignLabel.DEFAULT, null)
+                    }
+                };
         TileLevel tileLevel = new TileLevel(tileLayout);
         Tile[][] layout = tileLevel.getLayout();
         assertSame(tileLayout[0][0], layout[0][0]);
         assertSame(tileLayout[1][0], layout[1][0]);
         assertTrue(
-            "Es muss mindestens einen Ausgang geben!",
-            layout[0][1].getLevelElement() == LevelElement.EXIT
-                || layout[1][1].getLevelElement() == LevelElement.EXIT);
+                "Es muss mindestens einen Ausgang geben!",
+                layout[0][1].getLevelElement() == LevelElement.EXIT
+                        || layout[1][1].getLevelElement() == LevelElement.EXIT);
     }
 
     @Test
@@ -77,25 +79,25 @@ public class TileLevelTest {
     @Test
     public void test_levelCTOR_LevelElementsNoExit() {
         LevelElement[][] elementsLayout =
-            new LevelElement[][] {
-                {LevelElement.WALL, LevelElement.FLOOR}, {LevelElement.WALL, LevelElement.FLOOR}
-            };
+                new LevelElement[][] {
+                    {LevelElement.WALL, LevelElement.FLOOR}, {LevelElement.WALL, LevelElement.FLOOR}
+                };
         TileLevel tileLevel = new TileLevel(elementsLayout, DesignLabel.DEFAULT);
         Tile[][] layout = tileLevel.getLayout();
         assertSame(elementsLayout[0][0], layout[0][0].getLevelElement());
         assertSame(elementsLayout[1][0], layout[1][0].getLevelElement());
         assertTrue(
-            "Es muss mindestens einen Ausgang geben!",
-            layout[0][1].getLevelElement() == LevelElement.EXIT
-                || layout[1][1].getLevelElement() == LevelElement.EXIT);
+                "Es muss mindestens einen Ausgang geben!",
+                layout[0][1].getLevelElement() == LevelElement.EXIT
+                        || layout[1][1].getLevelElement() == LevelElement.EXIT);
     }
 
     @Test
     public void test_levelCTOR_LevelElementsNoFloors() {
         LevelElement[][] elementsLayout =
-            new LevelElement[][] {
-                {LevelElement.WALL, LevelElement.WALL}, {LevelElement.WALL, LevelElement.WALL}
-            };
+                new LevelElement[][] {
+                    {LevelElement.WALL, LevelElement.WALL}, {LevelElement.WALL, LevelElement.WALL}
+                };
 
         TileLevel level = new TileLevel(elementsLayout, DesignLabel.DEFAULT);
         assertNull(level.getStartTile());
@@ -105,20 +107,19 @@ public class TileLevelTest {
     @Test
     public void test_levelCTOR_LevelElementsEnoughFloorsForStartButNotExit() {
         LevelElement[][] elementsLayout =
-            new LevelElement[][] {
-                {LevelElement.WALL, LevelElement.FLOOR}, {LevelElement.WALL, LevelElement.WALL}
-            };
+                new LevelElement[][] {
+                    {LevelElement.WALL, LevelElement.FLOOR}, {LevelElement.WALL, LevelElement.WALL}
+                };
 
         TileLevel level = new TileLevel(elementsLayout, DesignLabel.DEFAULT);
         assertNotNull(level.getStartTile());
         assertNull(level.getEndTile());
     }
+
     @Test
-    public void test_levelCTOR_LevelElements_connections(){
+    public void test_levelCTOR_LevelElements_connections() {
         LevelElement[][] elementsLayout =
-            new LevelElement[][] {
-                {LevelElement.FLOOR, LevelElement.FLOOR, LevelElement.EXIT}
-        };
+                new LevelElement[][] {{LevelElement.FLOOR, LevelElement.FLOOR, LevelElement.EXIT}};
         TileLevel tileLevel = new TileLevel(elementsLayout, DesignLabel.DEFAULT);
         Tile[][] layout = tileLevel.getLayout();
         assertEquals(1, layout[0][0].getConnections().size);
@@ -131,83 +132,91 @@ public class TileLevelTest {
     }
 
     @Test
-    public void test_levelCTOR_LevelElements_tileTypeLists(){
+    public void test_levelCTOR_LevelElements_tileTypeLists() {
         LevelElement[][] elementsLayout =
-            new LevelElement[][] {
-                {LevelElement.FLOOR, LevelElement.FLOOR, LevelElement.EXIT, LevelElement.SKIP},
-                {LevelElement.WALL, LevelElement.WALL, LevelElement.SKIP, LevelElement.SKIP},
-                {LevelElement.DOOR, LevelElement.DOOR, LevelElement.HOLE, LevelElement.HOLE},
-            };
+                new LevelElement[][] {
+                    {LevelElement.FLOOR, LevelElement.FLOOR, LevelElement.EXIT, LevelElement.SKIP},
+                    {LevelElement.WALL, LevelElement.WALL, LevelElement.SKIP, LevelElement.SKIP},
+                    {LevelElement.DOOR, LevelElement.DOOR, LevelElement.HOLE, LevelElement.HOLE},
+                };
         TileLevel tileLevel = new TileLevel(elementsLayout, DesignLabel.DEFAULT);
-        assertEquals(2,tileLevel.getFloorTiles().size());
-        assertEquals(2,tileLevel.getDoorTiles().size());
-        assertEquals(2,tileLevel.getHoleTiles().size());
-        assertEquals(2,tileLevel.getWallTiles().size());
-        assertEquals(3,tileLevel.getSkipTiles().size());
+        assertEquals(2, tileLevel.getFloorTiles().size());
+        assertEquals(2, tileLevel.getDoorTiles().size());
+        assertEquals(2, tileLevel.getHoleTiles().size());
+        assertEquals(2, tileLevel.getWallTiles().size());
+        assertEquals(3, tileLevel.getSkipTiles().size());
     }
 
     @Test
-    public void test_nodeCount_NoAccessible(){
+    public void test_nodeCount_NoAccessible() {
         LevelElement[][] elementsLayout =
-            new LevelElement[][] {
-                {LevelElement.WALL, LevelElement.WALL, LevelElement.WALL, LevelElement.WALL},
-            };
+                new LevelElement[][] {
+                    {LevelElement.WALL, LevelElement.WALL, LevelElement.WALL, LevelElement.WALL},
+                };
         TileLevel tileLevel = new TileLevel(elementsLayout, DesignLabel.DEFAULT);
-        assertEquals(0,tileLevel.getNodeCount());
+        assertEquals(0, tileLevel.getNodeCount());
     }
 
     @Test
-    public void test_nodeCount_OneAccessible(){
+    public void test_nodeCount_OneAccessible() {
         LevelElement[][] elementsLayout =
-            new LevelElement[][] {
-                {LevelElement.FLOOR, LevelElement.WALL, LevelElement.WALL, LevelElement.WALL},
-            };
+                new LevelElement[][] {
+                    {LevelElement.FLOOR, LevelElement.WALL, LevelElement.WALL, LevelElement.WALL},
+                };
         TileLevel tileLevel = new TileLevel(elementsLayout, DesignLabel.DEFAULT);
-        assertEquals(1,tileLevel.getNodeCount());
+        assertEquals(1, tileLevel.getNodeCount());
     }
 
     @Test
-    public void test_nodeCount_FourAccessible(){
+    public void test_nodeCount_FourAccessible() {
         LevelElement[][] elementsLayout =
-            new LevelElement[][] {
-                {LevelElement.FLOOR, LevelElement.FLOOR, LevelElement.FLOOR, LevelElement.FLOOR},
-            };
+                new LevelElement[][] {
+                    {
+                        LevelElement.FLOOR,
+                        LevelElement.FLOOR,
+                        LevelElement.FLOOR,
+                        LevelElement.FLOOR
+                    },
+                };
         TileLevel tileLevel = new TileLevel(elementsLayout, DesignLabel.DEFAULT);
-        assertEquals(4,tileLevel.getNodeCount());
+        assertEquals(4, tileLevel.getNodeCount());
     }
 
     @Test
-    public void test_setRandomEnd(){
+    public void test_setRandomEnd() {
         LevelElement[][] elementsLayout =
-            new LevelElement[][] {
-                {LevelElement.EXIT, LevelElement.FLOOR, LevelElement.FLOOR, LevelElement.FLOOR},
-            };
+                new LevelElement[][] {
+                    {LevelElement.EXIT, LevelElement.FLOOR, LevelElement.FLOOR, LevelElement.FLOOR},
+                };
         TileLevel tileLevel = new TileLevel(elementsLayout, DesignLabel.DEFAULT);
         Tile oldEndTile = tileLevel.getEndTile();
-        assertNotSame(tileLevel.getStartTile(),tileLevel.getEndTile());
+        tileLevel.setRandomEnd();
+        assertNotSame(tileLevel.getStartTile(), tileLevel.getEndTile());
         assertNotSame(oldEndTile, tileLevel.getEndTile());
     }
+
     @Test
-    public void test_setRandomEnd_NoFreeFloors(){
+    public void test_setRandomEnd_NoFreeFloors() {
         LevelElement[][] elementsLayout =
-            new LevelElement[][] {
-                {LevelElement.FLOOR},
-            };
+                new LevelElement[][] {
+                    {LevelElement.FLOOR},
+                };
         TileLevel tileLevel = new TileLevel(elementsLayout, DesignLabel.DEFAULT);
-        assertNotSame(tileLevel.getStartTile(),tileLevel.getEndTile());
+        tileLevel.setRandomEnd();
+        assertNotSame(tileLevel.getStartTile(), tileLevel.getEndTile());
         assertNull(tileLevel.getEndTile());
     }
+
     @Test
-    public void test_setRandomEnd_NoFloors(){
+    public void test_setRandomEnd_NoFloors() {
         LevelElement[][] elementsLayout =
-            new LevelElement[][] {
-                {LevelElement.WALL},
-            };
+                new LevelElement[][] {
+                    {LevelElement.WALL},
+                };
         TileLevel tileLevel = new TileLevel(elementsLayout, DesignLabel.DEFAULT);
         tileLevel.setRandomEnd();
         assertNull(tileLevel.getEndTile());
     }
-
 
     @Test
     public void test_findPath_onlyOnePathPossible() {
@@ -293,10 +302,9 @@ public class TileLevelTest {
         var levelLayout = new LevelElement[3][3];
 
         for (int y = 0; y < 3; y++) {
-            for (int x = 0; x < 3; x++) {
-                levelLayout[y][x] = LevelElement.FLOOR;
-            }
+            Arrays.fill(levelLayout[y], LevelElement.FLOOR);
         }
+        levelLayout[0][0] = LevelElement.EXIT;
         var level = new TileLevel(levelLayout, DesignLabel.randomDesign());
         assertEquals(levelLayout[1][2], level.getTileAt(new Coordinate(2, 1)).getLevelElement());
     }
@@ -305,9 +313,7 @@ public class TileLevelTest {
     public void test_getRandomTile() {
         var levelLayout = new LevelElement[3][3];
         for (int y = 0; y < 3; y++) {
-            for (int x = 0; x < 3; x++) {
-                levelLayout[y][x] = LevelElement.FLOOR;
-            }
+            Arrays.fill(levelLayout[y], LevelElement.FLOOR);
         }
         var level = new TileLevel(levelLayout, DesignLabel.randomDesign());
         assertNotNull(level.getRandomTile());
@@ -340,9 +346,7 @@ public class TileLevelTest {
     public void test_getRandomTilePoint() {
         var levelLayout = new LevelElement[3][3];
         for (int y = 0; y < 3; y++) {
-            for (int x = 0; x < 3; x++) {
-                levelLayout[y][x] = LevelElement.FLOOR;
-            }
+            Arrays.fill(levelLayout[y], LevelElement.FLOOR);
         }
         var level = new TileLevel(levelLayout, DesignLabel.randomDesign());
         Point randomPoint = level.getRandomTilePoint();
@@ -400,6 +404,234 @@ public class TileLevelTest {
             compareString.append("\n");
         }
         assertEquals(compareString.toString(), level.printLevel());
+    }
+
+    @Test
+    public void test_addTile_FloorTile() {
+        TileLevel level =
+                new TileLevel(
+                        new LevelElement[][] {
+                            {LevelElement.FLOOR, LevelElement.FLOOR, LevelElement.FLOOR}
+                        },
+                        DesignLabel.DEFAULT);
+        Tile tile =
+                TileFactory.createTile(
+                        "", new Coordinate(1, 0), LevelElement.FLOOR, DesignLabel.DEFAULT);
+        level.removeTile(level.getLayout()[0][1]);
+        level.getLayout()[0][1] = tile;
+        level.addTile(tile);
+        assertTrue(
+                "tile needs to be added to specific Tile list",
+                level.getFloorTiles().contains(tile));
+        assertEquals(level.getNodeCount() - 1, tile.getIndex());
+        assertTrue(
+                "All neighbouring tiles need to be informed about the new tile",
+                level.getFloorTiles().stream()
+                        .filter(x -> !(x == tile))
+                        .allMatch(
+                                x ->
+                                        x.getConnections().size == 1
+                                                && x.getConnections()
+                                                        .contains(
+                                                                new TileConnection(x, tile),
+                                                                false)));
+        assertSame("tile needs to know its new level", level, tile.getLevel());
+        assertEquals(
+                "each accessible tile needs to have a unique index",
+                3,
+                Arrays.stream(level.getLayout())
+                        .flatMap(x -> Arrays.stream(x).map(Tile::getIndex))
+                        .distinct()
+                        .count());
+    }
+
+    @Test
+    public void test_addTile_ExitTile() {
+        TileLevel level =
+                new TileLevel(
+                        new LevelElement[][] {
+                            {LevelElement.FLOOR, LevelElement.FLOOR, LevelElement.FLOOR}
+                        },
+                        DesignLabel.DEFAULT);
+        Tile tile =
+                TileFactory.createTile(
+                        "", new Coordinate(1, 0), LevelElement.EXIT, DesignLabel.DEFAULT);
+        level.removeTile(level.getLayout()[0][1]);
+        level.getLayout()[0][1] = tile;
+        level.addTile(tile);
+        assertTrue(
+                "tile needs to be added to specific Tile list",
+                level.getExitTiles().contains(tile));
+        assertEquals(level.getNodeCount() - 1, tile.getIndex());
+        assertTrue(
+                "All neighbouring tiles need to be informed about the new tile",
+                level.getFloorTiles().stream()
+                        .filter(x -> !(x == tile))
+                        .allMatch(
+                                x ->
+                                        x.getConnections().size == 1
+                                                && x.getConnections()
+                                                        .contains(
+                                                                new TileConnection(x, tile),
+                                                                false)));
+        assertSame("tile needs to know its new level", level, tile.getLevel());
+        assertEquals(
+                "each accessible tile needs to have a unique index",
+                3,
+                Arrays.stream(level.getLayout())
+                        .flatMap(x -> Arrays.stream(x).map(Tile::getIndex))
+                        .distinct()
+                        .count());
+    }
+
+    @Test
+    public void test_addTile_DoorTile() {
+        TileLevel level =
+                new TileLevel(
+                        new LevelElement[][] {
+                            {LevelElement.FLOOR, LevelElement.FLOOR, LevelElement.FLOOR}
+                        },
+                        DesignLabel.DEFAULT);
+        Tile tile =
+                TileFactory.createTile(
+                        "", new Coordinate(1, 0), LevelElement.DOOR, DesignLabel.DEFAULT);
+        level.removeTile(level.getLayout()[0][1]);
+        level.getLayout()[0][1] = tile;
+        level.addTile(tile);
+        assertTrue(
+                "tile needs to be added to specific Tile list",
+                level.getDoorTiles().contains(tile));
+        assertEquals(level.getNodeCount() - 1, tile.getIndex());
+        assertTrue(
+                "All neighbouring tiles need to be informed about the new tile",
+                level.getFloorTiles().stream()
+                        .filter(x -> !(x == tile))
+                        .allMatch(
+                                x ->
+                                        x.getConnections().size == 1
+                                                && x.getConnections()
+                                                        .contains(
+                                                                new TileConnection(x, tile),
+                                                                false)));
+        assertSame("tile needs to know its new level", level, tile.getLevel());
+        assertEquals(
+                "each accessible tile needs to have a unique index",
+                3,
+                Arrays.stream(level.getLayout())
+                        .flatMap(x -> Arrays.stream(x).map(Tile::getIndex))
+                        .distinct()
+                        .count());
+    }
+
+    @Test
+    public void test_addTile_SkipTile() {
+        TileLevel level =
+                new TileLevel(
+                        new LevelElement[][] {
+                            {LevelElement.FLOOR, LevelElement.FLOOR, LevelElement.FLOOR}
+                        },
+                        DesignLabel.DEFAULT);
+        Tile tile =
+                TileFactory.createTile(
+                        "", new Coordinate(1, 0), LevelElement.SKIP, DesignLabel.DEFAULT);
+        level.removeTile(level.getLayout()[0][1]);
+        level.getLayout()[0][1] = tile;
+        level.addTile(tile);
+        assertTrue(
+                "tile needs to be added to specific Tile list",
+                level.getSkipTiles().contains(tile));
+        assertEquals(0, tile.getIndex());
+        assertTrue(
+                "All neighbouring tiles need to be informed about the new tile",
+                level.getFloorTiles().stream()
+                        .filter(x -> !(x == tile))
+                        .allMatch(x -> x.getConnections().size == 0));
+        assertSame("tile needs to know its new level", level, tile.getLevel());
+        assertEquals(
+                "each accessible tile needs to have a unique index",
+                2,
+                Arrays.stream(level.getLayout())
+                        .flatMap(
+                                x ->
+                                        Arrays.stream(x)
+                                                .filter(Tile::isAccessible)
+                                                .map(Tile::getIndex))
+                        .distinct()
+                        .count());
+    }
+
+    @Test
+    public void test_addTile_WallTile() {
+        TileLevel level =
+                new TileLevel(
+                        new LevelElement[][] {
+                            {LevelElement.FLOOR, LevelElement.FLOOR, LevelElement.FLOOR}
+                        },
+                        DesignLabel.DEFAULT);
+        Tile tile =
+                TileFactory.createTile(
+                        "", new Coordinate(1, 0), LevelElement.WALL, DesignLabel.DEFAULT);
+        level.removeTile(level.getLayout()[0][1]);
+        level.getLayout()[0][1] = tile;
+        level.addTile(tile);
+        assertTrue(
+                "tile needs to be added to specific Tile list",
+                level.getWallTiles().contains(tile));
+        assertEquals(0, tile.getIndex());
+        assertTrue(
+                "All neighbouring tiles need to be informed about the new tile",
+                level.getFloorTiles().stream()
+                        .filter(x -> !(x == tile))
+                        .allMatch(x -> x.getConnections().size == 0));
+        assertSame("tile needs to know its new level", level, tile.getLevel());
+        assertEquals(
+                "each accessible tile needs to have a unique index",
+                2,
+                Arrays.stream(level.getLayout())
+                        .flatMap(
+                                x ->
+                                        Arrays.stream(x)
+                                                .filter(Tile::isAccessible)
+                                                .map(Tile::getIndex))
+                        .distinct()
+                        .count());
+    }
+
+    @Test
+    public void test_addTile_HoleTile() {
+        TileLevel level =
+                new TileLevel(
+                        new LevelElement[][] {
+                            {LevelElement.FLOOR, LevelElement.FLOOR, LevelElement.FLOOR}
+                        },
+                        DesignLabel.DEFAULT);
+        Tile tile =
+                TileFactory.createTile(
+                        "", new Coordinate(1, 0), LevelElement.HOLE, DesignLabel.DEFAULT);
+        level.removeTile(level.getLayout()[0][1]);
+        level.getLayout()[0][1] = tile;
+        level.addTile(tile);
+        assertTrue(
+                "tile needs to be added to specific Tile list",
+                level.getHoleTiles().contains(tile));
+        assertEquals(0, tile.getIndex());
+        assertTrue(
+                "All neighbouring tiles need to be informed about the new tile",
+                level.getFloorTiles().stream()
+                        .filter(x -> !(x == tile))
+                        .allMatch(x -> x.getConnections().size == 0));
+        assertSame("tile needs to know its new level", level, tile.getLevel());
+        assertEquals(
+                "each accessible tile needs to have a unique index",
+                2,
+                Arrays.stream(level.getLayout())
+                        .flatMap(
+                                x ->
+                                        Arrays.stream(x)
+                                                .filter(Tile::isAccessible)
+                                                .map(Tile::getIndex))
+                        .distinct()
+                        .count());
     }
 
     @Test

--- a/game/test/level/elements/tile/TileFactoryTest.java
+++ b/game/test/level/elements/tile/TileFactoryTest.java
@@ -1,0 +1,90 @@
+package level.elements.tile;
+
+import static org.junit.Assert.*;
+
+import level.tools.Coordinate;
+import level.tools.DesignLabel;
+import level.tools.LevelElement;
+import org.junit.Test;
+
+public class TileFactoryTest {
+
+    /** checks if Tile of type SKIP can be generated.... */
+    @Test
+    public void createSKIPTile() {
+        Tile t =
+                TileFactory.createTile(
+                        "", new Coordinate(0, 0), LevelElement.SKIP, DesignLabel.DEFAULT);
+        assertEquals(SkipTile.class, t.getClass());
+        assertEquals(0, t.getCoordinate().x);
+        assertEquals(0, t.getCoordinate().y);
+        assertEquals(LevelElement.SKIP, t.getLevelElement());
+        assertEquals(DesignLabel.DEFAULT, t.getDesignLabel());
+        assertNull("No Level should be set for a newly created Tile", t.getLevel());
+    }
+    /** checks if Tile of type FLOOR can be generated.... */
+    @Test
+    public void createFLOORTile() {
+        Tile t =
+                TileFactory.createTile(
+                        "", new Coordinate(0, 0), LevelElement.FLOOR, DesignLabel.DEFAULT);
+        assertEquals(FloorTile.class, t.getClass());
+        assertEquals(0, t.getCoordinate().x);
+        assertEquals(0, t.getCoordinate().y);
+        assertEquals(LevelElement.FLOOR, t.getLevelElement());
+        assertEquals(DesignLabel.DEFAULT, t.getDesignLabel());
+        assertNull("No Level should be set for a newly created Tile", t.getLevel());
+    }
+    /** checks if Tile of type WALL can be generated.... */
+    @Test
+    public void createWALLTile() {
+        Tile t =
+                TileFactory.createTile(
+                        "", new Coordinate(0, 0), LevelElement.WALL, DesignLabel.DEFAULT);
+        assertEquals(WallTile.class, t.getClass());
+        assertEquals(0, t.getCoordinate().x);
+        assertEquals(0, t.getCoordinate().y);
+        assertEquals(LevelElement.WALL, t.getLevelElement());
+        assertEquals(DesignLabel.DEFAULT, t.getDesignLabel());
+        assertNull("No Level should be set for a newly created Tile", t.getLevel());
+    }
+    /** checks if Tile of type HOLE can be generated.... */
+    @Test
+    public void createHOLETile() {
+        Tile t =
+                TileFactory.createTile(
+                        "", new Coordinate(0, 0), LevelElement.HOLE, DesignLabel.DEFAULT);
+        assertEquals(HoleTile.class, t.getClass());
+        assertEquals(0, t.getCoordinate().x);
+        assertEquals(0, t.getCoordinate().y);
+        assertEquals(LevelElement.HOLE, t.getLevelElement());
+        assertEquals(DesignLabel.DEFAULT, t.getDesignLabel());
+        assertNull("No Level should be set for a newly created Tile", t.getLevel());
+    }
+    /** checks if Tile of type EXIT can be generated.... */
+    @Test
+    public void createEXITTile() {
+        Tile t =
+                TileFactory.createTile(
+                        "", new Coordinate(0, 0), LevelElement.EXIT, DesignLabel.DEFAULT);
+        assertEquals(ExitTile.class, t.getClass());
+        assertEquals(0, t.getCoordinate().x);
+        assertEquals(0, t.getCoordinate().y);
+        assertEquals(LevelElement.EXIT, t.getLevelElement());
+        assertEquals(DesignLabel.DEFAULT, t.getDesignLabel());
+        assertNull("No Level should be set for a newly created Tile", t.getLevel());
+    }
+    /** checks if Tile of type DOOR can be generated.... */
+    @Test
+    public void createDOORTile() {
+        Tile t =
+                TileFactory.createTile(
+                        "", new Coordinate(0, 0), LevelElement.DOOR, DesignLabel.DEFAULT);
+        assertEquals(DoorTile.class, t.getClass());
+        assertEquals(0, t.getCoordinate().x);
+        assertEquals(0, t.getCoordinate().y);
+        assertEquals(LevelElement.DOOR, t.getLevelElement());
+        assertEquals(DesignLabel.DEFAULT, t.getDesignLabel());
+        assertNull("No Level should be set for a newly created Tile", t.getLevel());
+    }
+}


### PR DESCRIPTION
fixes #485
fixes #462
fixes #461

Verhalten des TileLevels ist beim entfernen bzw. hinzufügen von Tiles jetzt korrigiert somit werden die Verbindungen aufgeräumt beim Entfernen sowie beim Einfügen werden neue Verbindungen hergestellt. Der Index des Tiles wird nun auch richtig entfernt bzw hinzugefügt. 


- [x] TileLevel
  - [x] levelelement[][] ctor
     - [ ] ~~erstellt Verbindungen zwischen allen Tiles~~
     - [ ] ~~trägt alle Tiles in die Sublisten ein~~
     - [ ] ~~wählt ein zufälliges Endtile aus, wenn keins vorgegeben wurde~~
    - [x] ruft einfach den Tile[][] mit den neu gebauten Tiles auf
  - [x] Tile[][] ctor
    - [x] erstellt Verbindungen zwischen allen Tiles
    - [x] trägt alle Tiles in die Sublisten ein
    - [x] wählt ein zufälliges Endtile aus, wenn keins vorgegeben wurde
- [x] addTile(Tile)
  - [x] indicie wird erhöht und gültig zu gewiesen
  - [x] Verbindungen zu allen nachbar Tiles aufgebaut
  - [x] Wenn ExitTile dann ändere vorheriges auf Floor um (vielleicht ist der exit kein Tile sowie die Türen) 
- [x] remove(Tile)
  - [x] tile aus verbindungen entfernen
  - [x] index aller Tiles die größer sind als des gelöschten um 1 verringern
- [x] getEndTile() nutze eine extra Variable neben ExitTiles
- [x] setEndTile() ebenfalls
- [x] TileFactory
  - [x] entfernen von LevelLogik
    - [x] hinzufügen des Levels nur auf Level ebene
    - [x] level trägt sich beim Tile ein und nicht die TileFactory
  - [x] skip extrabehandlung außerhalb vom switch
- [x] Tests
  - [x] TileFactory kann jeden TileTyp erstellen
    - [x] SKIP
    - [x] FLOOR
    - [x] WALL
    - [x] HOLE
    - [x] EXIT
    - [x] DOOR
  - [x] TileLevel
    - [x] Konstruktoren haben vergleichbares verhalten
      - [x] startTile wird zufällig festgelegt
        - [x] FloorTile vorhanden
        - [x] nicht vorhanden
      - [x] ExitTile
        - [x] vorhanden, dann übernehmen
        - [x] fehlt dann 
          - [x] ein zufälliges FloorTile
          - [x] Kein FloorTile vorhanden
      - [x] Verbindungen werden erstellt 
      - [x] Listen werden nach Tile Typ gefüllt
      - [x] LevelElement ctor erstellt korrekte Tile Typen
    - [x] getNodeCount ist identisch zu der Anzahl an Knoten
      - [x] Keine Knoten
      - [x] 1 Knoten
      - [x] 5 Knoten
    - [x] addTile 
      - [x] pro Tile typ
        - [x] wird in die zuständige Liste aufgenommen
        - [x] wird, wenn isAccessible ins pathfinding aufgenommen
          - [x] Index wird gesetzt
          - [x] Nachbarn erfahren vom neuen Tile
        - [x] bekommt das Level zugewiesen
    - [ ] changeTileElementType erlaubt das Umwandeln aller Typen in jeden anderen Typen
      - [x] Sonderfälle gehört nicht zu einem Level

restlichen Tests kommen noch