### PR TITLE
[GAME] use methods to control the different entity-sets

### DIFF
--- a/doc/ecs/create_own_content.md
+++ b/doc/ecs/create_own_content.md
@@ -11,7 +11,7 @@ Um eine eigene Entität zu erstellen, muss man:
 1. Eine neue Instanz vom Typ `Entity` anlegen
 2. Die gewünschten Komponenten erstellen
 
-Beispiel: 
+Beispiel:
 ```java
 Entity monster = new Entity();
 
@@ -22,6 +22,8 @@ VelocityComponent vc = new AnimationComponent(monster);
 ```
 
 *Anmerkung*: Die Komponenten wurden im Beispiel alle mit den jeweiligen Default-Werten initialisiert. Die Verwendung der anderen Konstruktoren (mit eigenen Werten) geht natürlich auch.
+
+*Hinweis: Um Entitäten aus dem Spiel zu entfernen, nutzen Sie die Methode `Game#removeEntity`.*
 
 ## Component erstellen
 
@@ -40,9 +42,9 @@ Systeme werden im package `ecs.systems` abgelegt und sollen den Namensschema `$W
 
 
 Die Funktionalität des Systems wird in der `update`-Methode implementiert. Diese wird einmal pro Frame aufgerufen.
-In der `update`-Methode wird dann über die Collectiom `ECS.entities`iteriert, alle Entitäten mit dem Key-Component gefiltert und dann die eigentliche System-Logik auf die Entiäten angewendet.
+In der `update`-Methode wird dann über die Collectiom `Game.entities`iteriert, alle Entitäten mit dem Key-Component gefiltert und dann die eigentliche System-Logik auf die Entiäten angewendet.
 
-Beispiel aus dem `HealthSystem`: 
+Beispiel aus dem `HealthSystem`:
 ```java
 
  // private record to hold all data during streaming
@@ -51,7 +53,7 @@ private record HSData(Entity e, HealthComponent hc, AnimationComponent ac) {}
 
  @Override
 public void update() {
-        ECS.entities.stream()
+        Game.getEntities().stream()
                 // Consider only entities that have a HealthComponent
                 .flatMap(e -> e.getComponent(HealthComponent.class).stream())
                 // Form triples (e, hc, ac)
@@ -63,7 +65,7 @@ public void update() {
                 // Remove all dead entities
                 .forEach(this::removeDeadEntities);
     }
- 
+
 private HSData buildDataObject(HealthComponent hc) {
         Entity e = hc.getEntity();
 

--- a/doc/ecs/readme.md
+++ b/doc/ecs/readme.md
@@ -3,7 +3,7 @@ title: "ECS Basics"
 ---
 
 
-Im Projekt wird das [ECS-Paradigmas](https://en.wikipedia.org/wiki/Entity_component_system) angewendet. 
+Im Projekt wird das [ECS-Paradigmas](https://en.wikipedia.org/wiki/Entity_component_system) angewendet.
 
 ## Was ist ein ECS (Kurzform)
 
@@ -21,23 +21,23 @@ Siehe auch [Strategy Pattern im ECS](ecs_and_strategy_pattern.md)
 Systeme agieren auf Components und ändern die Werte in diesen. Sie beschreiben also das Verhalten der Entitäten. Ein System kann auf ein oder mehreren Components agieren.
 In Systemen wird die eigentliche Logik implementiert.
 
-Der Zustand einer Entität wird also über ihre Components bestimmt, und ihr Verhalten über die Systeme, die mit der jeweiligen Component-Kombination arbeiten. 
+Der Zustand einer Entität wird also über ihre Components bestimmt, und ihr Verhalten über die Systeme, die mit der jeweiligen Component-Kombination arbeiten.
 
 ## Basisstruktur
 
 ![Struktur ECS](img/ecs.png)
 
-Neu erzeugte Entitäten speichern sich automatisch im HashSet `entities` der `ECS`-Klasse ab.
-`ECS_System`e speichern sich automatisch im `SystemController` `systems` der `ECS`-Klasse ab.
+*Anmerkung: Das abgebildete UML ist nicht aktuell, es wird in #496 aktualisiert.*
 
-Die Systeme iterieren über die in `ECS` gespeicherten Entitäten und greifen über die Methode `Entite#getComponent` auf die für die jeweilige Funktionalität benötigten Components zu.
+Neu erzeugte Entitäten speichern sich automatisch im HashSet `entities` der `Game`-Klasse ab.
+`ECS_System`e speichern sich automatisch im `SystemController` `systems` der `Game`-Klasse ab.
+
+Die Systeme iterieren über die in `Game` gespeicherten Entitäten und greifen über die Methode `Entity#getComponent` auf die für die jeweilige Funktionalität benötigten Components zu.
 
 *Anmerkung*: Gelb hinterlegte Klassen stammen aus dem PM-Dungeon-Framework.
 
 *Anmerkung*: Das UML-Diagramm ist auf die wesentlichen Bestandteile gekürzt.
 
-## Integration des ECS in das PM-Dungeon-Framework
+## Integration des ECS in die Game-Loop
 
-Die Klasse `ECS` ist die Start-Klasse und erbt von `Game` des PM-Dungeon-Frameworks.
-
-Um die Systeme in die GameLoop des Frameworks zu integrieren, wird ein Objekt vom Typ `SystemController` genutzt. Dieser Controller funktioniert analog zu den anderen Controllern des Frameworks: Er hält die Menge aller vorhandenen Systeme und ruft einmal pro Frame für jedes System die `update`-Methode. Die Registrierung der Systeme beim Controller wird über den Konstruktor der Klasse `ECS_System` erledigt - dadurch müssen abgeleitete Systeme dies nicht selbst machen.
+Um die Systeme in die GameLoop zu integrieren, wird ein Objekt vom Typ `SystemController` genutzt. Er hält die Menge aller vorhandenen Systeme und ruft einmal pro Frame für jedes System die `update`-Methode. Die Registrierung der Systeme beim Controller wird über den Konstruktor der Klasse `ECS_System` erledigt - dadurch müssen abgeleitete Systeme dies nicht selbst machen.

--- a/game/src/ecs/components/skill/DamageProjectileSkill.java
+++ b/game/src/ecs/components/skill/DamageProjectileSkill.java
@@ -64,7 +64,7 @@ public abstract class DamageProjectileSkill implements ISkillFunction {
                                 .ifPresent(
                                         hc -> {
                                             ((HealthComponent) hc).receiveHit(projectileDamage);
-                                            Game.entitiesToRemove.add(projectile);
+                                            Game.removeEntity(projectile);
                                         });
                     }
                 };

--- a/game/src/ecs/entities/Entity.java
+++ b/game/src/ecs/entities/Entity.java
@@ -19,7 +19,7 @@ public class Entity {
 
     public Entity() {
         components = new HashMap<>();
-        Game.entitiesToAdd.add(this);
+        Game.addEntity(this);
         entityLogger = Logger.getLogger(this.getClass().getName());
         entityLogger.info("The entity '" + this.getClass().getSimpleName() + "' was created.");
     }

--- a/game/src/ecs/items/Item.java
+++ b/game/src/ecs/items/Item.java
@@ -82,7 +82,7 @@ public abstract class Item {
                     }
                 });
 
-        Game.addEntity(droppedItem);
+        Game.getEntities().add(droppedItem);
     }
 
     public ItemType getItemType() {

--- a/game/src/ecs/items/Item.java
+++ b/game/src/ecs/items/Item.java
@@ -77,12 +77,12 @@ public abstract class Item {
                                 .ifPresent(
                                         (x) -> {
                                             if (((InventoryComponent) x).addItem(this))
-                                                Game.entitiesToRemove.add(droppedItem);
+                                                Game.removeEntity(droppedItem);
                                         });
                     }
                 });
 
-        Game.entities.add(droppedItem);
+        Game.addEntity(droppedItem);
     }
 
     public ItemType getItemType() {

--- a/game/src/ecs/systems/AISystem.java
+++ b/game/src/ecs/systems/AISystem.java
@@ -11,7 +11,7 @@ public class AISystem extends ECS_System {
 
     @Override
     public void update() {
-        Game.entities.stream()
+        Game.getEntities().stream()
                 .flatMap(e -> e.getComponent(AIComponent.class).stream())
                 .map(aic -> buildDataObject((AIComponent) aic))
                 .forEach(aic -> aic.aic.execute());

--- a/game/src/ecs/systems/CollisionSystem.java
+++ b/game/src/ecs/systems/CollisionSystem.java
@@ -18,7 +18,7 @@ public class CollisionSystem extends ECS_System {
     /** checks if there is a collision between two entities based on their hitbox */
     @Override
     public void update() {
-        Game.entities.stream()
+        Game.getEntities().stream()
                 .flatMap(
                         a ->
                                 a
@@ -27,7 +27,7 @@ public class CollisionSystem extends ECS_System {
                                         .stream())
                 .flatMap(
                         a ->
-                                Game.entities.stream()
+                                Game.getEntities().stream()
                                         .filter(b -> a.getEntity().id < b.id)
                                         .flatMap(
                                                 b ->

--- a/game/src/ecs/systems/DrawSystem.java
+++ b/game/src/ecs/systems/DrawSystem.java
@@ -30,7 +30,7 @@ public class DrawSystem extends ECS_System {
 
     /** draw entities at their position */
     public void update() {
-        Game.entities.stream()
+        Game.getEntities().stream()
                 .flatMap(e -> e.getComponent(AnimationComponent.class).stream())
                 .map(ac -> buildDataObject((AnimationComponent) ac))
                 .forEach(this::draw);

--- a/game/src/ecs/systems/HealthSystem.java
+++ b/game/src/ecs/systems/HealthSystem.java
@@ -21,7 +21,7 @@ public class HealthSystem extends ECS_System {
 
     @Override
     public void update() {
-        Game.entities.stream()
+        Game.getEntities().stream()
                 // Consider only entities that have a HealthComponent
                 .flatMap(e -> e.getComponent(HealthComponent.class).stream())
                 // Form triples (e, hc, ac)
@@ -94,7 +94,7 @@ public class HealthSystem extends ECS_System {
         hsd.hc.triggerOnDeath();
         hsd.ac.setCurrentAnimation(hsd.hc.getDieAnimation());
         // TODO: Before removing the entity, check if the animation is finished (Issue #246)
-        Game.entitiesToRemove.add(hsd.hc.getEntity());
+        Game.removeEntity(hsd.hc.getEntity());
 
         // Add XP
         hsd.e

--- a/game/src/ecs/systems/PlayerSystem.java
+++ b/game/src/ecs/systems/PlayerSystem.java
@@ -16,7 +16,7 @@ public class PlayerSystem extends ECS_System {
 
     @Override
     public void update() {
-        Game.entities.stream()
+        Game.getEntities().stream()
                 .flatMap(e -> e.getComponent(PlayableComponent.class).stream())
                 .map(pc -> buildDataObject((PlayableComponent) pc))
                 .forEach(this::checkKeystroke);

--- a/game/src/ecs/systems/ProjectileSystem.java
+++ b/game/src/ecs/systems/ProjectileSystem.java
@@ -15,7 +15,7 @@ public class ProjectileSystem extends ECS_System {
     /** sets the velocity and removes entities that reached their endpoint */
     @Override
     public void update() {
-        Game.entities.stream()
+        Game.getEntities().stream()
                 // Consider only entities that have a ProjectileComponent
                 .flatMap(e -> e.getComponent(ProjectileComponent.class).stream())
                 .map(prc -> buildDataObject((ProjectileComponent) prc))
@@ -54,7 +54,7 @@ public class ProjectileSystem extends ECS_System {
     }
 
     private void removeEntitiesOnEndpoint(PSData data) {
-        Game.entitiesToRemove.add(data.pc.getEntity());
+        Game.removeEntity(data.pc.getEntity());
     }
 
     /**

--- a/game/src/ecs/systems/SkillSystem.java
+++ b/game/src/ecs/systems/SkillSystem.java
@@ -8,7 +8,7 @@ public class SkillSystem extends ECS_System {
     /** reduces the cool down for all skills */
     @Override
     public void update() {
-        Game.entities.stream()
+        Game.getEntities().stream()
                 // Consider only entities that have a SkillComponent
                 .flatMap(e -> e.getComponent(SkillComponent.class).stream())
                 .forEach(sc -> ((SkillComponent) sc).reduceAllCoolDowns());

--- a/game/src/ecs/systems/VelocitySystem.java
+++ b/game/src/ecs/systems/VelocitySystem.java
@@ -17,7 +17,7 @@ public class VelocitySystem extends ECS_System {
 
     /** Updates the position of all entities based on their velocity */
     public void update() {
-        Game.entities.stream()
+        Game.getEntities().stream()
                 .flatMap(e -> e.getComponent(VelocityComponent.class).stream())
                 .map(vc -> buildDataObject((VelocityComponent) vc))
                 .forEach(this::updatePosition);
@@ -35,7 +35,7 @@ public class VelocitySystem extends ECS_System {
         // remove projectiles that hit the wall or other non-accessible
         // tiles
         else if (vsd.e.getComponent(ProjectileComponent.class).isPresent())
-            Game.entitiesToRemove.add(vsd.e);
+            Game.removeEntity(vsd.e);
 
         vsd.vc.setCurrentYVelocity(0);
         vsd.vc.setCurrentXVelocity(0);

--- a/game/src/ecs/systems/XPSystem.java
+++ b/game/src/ecs/systems/XPSystem.java
@@ -7,7 +7,7 @@ public class XPSystem extends ECS_System {
 
     @Override
     public void update() {
-        Game.entities.stream()
+        Game.getEntities().stream()
                 .flatMap(e -> e.getComponent(XPComponent.class).stream())
                 .forEach(
                         component -> {

--- a/game/src/ecs/tools/interaction/InteractionTool.java
+++ b/game/src/ecs/tools/interaction/InteractionTool.java
@@ -26,7 +26,7 @@ public class InteractionTool {
                         entity.getComponent(PositionComponent.class)
                                 .orElseThrow(() -> MissingPCFromEntity(Hero.class.getName()));
         Optional<InteractionData> data =
-                Game.entities.stream()
+                Game.getEntities().stream()
                         .flatMap(
                                 x ->
                                         x

--- a/game/src/starter/Game.java
+++ b/game/src/starter/Game.java
@@ -256,44 +256,41 @@ public class Game extends ScreenAdapter implements IOnLevelLoader {
     }
 
     /**
-     * Saves entities that are added in next frame
+     * Given entity will be added to the game in the next frame
      *
-     * @param entity will be added next frame
+     * @param entity will be added to the game next frame
      */
-    public static void addEntity(Entity entity){
+    public static void addEntity(Entity entity) {
         entitiesToAdd.add(entity);
     }
 
     /**
-     * Saves entities that are removed in next frame
+     * Given entity will be removed from the game in the next frame
      *
-     * @param entity will be removed next frame
+     * @param entity will be removed from the game next frame
      */
-    public static void removeEntity(Entity entity){
+    public static void removeEntity(Entity entity) {
         entitiesToRemove.add(entity);
     }
 
     /**
-     *
      * @return Set with all entities currently in game
      */
-    public static Set<Entity> getEntities(){
+    public static Set<Entity> getEntities() {
         return entities;
     }
 
     /**
-     *
-     * @return Set with all entities currently in game
+     * @return Set with all entities that will be added to the game next frame
      */
-    public static Set<Entity> getEntitiesToAdd(){
+    public static Set<Entity> getEntitiesToAdd() {
         return entitiesToAdd;
     }
 
     /**
-     *
-     * @return Set with all entities currently in game
+     * @return Set with all entities that will be removed from the game next frame
      */
-    public static Set<Entity> getEntitiesToRemove(){
+    public static Set<Entity> getEntitiesToRemove() {
         return entitiesToRemove;
     }
 }

--- a/game/src/starter/Game.java
+++ b/game/src/starter/Game.java
@@ -64,11 +64,11 @@ public class Game extends ScreenAdapter implements IOnLevelLoader {
     static boolean paused = false;
 
     /** All entities that are currently active in the dungeon */
-    public static Set<Entity> entities = new HashSet<>();
+    private static Set<Entity> entities = new HashSet<>();
     /** All entities to be removed from the dungeon in the next frame */
-    public static Set<Entity> entitiesToRemove = new HashSet<>();
-
-    public static Set<Entity> entitiesToAdd = new HashSet<>();
+    private static Set<Entity> entitiesToRemove = new HashSet<>();
+    /** All entities to be added from the dungeon in the next frame */
+    private static Set<Entity> entitiesToAdd = new HashSet<>();
 
     /** List of all Systems in the ECS */
     public static SystemController systems;
@@ -253,5 +253,31 @@ public class Game extends ScreenAdapter implements IOnLevelLoader {
             throw new RuntimeException(e);
         }
         DesktopLauncher.run(new Game());
+    }
+
+    /**
+     * Saves entities that are added in next frame
+     *
+     * @param entity will be added next frame
+     */
+    public static void addEntity(Entity entity){
+        entitiesToAdd.add(entity);
+    }
+
+    /**
+     * Saves entities that are removed in next frame
+     *
+     * @param entity will be removed next frame
+     */
+    public static void removeEntity(Entity entity){
+        entitiesToRemove.add(entity);
+    }
+
+    /**
+     *
+     * @return Set with all entities currently in game
+     */
+    public static Set<Entity> getEntities(){
+        return entities;
     }
 }

--- a/game/src/starter/Game.java
+++ b/game/src/starter/Game.java
@@ -280,4 +280,20 @@ public class Game extends ScreenAdapter implements IOnLevelLoader {
     public static Set<Entity> getEntities(){
         return entities;
     }
+
+    /**
+     *
+     * @return Set with all entities currently in game
+     */
+    public static Set<Entity> getEntitiesToAdd(){
+        return entitiesToAdd;
+    }
+
+    /**
+     *
+     * @return Set with all entities currently in game
+     */
+    public static Set<Entity> getEntitiesToRemove(){
+        return entitiesToRemove;
+    }
 }

--- a/game/test/ecs/EntityTest.java
+++ b/game/test/ecs/EntityTest.java
@@ -16,18 +16,18 @@ public class EntityTest {
 
     @Before
     public void setup() {
-        Game.entities.clear();
-        Game.entitiesToAdd.clear();
-        Game.entitiesToRemove.clear();
+        Game.getEntities().clear();
+        Game.getEntitiesToAdd().clear();
+        Game.getEntitiesToRemove().clear();
         entity = new Entity();
         entity.addComponent(testComponent);
     }
 
     @Test
     public void cTor() {
-        Game.entities.addAll(Game.entitiesToAdd);
-        Game.entitiesToAdd.clear();
-        assertTrue(Game.entities.contains(entity));
+        Game.getEntities().addAll(Game.getEntitiesToAdd());
+        Game.getEntitiesToAdd().clear();
+        assertTrue(Game.getEntities().contains(entity));
     }
 
     @Test

--- a/game/test/ecs/components/DropLootTest.java
+++ b/game/test/ecs/components/DropLootTest.java
@@ -38,9 +38,9 @@ public class DropLootTest {
         Entity entity = new Entity();
         new PositionComponent(entity, new Point(1, 2));
         new InventoryComponent(entity, 10);
-        Game.entities.clear();
+        Game.getEntities().clear();
         dropLoot.onDeath(entity);
-        assertTrue(Game.entities.isEmpty());
+        assertTrue(Game.getEntities().isEmpty());
     }
 
     /** Checks the handling when the InventoryComponent has exactly one Item */
@@ -52,11 +52,11 @@ public class DropLootTest {
         new PositionComponent(entity, entityPosition);
         InventoryComponent inventoryComponent = new InventoryComponent(entity, 10);
         inventoryComponent.addItem(new Item() {});
-        Game.entities.clear();
+        Game.getEntities().clear();
         dropLoot.onDeath(entity);
-        assertEquals(1, Game.entities.size());
+        assertEquals(1, Game.getEntities().size());
         assertTrue(
-                Game.entities.stream()
+                Game.getEntities().stream()
                         .allMatch(
                                 x ->
                                         x.getComponent(PositionComponent.class)
@@ -79,11 +79,11 @@ public class DropLootTest {
         InventoryComponent inventoryComponent = new InventoryComponent(entity, 10);
         inventoryComponent.addItem(new Item() {});
         inventoryComponent.addItem(new Item() {});
-        Game.entities.clear();
+        Game.getEntities().clear();
         dropLoot.onDeath(entity);
-        assertEquals(2, Game.entities.size());
+        assertEquals(2, Game.getEntities().size());
         assertTrue(
-                Game.entities.stream()
+                Game.getEntities().stream()
                         .allMatch(
                                 x ->
                                         x.getComponent(PositionComponent.class)

--- a/game/test/ecs/components/HealthComponentTest.java
+++ b/game/test/ecs/components/HealthComponentTest.java
@@ -15,7 +15,7 @@ public class HealthComponentTest {
 
     @Test
     public void receiveHit() {
-        Game.entities.clear();
+        Game.getEntities().clear();
         Entity entity = new Entity();
         HealthComponent hc = new HealthComponent(entity);
         Damage fdmg = new Damage(3, DamageType.FIRE, null);
@@ -33,7 +33,7 @@ public class HealthComponentTest {
 
     @Test
     public void testDamageCause() {
-        Game.entities.clear();
+        Game.getEntities().clear();
         Entity entity = new Entity();
         Entity damager = new Entity();
         Entity damager2 = new Entity();
@@ -49,7 +49,7 @@ public class HealthComponentTest {
 
     @Test
     public void setMaximalHealthPointsLowerThanCurrent() {
-        Game.entities.clear();
+        Game.getEntities().clear();
         Entity entity = new Entity();
         HealthComponent hc = new HealthComponent(entity, 10, null, null, null);
         assertEquals(10, hc.getMaximalHealthpoints());
@@ -61,7 +61,7 @@ public class HealthComponentTest {
 
     @Test
     public void setMaximalHealthPointsHigherThanCurrent() {
-        Game.entities.clear();
+        Game.getEntities().clear();
         Entity entity = new Entity();
         HealthComponent hc = new HealthComponent(entity, 10, null, null, null);
         assertEquals(10, hc.getMaximalHealthpoints());
@@ -73,7 +73,7 @@ public class HealthComponentTest {
 
     @Test
     public void setCurrentHealthPointsHigherThanMaximum() {
-        Game.entities.clear();
+        Game.getEntities().clear();
         Entity entity = new Entity();
         HealthComponent hc = new HealthComponent(entity, 10, null, null, null);
         hc.setCurrentHealthpoints(12);
@@ -82,7 +82,7 @@ public class HealthComponentTest {
 
     @Test
     public void setCurrentHealthPointsLowerThanMaximum() {
-        Game.entities.clear();
+        Game.getEntities().clear();
         Entity entity = new Entity();
         HealthComponent hc = new HealthComponent(entity, 10, null, null, null);
         hc.setCurrentHealthpoints(8);
@@ -91,7 +91,7 @@ public class HealthComponentTest {
 
     @Test
     public void triggerOnDeath() {
-        Game.entities.clear();
+        Game.getEntities().clear();
         Entity entity = new Entity();
         IOnDeathFunction onDeathFunction = Mockito.mock(IOnDeathFunction.class);
         HealthComponent hc = new HealthComponent(entity, 10, onDeathFunction, null, null);
@@ -101,7 +101,7 @@ public class HealthComponentTest {
 
     @Test
     public void setDieAnimation() {
-        Game.entities.clear();
+        Game.getEntities().clear();
         Entity entity = new Entity();
         HealthComponent hc = new HealthComponent(entity);
         Animation animation = Mockito.mock(Animation.class);
@@ -111,7 +111,7 @@ public class HealthComponentTest {
 
     @Test
     public void setGetHitAnimation() {
-        Game.entities.clear();
+        Game.getEntities().clear();
         Entity entity = new Entity();
         HealthComponent hc = new HealthComponent(entity);
         Animation animation = Mockito.mock(Animation.class);
@@ -121,7 +121,7 @@ public class HealthComponentTest {
 
     @Test
     public void setOnDeathFunction() {
-        Game.entities.clear();
+        Game.getEntities().clear();
         Entity entity = new Entity();
         HealthComponent hc = new HealthComponent(entity);
         IOnDeathFunction function = Mockito.mock(IOnDeathFunction.class);

--- a/game/test/ecs/components/XPComponentTest.java
+++ b/game/test/ecs/components/XPComponentTest.java
@@ -14,7 +14,7 @@ public class XPComponentTest {
     @Test
     public void testStartXP() {
         /* Prepare */
-        Game.entities.clear();
+        Game.getEntities().clear();
         Game.systems = new SystemController();
         Entity entity = new Entity();
         XPComponent xpComponent = new XPComponent(entity, null);
@@ -28,7 +28,7 @@ public class XPComponentTest {
     @Test
     public void testAddXPSingle() {
         /* Prepare */
-        Game.entities.clear();
+        Game.getEntities().clear();
         Game.systems = new SystemController();
         Entity entity = new Entity();
         XPComponent xpComponent = new XPComponent(entity, null);
@@ -42,7 +42,7 @@ public class XPComponentTest {
     @Test
     public void testAddXPMultiple() {
         /* Prepare */
-        Game.entities.clear();
+        Game.getEntities().clear();
         Game.systems = new SystemController();
         Entity entity = new Entity();
         XPComponent xpComponent = new XPComponent(entity, null);
@@ -57,7 +57,7 @@ public class XPComponentTest {
     @Test
     public void testXPToNextLevelNonZero() {
         /* Prepare */
-        Game.entities.clear();
+        Game.getEntities().clear();
         Game.systems = new SystemController();
         Entity entity = new Entity();
         XPComponent xpComponent = new XPComponent(entity, null);
@@ -71,7 +71,7 @@ public class XPComponentTest {
     @Test
     public void testXPToNextLevelExact() {
         /* Prepare */
-        Game.entities.clear();
+        Game.getEntities().clear();
         Game.systems = new SystemController();
         Entity entity = new Entity();
         XPComponent xpComponent = new XPComponent(entity, null);
@@ -85,7 +85,7 @@ public class XPComponentTest {
     @Test
     public void testXPToNextLevelMore() {
         /* Prepare */
-        Game.entities.clear();
+        Game.getEntities().clear();
         Game.systems = new SystemController();
         Entity entity = new Entity();
         XPComponent xpComponent = new XPComponent(entity, null);

--- a/game/test/ecs/entities/ChestTest.java
+++ b/game/test/ecs/entities/ChestTest.java
@@ -18,9 +18,9 @@ public class ChestTest {
 
     /** Helper cleans up class attributes used by Chest Initializes the Item#ITEM_REGISTER */
     private static void cleanup() {
-        Game.entities.clear();
-        Game.entitiesToAdd.clear();
-        Game.entitiesToRemove.clear();
+        Game.getEntities().clear();
+        Game.getEntitiesToAdd().clear();
+        Game.getEntitiesToRemove().clear();
         Item.ITEM_REGISTER.clear();
     }
 
@@ -32,9 +32,9 @@ public class ChestTest {
         List<Item> items = List.of();
         Point position = new Point(0, 0);
         Chest c = new Chest(items, position);
-        Game.entities.addAll(Game.entitiesToAdd);
-        Game.entitiesToAdd.clear();
-        assertEquals("Chest is added to Game", 1, Game.entities.size());
+        Game.getEntities().addAll(Game.getEntitiesToAdd());
+        Game.getEntitiesToAdd().clear();
+        assertEquals("Chest is added to Game", 1, Game.getEntities().size());
         assertTrue(
                 "Needs the AnimationComponent to be visible to the player.",
                 c.getComponent(AnimationComponent.class).isPresent());
@@ -63,14 +63,14 @@ public class ChestTest {
         List<Item> items = List.of(Item.ITEM_REGISTER.get(0));
         Point position = new Point(0, 0);
         Chest c = new Chest(items, position);
-        Game.entities.addAll(Game.entitiesToAdd);
-        Game.entitiesToAdd.clear();
-        assertEquals(1, Game.entities.size());
+        Game.getEntities().addAll(Game.getEntitiesToAdd());
+        Game.getEntitiesToAdd().clear();
+        assertEquals(1, Game.getEntities().size());
         c.getComponent(InteractionComponent.class)
                 .map(InteractionComponent.class::cast)
                 .get()
                 .triggerInteraction();
-        assertEquals(2, Game.entities.size());
+        assertEquals(2, Game.getEntities().size());
 
         cleanup();
     }
@@ -83,13 +83,13 @@ public class ChestTest {
         List<Item> items = List.of(Item.ITEM_REGISTER.get(0));
         Point position = new Point(0, 0);
         Chest c = new Chest(items, position);
-        Game.entities.remove(c);
-        assertEquals(0, Game.entities.size());
+        Game.removeEntity(c);
+        assertEquals(0, Game.getEntities().size());
         c.getComponent(InteractionComponent.class)
                 .map(InteractionComponent.class::cast)
                 .ifPresent(InteractionComponent::triggerInteraction);
-        assertEquals(1, Game.entities.size());
-        Entity droppedItem = Game.entities.iterator().next();
+        assertEquals(1, Game.getEntities().size());
+        Entity droppedItem = Game.getEntities().iterator().next();
         assertTrue(
                 "droppedItem should have the HitboxComponent",
                 droppedItem
@@ -113,9 +113,9 @@ public class ChestTest {
                         },
                         DesignLabel.DEFAULT);
         Chest newChest = Chest.createNewChest();
-        Game.entities.addAll(Game.entitiesToAdd);
-        Game.entitiesToAdd.clear();
-        assertTrue("Chest is added to Game", Game.entities.contains(newChest));
+        Game.getEntities().addAll(Game.getEntitiesToAdd());
+        Game.getEntitiesToAdd().clear();
+        assertTrue("Chest is added to Game", Game.getEntities().contains(newChest));
         assertTrue(
                 "Needs the AnimationComponent to be visible to the player.",
                 newChest.getComponent(AnimationComponent.class).isPresent());

--- a/game/test/ecs/items/ItemTest.java
+++ b/game/test/ecs/items/ItemTest.java
@@ -61,17 +61,17 @@ public class ItemTest {
 
     @Before
     public void before() {
-        Game.entities.clear();
+        Game.getEntities().clear();
     }
 
     @Test
     public void onDropCheckEntity() {
         Item item = new ItemImpl();
-        assertEquals(0, Game.entities.size());
+        assertEquals(0, Game.getEntities().size());
         Point point = new Point(0, 0);
         item.onDrop(point);
-        assertEquals(1, Game.entities.size());
-        Entity e = Game.entities.iterator().next();
+        assertEquals(1, Game.getEntities().size());
+        Entity e = Game.getEntities().iterator().next();
         PositionComponent pc =
                 (PositionComponent) e.getComponent(PositionComponent.class).orElseThrow();
         assertEquals(point.x, pc.getPosition().x, 0.001);

--- a/game/test/ecs/systems/AISystemTest.java
+++ b/game/test/ecs/systems/AISystemTest.java
@@ -20,9 +20,9 @@ public class AISystemTest {
     @Before
     public void setup() {
         Game.systems = Mockito.mock(SystemController.class);
-        Game.entities.clear();
-        Game.entitiesToAdd.clear();
-        Game.entitiesToRemove.clear();
+        Game.getEntities().clear();
+        Game.getEntitiesToAdd().clear();
+        Game.getEntitiesToRemove().clear();
         system = new AISystem();
         entity = new Entity();
         AIComponent component = new AIComponent(entity);
@@ -39,8 +39,8 @@ public class AISystemTest {
 
     @Test
     public void update() {
-        Game.entities.addAll(Game.entitiesToAdd);
-        Game.entitiesToAdd.clear();
+        Game.getEntities().addAll(Game.getEntitiesToAdd());
+        Game.getEntitiesToAdd().clear();
         system.update();
         assertEquals(1, updateCounter);
     }

--- a/game/test/ecs/systems/CollisionSystemTest.java
+++ b/game/test/ecs/systems/CollisionSystemTest.java
@@ -32,9 +32,9 @@ public class CollisionSystemTest {
      */
     private static void cleanUpEnvironment() {
         Game.systems = null;
-        Game.entities.clear();
-        Game.entitiesToAdd.clear();
-        Game.entitiesToRemove.clear();
+        Game.getEntities().clear();
+        Game.getEntitiesToAdd().clear();
+        Game.getEntitiesToRemove().clear();
     }
 
     /** Creating a clean Systemcontroller to avoid interferences */
@@ -52,8 +52,8 @@ public class CollisionSystemTest {
     private static Entity prepareEntityWithPosition(Point point1) {
         Entity e1 = new Entity();
         new PositionComponent(e1, point1);
-        Game.entities.addAll(Game.entitiesToAdd);
-        Game.entitiesToAdd.clear();
+        Game.getEntities().addAll(Game.getEntitiesToAdd());
+        Game.getEntitiesToAdd().clear();
         return e1;
     }
 

--- a/game/test/ecs/systems/DrawSystemTest.java
+++ b/game/test/ecs/systems/DrawSystemTest.java
@@ -25,15 +25,15 @@ public class DrawSystemTest {
     @Before
     public void setup() {
         Game.systems = Mockito.mock(SystemController.class);
-        Game.entities.clear();
-        Game.entitiesToAdd.clear();
-        Game.entitiesToRemove.clear();
+        Game.getEntities().clear();
+        Game.getEntitiesToAdd().clear();
+        Game.getEntitiesToRemove().clear();
         drawSystem = new DrawSystem(painter);
         entity = new Entity();
         new AnimationComponent(entity, animation);
         new PositionComponent(entity, new Point(3, 3));
-        Game.entities.addAll(Game.entitiesToAdd);
-        Game.entitiesToAdd.clear();
+        Game.getEntities().addAll(Game.getEntitiesToAdd());
+        Game.getEntitiesToAdd().clear();
     }
 
     @Test

--- a/game/test/ecs/systems/HealthSystemTest.java
+++ b/game/test/ecs/systems/HealthSystemTest.java
@@ -20,11 +20,11 @@ public class HealthSystemTest {
 
     @Test
     public void updateEntityDies() {
-        Game.entities.clear();
+        Game.getEntities().clear();
         Game.systems = new SystemController();
         Entity entity = new Entity();
-        Game.entities.addAll(Game.entitiesToAdd);
-        Game.entitiesToAdd.clear();
+        Game.getEntities().addAll(Game.getEntitiesToAdd());
+        Game.getEntitiesToAdd().clear();
         IOnDeathFunction onDeath = Mockito.mock(IOnDeathFunction.class);
         Animation dieAnimation = Mockito.mock(Animation.class);
         AnimationComponent ac = new AnimationComponent(entity);
@@ -33,16 +33,16 @@ public class HealthSystemTest {
         component.setCurrentHealthpoints(0);
         system.update();
         assertEquals(dieAnimation, ac.getCurrentAnimation());
-        assertTrue(Game.entitiesToRemove.contains(entity));
+        assertTrue(Game.getEntitiesToRemove().contains(entity));
     }
 
     @Test
     public void updateEntityGetDamage() {
-        Game.entities.clear();
+        Game.getEntities().clear();
         Game.systems = new SystemController();
         Entity entity = new Entity();
-        Game.entities.addAll(Game.entitiesToAdd);
-        Game.entitiesToAdd.clear();
+        Game.getEntities().addAll(Game.getEntitiesToAdd());
+        Game.getEntitiesToAdd().clear();
         IOnDeathFunction onDeath = Mockito.mock(IOnDeathFunction.class);
         Animation hitAnimation = Mockito.mock(Animation.class);
         AnimationComponent ac = new AnimationComponent(entity);
@@ -57,11 +57,11 @@ public class HealthSystemTest {
 
     @Test
     public void updateEntityGetNegativeDamage() {
-        Game.entities.clear();
+        Game.getEntities().clear();
         Game.systems = new SystemController();
         Entity entity = new Entity();
-        Game.entities.addAll(Game.entitiesToAdd);
-        Game.entitiesToAdd.clear();
+        Game.getEntities().addAll(Game.getEntitiesToAdd());
+        Game.getEntitiesToAdd().clear();
         IOnDeathFunction onDeath = Mockito.mock(IOnDeathFunction.class);
         Animation hitAnimation = Mockito.mock(Animation.class);
         AnimationComponent ac = new AnimationComponent(entity);
@@ -76,11 +76,11 @@ public class HealthSystemTest {
 
     @Test
     public void updateEntityGetZeroDamage() {
-        Game.entities.clear();
+        Game.getEntities().clear();
         Game.systems = new SystemController();
         Entity entity = new Entity();
-        Game.entities.addAll(Game.entitiesToAdd);
-        Game.entitiesToAdd.clear();
+        Game.getEntities().addAll(Game.getEntitiesToAdd());
+        Game.getEntitiesToAdd().clear();
         IOnDeathFunction onDeath = Mockito.mock(IOnDeathFunction.class);
         Animation hitAnimation = Mockito.mock(Animation.class);
         AnimationComponent ac = new AnimationComponent(entity);
@@ -94,22 +94,22 @@ public class HealthSystemTest {
 
     @Test
     public void updateWithoutHealthComponent() {
-        Game.entities.clear();
+        Game.getEntities().clear();
         Game.systems = new SystemController();
         Entity entity = new Entity();
-        Game.entities.addAll(Game.entitiesToAdd);
-        Game.entitiesToAdd.clear();
+        Game.getEntities().addAll(Game.getEntitiesToAdd());
+        Game.getEntitiesToAdd().clear();
         HealthSystem system = new HealthSystem();
         system.update();
     }
 
     @Test
     public void updateWithoutAnimationComponent() {
-        Game.entities.clear();
+        Game.getEntities().clear();
         Game.systems = new SystemController();
         Entity entity = new Entity();
-        Game.entities.addAll(Game.entitiesToAdd);
-        Game.entitiesToAdd.clear();
+        Game.getEntities().addAll(Game.getEntitiesToAdd());
+        Game.getEntitiesToAdd().clear();
         HealthComponent component = new HealthComponent(entity);
         HealthSystem system = new HealthSystem();
         assertThrows(MissingComponentException.class, () -> system.update());
@@ -117,11 +117,11 @@ public class HealthSystemTest {
 
     @Test
     public void testDamageWithModifier() {
-        Game.entities.clear();
+        Game.getEntities().clear();
         Game.systems = new SystemController();
         Entity entity = new Entity();
-        Game.entities.addAll(Game.entitiesToAdd);
-        Game.entitiesToAdd.clear();
+        Game.getEntities().addAll(Game.getEntitiesToAdd());
+        Game.getEntitiesToAdd().clear();
         new AnimationComponent(entity);
         StatsComponent statsComponent = new StatsComponent(entity);
         statsComponent.getDamageModifiers().setMultiplier(DamageType.PHYSICAL, 2);
@@ -139,11 +139,11 @@ public class HealthSystemTest {
 
     @Test
     public void testDamageWithModifierNegative() {
-        Game.entities.clear();
+        Game.getEntities().clear();
         Game.systems = new SystemController();
         Entity entity = new Entity();
-        Game.entities.addAll(Game.entitiesToAdd);
-        Game.entitiesToAdd.clear();
+        Game.getEntities().addAll(Game.getEntitiesToAdd());
+        Game.getEntitiesToAdd().clear();
         new AnimationComponent(entity);
         StatsComponent statsComponent = new StatsComponent(entity);
         statsComponent.getDamageModifiers().setMultiplier(DamageType.PHYSICAL, -2);
@@ -161,11 +161,11 @@ public class HealthSystemTest {
 
     @Test
     public void testDamageWithModifierZero() {
-        Game.entities.clear();
+        Game.getEntities().clear();
         Game.systems = new SystemController();
         Entity entity = new Entity();
-        Game.entities.addAll(Game.entitiesToAdd);
-        Game.entitiesToAdd.clear();
+        Game.getEntities().addAll(Game.getEntitiesToAdd());
+        Game.getEntitiesToAdd().clear();
         new AnimationComponent(entity);
         StatsComponent statsComponent = new StatsComponent(entity);
         statsComponent.getDamageModifiers().setMultiplier(DamageType.PHYSICAL, 0);
@@ -183,11 +183,11 @@ public class HealthSystemTest {
 
     @Test
     public void testDamageWithModifierHuge() {
-        Game.entities.clear();
+        Game.getEntities().clear();
         Game.systems = new SystemController();
         Entity entity = new Entity();
-        Game.entities.addAll(Game.entitiesToAdd);
-        Game.entitiesToAdd.clear();
+        Game.getEntities().addAll(Game.getEntitiesToAdd());
+        Game.getEntitiesToAdd().clear();
         new AnimationComponent(entity);
         StatsComponent statsComponent = new StatsComponent(entity);
         statsComponent.getDamageModifiers().setMultiplier(DamageType.PHYSICAL, 100);

--- a/game/test/ecs/systems/SkillSystemTest.java
+++ b/game/test/ecs/systems/SkillSystemTest.java
@@ -16,12 +16,12 @@ public class SkillSystemTest {
 
     @Test
     public void update() {
-        Game.entities.clear();
+        Game.getEntities().clear();
         Game.systems = new SystemController();
         SkillSystem system = new SkillSystem();
         Entity entity = new Entity();
-        Game.entities.addAll(Game.entitiesToAdd);
-        Game.entitiesToAdd.clear();
+        Game.getEntities().addAll(Game.getEntitiesToAdd());
+        Game.getEntitiesToAdd().clear();
         ISkillFunction skillFunction = Mockito.mock(ISkillFunction.class);
         int coolDownInSeconds = 2;
         Skill testSkill = new Skill(skillFunction, coolDownInSeconds);

--- a/game/test/ecs/systems/VelocitySystemTest.java
+++ b/game/test/ecs/systems/VelocitySystemTest.java
@@ -44,9 +44,9 @@ public class VelocitySystemTest {
         Game.systems = Mockito.mock(SystemController.class);
         Game.currentLevel = level;
         Mockito.when(level.getTileAt(Mockito.any())).thenReturn(tile);
-        Game.entities.clear();
-        Game.entitiesToAdd.clear();
-        Game.entitiesToRemove.clear();
+        Game.getEntities().clear();
+        Game.getEntitiesToAdd().clear();
+        Game.getEntitiesToRemove().clear();
         entity = new Entity();
 
         velocitySystem = new VelocitySystem();
@@ -55,8 +55,8 @@ public class VelocitySystemTest {
         positionComponent =
                 new PositionComponent(entity, new Point(startXPosition, startYPosition));
         animationComponent = new AnimationComponent(entity, idleLeft, idleRight);
-        Game.entities.addAll(Game.entitiesToAdd);
-        Game.entitiesToAdd.clear();
+        Game.getEntities().addAll(Game.getEntitiesToAdd());
+        Game.getEntitiesToAdd().clear();
     }
 
     @Test

--- a/game/test/ecs/systems/XPSystemTest.java
+++ b/game/test/ecs/systems/XPSystemTest.java
@@ -16,9 +16,9 @@ public class XPSystemTest {
     @Test
     public void testStartingWithZero() {
         /* Prepare */
-        Game.entities.clear();
-        Game.entitiesToAdd.clear();
-        Game.entitiesToRemove.clear();
+        Game.getEntities().clear();
+        Game.getEntitiesToAdd().clear();
+        Game.getEntitiesToRemove().clear();
         Game.systems = new SystemController();
         Entity entity = new Entity();
         ILevelUp levelUp = Mockito.mock(ILevelUp.class);
@@ -36,9 +36,9 @@ public class XPSystemTest {
     @Test
     public void testNoLevelUp() {
         /* Prepare */
-        Game.entities.clear();
-        Game.entitiesToAdd.clear();
-        Game.entitiesToRemove.clear();
+        Game.getEntities().clear();
+        Game.getEntitiesToAdd().clear();
+        Game.getEntitiesToRemove().clear();
         Game.systems = new SystemController();
         Entity entity = new Entity();
         ILevelUp levelUp = Mockito.mock(ILevelUp.class);
@@ -55,16 +55,16 @@ public class XPSystemTest {
     @Test
     public void testLevelUpExact() {
         /* Prepare */
-        Game.entities.clear();
-        Game.entitiesToAdd.clear();
-        Game.entitiesToRemove.clear();
+        Game.getEntities().clear();
+        Game.getEntitiesToAdd().clear();
+        Game.getEntitiesToRemove().clear();
         Game.systems = new SystemController();
         Entity entity = new Entity();
         ILevelUp levelUp = Mockito.mock(ILevelUp.class);
         XPComponent xpComponent = new XPComponent(entity, levelUp);
         XPSystem xpSystem = new XPSystem();
-        Game.entities.addAll(Game.entitiesToAdd);
-        Game.entitiesToAdd.clear();
+        Game.getEntities().addAll(Game.getEntitiesToAdd());
+        Game.getEntitiesToAdd().clear();
 
         /* Test */
         xpComponent.addXP(100); // First level is reached with 100 XP
@@ -77,16 +77,16 @@ public class XPSystemTest {
     @Test
     public void testLevelUpOverflow() {
         /* Prepare */
-        Game.entities.clear();
-        Game.entitiesToAdd.clear();
-        Game.entitiesToRemove.clear();
+        Game.getEntities().clear();
+        Game.getEntitiesToAdd().clear();
+        Game.getEntitiesToRemove().clear();
         Game.systems = new SystemController();
         Entity entity = new Entity();
         ILevelUp levelUp = Mockito.mock(ILevelUp.class);
         XPComponent xpComponent = new XPComponent(entity, levelUp);
         XPSystem xpSystem = new XPSystem();
-        Game.entities.addAll(Game.entitiesToAdd);
-        Game.entitiesToAdd.clear();
+        Game.getEntities().addAll(Game.getEntitiesToAdd());
+        Game.getEntitiesToAdd().clear();
 
         /* Test */
         xpComponent.addXP(120); // First level is reached with 100 XP
@@ -102,16 +102,16 @@ public class XPSystemTest {
     @Test
     public void testLevelUpMultipleExact() {
         /* Prepare */
-        Game.entities.clear();
-        Game.entitiesToAdd.clear();
-        Game.entitiesToRemove.clear();
+        Game.getEntities().clear();
+        Game.getEntitiesToAdd().clear();
+        Game.getEntitiesToRemove().clear();
         Game.systems = new SystemController();
         Entity entity = new Entity();
         ILevelUp levelUp = Mockito.mock(ILevelUp.class);
         XPComponent xpComponent = new XPComponent(entity, levelUp);
         XPSystem xpSystem = new XPSystem();
-        Game.entities.addAll(Game.entitiesToAdd);
-        Game.entitiesToAdd.clear();
+        Game.getEntities().addAll(Game.getEntitiesToAdd());
+        Game.getEntitiesToAdd().clear();
 
         /* Test */
         xpComponent.addXP(201);
@@ -127,9 +127,9 @@ public class XPSystemTest {
     @Test
     public void testLevelUpMultipleOverflow() {
         /* Prepare */
-        Game.entities.clear();
-        Game.entitiesToAdd.clear();
-        Game.entitiesToRemove.clear();
+        Game.getEntities().clear();
+        Game.getEntitiesToAdd().clear();
+        Game.getEntitiesToRemove().clear();
         Game.systems = new SystemController();
         Entity entity = new Entity();
         ILevelUp levelUp = Mockito.mock(ILevelUp.class);
@@ -137,8 +137,8 @@ public class XPSystemTest {
         XPSystem xpSystem = new XPSystem();
 
         /* Test */
-        Game.entities.addAll(Game.entitiesToAdd);
-        Game.entitiesToAdd.clear();
+        Game.getEntities().addAll(Game.getEntitiesToAdd());
+        Game.getEntitiesToAdd().clear();
         xpComponent.addXP(221);
         xpSystem.update();
         assertEquals(2, xpComponent.getCurrentLevel());
@@ -149,9 +149,9 @@ public class XPSystemTest {
     @Test
     public void testNegativeXP() {
         /* Prepare */
-        Game.entities.clear();
-        Game.entitiesToAdd.clear();
-        Game.entitiesToRemove.clear();
+        Game.getEntities().clear();
+        Game.getEntitiesToAdd().clear();
+        Game.getEntitiesToRemove().clear();
         Game.systems = new SystemController();
         Entity entity = new Entity();
         ILevelUp levelUp = Mockito.mock(ILevelUp.class);

--- a/game/test/ecs/tools/interaction/ControlPointReachableTest.java
+++ b/game/test/ecs/tools/interaction/ControlPointReachableTest.java
@@ -73,7 +73,7 @@ public class ControlPointReachableTest {
 
     private void cleanup() {
         Game.currentLevel = null;
-        Game.entities.clear();
+        Game.getEntities().clear();
     }
 
     private void setup() {

--- a/game/test/ecs/tools/interaction/InteractionToolTest.java
+++ b/game/test/ecs/tools/interaction/InteractionToolTest.java
@@ -55,9 +55,9 @@ public class InteractionToolTest {
 
     /** cleanup to reset static Attributes from Game used by the InteractionTool */
     private static void cleanup() {
-        Game.entities.clear();
-        Game.entitiesToAdd.clear();
-        Game.entitiesToRemove.clear();
+        Game.getEntities().clear();
+        Game.getEntitiesToAdd().clear();
+        Game.getEntitiesToRemove().clear();
         Game.hero = null;
         Game.currentLevel = null;
     }
@@ -91,8 +91,8 @@ public class InteractionToolTest {
         cleanup();
         Game.hero = fullMockedHero(true);
         Game.currentLevel = prepareLevel();
-        Game.entities.addAll(Game.entitiesToAdd);
-        Game.entitiesToAdd.clear();
+        Game.getEntities().addAll(Game.getEntitiesToAdd());
+        Game.getEntitiesToAdd().clear();
         InteractionTool.interactWithClosestInteractable(Game.hero);
         cleanup();
     }
@@ -105,7 +105,7 @@ public class InteractionToolTest {
         cleanup();
         Game.hero = fullMockedHero(true);
         Game.currentLevel = prepareLevel();
-        Game.entities.add(Game.hero);
+        Game.getEntities().add(Game.hero);
         InteractionTool.interactWithClosestInteractable(Game.hero);
         cleanup();
     }
@@ -148,8 +148,8 @@ public class InteractionToolTest {
         SimpleCounter sc_e = new SimpleCounter();
         new InteractionComponent(e, 5f, false, (x) -> sc_e.inc());
 
-        Game.entities.addAll(Game.entitiesToAdd);
-        Game.entitiesToAdd.clear();
+        Game.getEntities().addAll(Game.getEntitiesToAdd());
+        Game.getEntitiesToAdd().clear();
 
         InteractionTool.interactWithClosestInteractable(Game.hero);
         assertEquals("One interaction should happen", 1, sc_e.getCount());
@@ -169,8 +169,8 @@ public class InteractionToolTest {
         SimpleCounter sc_e = new SimpleCounter();
         new InteractionComponent(e, 5f, false, (x) -> sc_e.inc());
 
-        Game.entities.addAll(Game.entitiesToAdd);
-        Game.entitiesToAdd.clear();
+        Game.getEntities().addAll(Game.getEntitiesToAdd());
+        Game.getEntitiesToAdd().clear();
 
         MissingComponentException exception =
                 assertThrows(
@@ -211,8 +211,8 @@ public class InteractionToolTest {
         Entity eFar = new Entity();
         new PositionComponent(eFar, new Point(3, 0));
 
-        Game.entities.addAll(Game.entitiesToAdd);
-        Game.entitiesToAdd.clear();
+        Game.getEntities().addAll(Game.getEntitiesToAdd());
+        Game.getEntitiesToAdd().clear();
 
         SimpleCounter sc_eFar = new SimpleCounter();
         new InteractionComponent(eFar, 5f, false, (x) -> sc_eFar.inc());
@@ -248,8 +248,8 @@ public class InteractionToolTest {
         SimpleCounter sc_eClose = new SimpleCounter();
         new InteractionComponent(eClose, 5f, false, (x) -> sc_eClose.inc());
 
-        Game.entities.addAll(Game.entitiesToAdd);
-        Game.entitiesToAdd.clear();
+        Game.getEntities().addAll(Game.getEntitiesToAdd());
+        Game.getEntitiesToAdd().clear();
 
         InteractionTool.interactWithClosestInteractable(Game.hero);
         assertEquals("One interaction should happen", 1, sc_eClose.getCount());

--- a/game/test/starter/GameTest.java
+++ b/game/test/starter/GameTest.java
@@ -1,8 +1,12 @@
 package starter;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import ecs.entities.Entity;
 import graphic.DungeonCamera;
 import graphic.Painter;
 import level.LevelAPI;
@@ -29,6 +33,10 @@ class GameTest {
 
     @Before
     public void setUp() throws Exception {
+        Game.getEntities().clear();
+        Game.getEntitiesToAdd().clear();
+        Game.getEntitiesToRemove().clear();
+
         game = Mockito.spy(Game.class);
         batch = Mockito.mock(SpriteBatch.class);
 
@@ -85,4 +93,31 @@ class GameTest {
         Mockito.verifyNoMoreInteractions(game);
          */
     }
+
+    @Test
+    public void addEntity() {
+        Entity e1 = Mockito.mock(Entity.class);
+        Game.addEntity(e1);
+        assertTrue(Game.getEntitiesToAdd().contains(e1));
+        assertEquals(1, Game.getEntitiesToAdd().size());
+        Game.getEntities().clear();
+        Game.getEntitiesToAdd().clear();
+    }
+
+    @Test
+    public void removeEntity() {
+        Entity e1 = Mockito.mock(Entity.class);
+        Game.removeEntity(e1);
+        assertTrue(Game.getEntitiesToRemove().contains(e1));
+        assertEquals(1, Game.getEntitiesToRemove().size());
+        Game.getEntities().clear();
+        Game.getEntitiesToRemove().clear();
+    }
+
+    /*
+    Cannot be tested at the moment, render test must be fixed first
+
+    @Test
+    public void test_getEntity(){}
+     */
 }


### PR DESCRIPTION
fixes #489

- Die Sets entities, entitiesToAdd und entitiesToRemove sind jetzt private
    - Die Methoden `addEntity(Entity entity)` und `removeEntity(Entity entity)` implementiert, welche die Entitäten zu den jeweiligen Sets hinzufügt
    - Getter für die Sets erstellt
- Bestehende Tests angepasst
- Test zum Hinzufügen in die Sets entitiesToAdd und entitiesToRemove ergänzt
- Dokumentation aktualisiert