### PR TITLE
[GAME] SkillComponent aus Hero-Klasse entfernt

### DIFF
--- a/game/src/ecs/entities/Hero.java
+++ b/game/src/ecs/entities/Hero.java
@@ -37,9 +37,7 @@ public class Hero extends Entity {
         setupAnimationComponent();
         setupHitboxComponent();
         PlayableComponent pc = new PlayableComponent(this);
-        SkillComponent sc = new SkillComponent(this);
         setupFireballSkill();
-        sc.addSkill(firstSkill);
         pc.setSkillSlot1(firstSkill);
     }
 


### PR DESCRIPTION
fixes #531 

- SkillComponent war in der Hero-Klasse, wurde aber noch nicht genutzt. Um es den Studis leichter zu machen, wurde es entfernt.