### PR TITLE
[GAME] update Javadoc for AnimationComponent, DrawSystem and Animation

### DIFF
--- a/game/src/ecs/components/AnimationComponent.java
+++ b/game/src/ecs/components/AnimationComponent.java
@@ -10,8 +10,11 @@ import semanticAnalysis.types.DSLType;
 import semanticAnalysis.types.DSLTypeMember;
 
 /**
- * AnimationComponent is a component that stores the possible animations and the current animation
- * of an entity
+ * The AnimationComponent class represents a component that stores the possible idle animations and
+ * the current animation of an entity. The AnimationComponent can have two idle animations when the
+ * entity is not moving, an idle animation for when the entity is facing left and another idle
+ * animation for when the entity is facing right. The current animation is the animation that is
+ * currently being displayed.
  */
 @DSLType(name = "animation_component")
 public class AnimationComponent extends Component {
@@ -22,9 +25,12 @@ public class AnimationComponent extends Component {
     private final Logger animCompLogger = Logger.getLogger(this.getClass().getName());
 
     /**
-     * @param entity associated entity
-     * @param idleLeft Idleanimation faced left
-     * @param idleRight Idleanimation faced right
+     * Creates an AnimationComponent object with the associated entity, idle animation faced left,
+     * and idle animation faced right.
+     *
+     * @param entity the associated entity
+     * @param idleLeft the idle animation faced left
+     * @param idleRight the idle animation faced right
      */
     public AnimationComponent(Entity entity, Animation idleLeft, Animation idleRight) {
         super(entity);
@@ -34,15 +40,19 @@ public class AnimationComponent extends Component {
     }
 
     /**
-     * @param entity associated entity
-     * @param idle Idleanimation
+     * Creates an AnimationComponent object with the associated entity and idle animation.
+     *
+     * @param entity the associated entity
+     * @param idle the idle animation
      */
     public AnimationComponent(Entity entity, Animation idle) {
         this(entity, idle, idle);
     }
 
     /**
-     * @param entity associated entity
+     * Creates an AnimationComponent object with the associated entity and default idle animations.
+     *
+     * @param entity the associated entity
      */
     public AnimationComponent(@DSLContextMember(name = "entity") Entity entity) {
         super(entity);
@@ -57,7 +67,9 @@ public class AnimationComponent extends Component {
     }
 
     /**
-     * @param animation new current animation of the entity
+     * Sets the current animation of the entity to the given animation.
+     *
+     * @param animation the new current animation of the entity
      */
     public void setCurrentAnimation(Animation animation) {
         if (animation.getAnimationFrames().size() > 0) {
@@ -73,7 +85,9 @@ public class AnimationComponent extends Component {
     }
 
     /**
-     * @return current animation of the entity
+     * Returns the current animation of the entity.
+     *
+     * @return the current animation of the entity
      */
     public Animation getCurrentAnimation() {
         if (currentAnimation.getAnimationFrames().size() > 0) {
@@ -97,14 +111,18 @@ public class AnimationComponent extends Component {
     }
 
     /**
-     * @return Idleanimation faced left
+     * Returns the idle animation faced left of the entity.
+     *
+     * @return the idle animation faced left of the entity
      */
     public Animation getIdleLeft() {
         return idleLeft;
     }
 
     /**
-     * @return Idleanimation faced right
+     * Returns the idle animation faced right of the entity.
+     *
+     * @return the idle animation faced right of the entity
      */
     public Animation getIdleRight() {
         return idleRight;

--- a/game/src/ecs/systems/DrawSystem.java
+++ b/game/src/ecs/systems/DrawSystem.java
@@ -11,16 +11,26 @@ import java.util.HashMap;
 import java.util.Map;
 import starter.Game;
 
-/** used to draw entities */
+/**
+ * A system used to draw entities on the screen based on their current animation and position. It
+ * uses a Painter object to draw the entities and maintains a mapping of PainterConfig objects for
+ * each texture used.
+ */
 public class DrawSystem extends ECS_System {
 
     private Painter painter;
     private Map<String, PainterConfig> configs;
 
+    /**
+     * Private record class used to store the entity, its animation component and its position
+     * component in one object
+     */
     private record DSData(Entity e, AnimationComponent ac, PositionComponent pc) {}
 
     /**
-     * @param painter PM-Dungeon painter to draw
+     * Constructor for DrawSystem
+     *
+     * @param painter the PM-Dungeon painter used to draw the entities
      */
     public DrawSystem(Painter painter) {
         super();
@@ -28,7 +38,11 @@ public class DrawSystem extends ECS_System {
         configs = new HashMap<>();
     }
 
-    /** draw entities at their position */
+    /**
+     * It loops through all the entities in the game and draws the animation component of each
+     * entity that has it. It uses the current animation of the entity and draws it at the position
+     * of the entity.
+     */
     public void update() {
         Game.getEntities().stream()
                 .flatMap(e -> e.getComponent(AnimationComponent.class).stream())
@@ -36,6 +50,11 @@ public class DrawSystem extends ECS_System {
                 .forEach(this::draw);
     }
 
+    /**
+     * Draws the current animation of the provided entity at the current location
+     *
+     * @param dsd object containing the entity, its animation component and its position component
+     */
     private void draw(DSData dsd) {
         final Animation animation = dsd.ac.getCurrentAnimation();
         String currentAnimationTexture = animation.getNextAnimationTexturePath();
@@ -48,6 +67,14 @@ public class DrawSystem extends ECS_System {
                 configs.get(currentAnimationTexture));
     }
 
+    /**
+     * Builds a DSData object containing the entity, its animation component and its position
+     * component
+     *
+     * @param ac the animation component of the entity
+     * @return the DSData object containing the entity, its animation component and its position
+     *     component
+     */
     private DSData buildDataObject(AnimationComponent ac) {
         Entity e = ac.getEntity();
 
@@ -58,12 +85,18 @@ public class DrawSystem extends ECS_System {
         return new DSData(e, ac, pc);
     }
 
+    /** It is not possible to pause the DrawSystem, so it always runs. */
     @Override
     public void toggleRun() {
         // DrawSystem cant pause
         run = true;
     }
 
+    /**
+     * Returns a new MissingComponentException for a missing PositionComponent
+     *
+     * @return the new MissingComponentException
+     */
     private static MissingComponentException missingPC() {
         return new MissingComponentException("PositionComponent");
     }

--- a/game/src/graphic/Animation.java
+++ b/game/src/graphic/Animation.java
@@ -4,7 +4,11 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-/** A list of textures from an animation. */
+/**
+
+ A collection of textures that form an animation sequence.
+ Animations are used to draw entities on the screen.
+ */
 public class Animation {
 
     /** The set of textures that build the animation. */


### PR DESCRIPTION
updaten der Javadoc für die Components und Systeme die mit sich mit den Theme "Zeichnen" beschäftigen
Konkret sind das:

- `Animation`
- `AnimationComponent`
- `DrawSystem`

@cagix Ich schnürre grade kleinen Themen-Bundles, um die Dokumentation für den Semesterstart noch etwas aufzupolieren und schnelle merge Prozesse zu ermöglichen. 
Meine Taktik ist dabei aktuell nur die JavaDoc mit meiner Lieblings AI anzupassen. Die Dokumentation in `doc` ist Aufwendiger und folgt später.
