### PR TITLE
[GAME] Add Ctor with default position (PositonComponent)

### DIFF
--- a/game/src/ecs/components/PositionComponent.java
+++ b/game/src/ecs/components/PositionComponent.java
@@ -1,7 +1,6 @@
 package ecs.components;
 
 import ecs.entities.Entity;
-import java.util.logging.Logger;
 import level.tools.LevelElement;
 import logging.CustomLogLevel;
 import semanticAnalysis.types.DSLContextMember;
@@ -9,12 +8,14 @@ import semanticAnalysis.types.DSLType;
 import starter.Game;
 import tools.Point;
 
+import java.util.logging.Logger;
+
 /** PositionComponent is a component that stores the x, y (as Point) position of an entity */
 @DSLType(name = "position_component")
 public class PositionComponent extends Component {
 
-    private /*@DSLTypeMember(name="position")*/ Point position;
     private final Logger positionCompLogger = Logger.getLogger(this.getClass().getName());
+    private /*@DSLTypeMember(name="position")*/ Point position;
 
     /**
      * Creates a new PositionComponent to store the associated entity's position in the level and

--- a/game/src/ecs/components/PositionComponent.java
+++ b/game/src/ecs/components/PositionComponent.java
@@ -31,8 +31,7 @@ public class PositionComponent extends Component {
      * @param y y-position of the entity
      */
     public PositionComponent(@DSLContextMember(name = "entity") Entity entity, float x, float y) {
-        super(entity);
-        this.position = new Point(x, y);
+        this(entity, new Point(x, y));
     }
 
     /**

--- a/game/src/ecs/components/PositionComponent.java
+++ b/game/src/ecs/components/PositionComponent.java
@@ -39,7 +39,7 @@ public class PositionComponent extends Component {
      * <p>Creates a new PositionComponent to store the associated entity's position in the level and
      * add this component to the associated entity.
      *
-     * <p>Sets the position of this entity to a Point with the given x and y positions.
+     * <p>Sets the position of this entity to a point with the given x and y positions.
      *
      * @param entity associated entity
      * @param x x-position of the entity

--- a/game/src/ecs/components/PositionComponent.java
+++ b/game/src/ecs/components/PositionComponent.java
@@ -10,7 +10,7 @@ import tools.Point;
 
 import java.util.logging.Logger;
 
-/** PositionComponent is a component that stores the x, y (as Point) position of an entity */
+/** A PositionComponent stores the associated entity's position in the level */
 @DSLType(name = "position_component")
 public class PositionComponent extends Component {
 
@@ -18,10 +18,12 @@ public class PositionComponent extends Component {
     private /*@DSLTypeMember(name="position")*/ Point position;
 
     /**
-     * Creates a new PositionComponent to store the associated entity's position in the level and
+     * Creates a new PositionComponent at a given point.
+     *
+     * <p>Creates a new PositionComponent to store the associated entity's position in the level and
      * add this component to the associated entity.
      *
-     * <p>Set the position of this entity to the given Point.
+     * <p>Sets the position of this entity to the given point.
      *
      * @param entity associated entity
      * @param point position of the entity
@@ -32,10 +34,12 @@ public class PositionComponent extends Component {
     }
 
     /**
-     * Creates a new PositionComponent to store the associated entity's position in the level and
+     * Creates a new PositionComponent at a given point.
+     *
+     * <p>Creates a new PositionComponent to store the associated entity's position in the level and
      * add this component to the associated entity.
      *
-     * <p>Set the position of this entity to a Point with the given x and y positions.
+     * <p>Sets the position of this entity to a Point with the given x and y positions.
      *
      * @param entity associated entity
      * @param x x-position of the entity
@@ -46,12 +50,14 @@ public class PositionComponent extends Component {
     }
 
     /**
-     * Creates a new PositionComponent to store the associated entity's position in the level and
+     * Creates a new PositionComponent at a random point.
+     *
+     * <p>Creates a new PositionComponent to store the associated entity's position in the level and
      * add this component to the associated entity.
      *
-     * <p>Set the position of this entity on a random floor tile in the level. If no level is
-     * loaded, set the position to (0,0). Please note that (0,0) may not necessarily be a playable
-     * area within the level, it could be a wall or an "out of level" area.
+     * <p>Sets the position of this entity on a random floor tile in the level. If no level is
+     * loaded, set the position to (0,0). Beware that (0,0) may not necessarily be a playable area
+     * within the level, it could be a wall or an "out of level" area.
      *
      * @param entity associated entity
      */

--- a/game/src/ecs/components/PositionComponent.java
+++ b/game/src/ecs/components/PositionComponent.java
@@ -30,6 +30,7 @@ public class PositionComponent extends Component {
      */
     public PositionComponent(@DSLContextMember(name = "entity") Entity entity, Point point) {
         super(entity);
+
         this.position = point;
     }
 
@@ -63,10 +64,13 @@ public class PositionComponent extends Component {
      */
     public PositionComponent(@DSLContextMember(name = "entity") Entity entity) {
         super(entity);
-        if (Game.currentLevel != null)
+
+        if (Game.currentLevel != null) {
             position =
                     Game.currentLevel.getRandomTile(LevelElement.FLOOR).getCoordinate().toPoint();
-        else position = new Point(0, 0);
+        } else {
+            position = new Point(0, 0);
+        }
     }
 
     /**

--- a/game/src/ecs/components/PositionComponent.java
+++ b/game/src/ecs/components/PositionComponent.java
@@ -1,7 +1,6 @@
 package ecs.components;
 
 import ecs.entities.Entity;
-import level.tools.LevelElement;
 import logging.CustomLogLevel;
 import semanticAnalysis.types.DSLContextMember;
 import semanticAnalysis.types.DSLType;
@@ -66,7 +65,7 @@ public class PositionComponent extends Component {
         super(entity);
 
         if (Game.currentLevel != null) {
-            position = Game.currentLevel.getRandomTile(LevelElement.FLOOR).getCoordinateAsPoint();
+            position = Game.currentLevel.getRandomFloorTile().getCoordinateAsPoint();
         } else {
             position = new Point(0, 0);
         }

--- a/game/src/ecs/components/PositionComponent.java
+++ b/game/src/ecs/components/PositionComponent.java
@@ -35,8 +35,9 @@ public class PositionComponent extends Component {
     }
 
     /**
-     * Set the position of this entity on a random floor tile in the level. if no level is loaded,
-     * set the position to (0,0)
+     * Set the position of this entity on a random floor tile in the level. If no level is loaded,
+     * set the position to (0,0). Please note that (0,0) may not necessarily be a playable area
+     * within the level, it could be a wall or an "out of level" area.
      *
      * @param entity associated entity
      */

--- a/game/src/ecs/components/PositionComponent.java
+++ b/game/src/ecs/components/PositionComponent.java
@@ -66,8 +66,7 @@ public class PositionComponent extends Component {
         super(entity);
 
         if (Game.currentLevel != null) {
-            position =
-                    Game.currentLevel.getRandomTile(LevelElement.FLOOR).getCoordinate().toPoint();
+            position = Game.currentLevel.getRandomTile(LevelElement.FLOOR).getCoordinateAsPoint();
         } else {
             position = new Point(0, 0);
         }

--- a/game/src/ecs/components/PositionComponent.java
+++ b/game/src/ecs/components/PositionComponent.java
@@ -1,13 +1,12 @@
 package ecs.components;
 
 import ecs.entities.Entity;
+import java.util.logging.Logger;
 import logging.CustomLogLevel;
 import semanticAnalysis.types.DSLContextMember;
 import semanticAnalysis.types.DSLType;
 import starter.Game;
 import tools.Point;
-
-import java.util.logging.Logger;
 
 /** A PositionComponent stores the associated entity's position in the level */
 @DSLType(name = "position_component")

--- a/game/src/ecs/components/PositionComponent.java
+++ b/game/src/ecs/components/PositionComponent.java
@@ -17,6 +17,11 @@ public class PositionComponent extends Component {
     private final Logger positionCompLogger = Logger.getLogger(this.getClass().getName());
 
     /**
+     * Creates a new PositionComponent to store the associated entity's position in the level and
+     * add this component to the associated entity.
+     *
+     * <p>Set the position of this entity to the given Point.
+     *
      * @param entity associated entity
      * @param point position of the entity
      */
@@ -26,6 +31,11 @@ public class PositionComponent extends Component {
     }
 
     /**
+     * Creates a new PositionComponent to store the associated entity's position in the level and
+     * add this component to the associated entity.
+     *
+     * <p>Set the position of this entity to a Point with the given x and y positions.
+     *
      * @param entity associated entity
      * @param x x-position of the entity
      * @param y y-position of the entity
@@ -35,9 +45,12 @@ public class PositionComponent extends Component {
     }
 
     /**
-     * Set the position of this entity on a random floor tile in the level. If no level is loaded,
-     * set the position to (0,0). Please note that (0,0) may not necessarily be a playable area
-     * within the level, it could be a wall or an "out of level" area.
+     * Creates a new PositionComponent to store the associated entity's position in the level and
+     * add this component to the associated entity.
+     *
+     * <p>Set the position of this entity on a random floor tile in the level. If no level is
+     * loaded, set the position to (0,0). Please note that (0,0) may not necessarily be a playable
+     * area within the level, it could be a wall or an "out of level" area.
      *
      * @param entity associated entity
      */

--- a/game/src/ecs/components/PositionComponent.java
+++ b/game/src/ecs/components/PositionComponent.java
@@ -27,11 +27,26 @@ public class PositionComponent extends Component {
 
     /**
      * @param entity associated entity
+     * @param x x-position of the entity
+     * @param y y-position of the entity
+     */
+    public PositionComponent(@DSLContextMember(name = "entity") Entity entity, float x, float y) {
+        super(entity);
+        this.position = new Point(x, y);
+    }
+
+    /**
+     * Set the position of this entity on a random floor tile in the level. if no level is loaded,
+     * set the position to (0,0)
+     *
+     * @param entity associated entity
      */
     public PositionComponent(@DSLContextMember(name = "entity") Entity entity) {
         super(entity);
-        this.position =
-                Game.currentLevel.getRandomTile(LevelElement.FLOOR).getCoordinate().toPoint();
+        if (Game.currentLevel != null)
+            position =
+                    Game.currentLevel.getRandomTile(LevelElement.FLOOR).getCoordinate().toPoint();
+        else position = new Point(0, 0);
     }
 
     /**

--- a/game/src/ecs/entities/Hero.java
+++ b/game/src/ecs/entities/Hero.java
@@ -7,7 +7,6 @@ import ecs.components.PositionComponent;
 import ecs.components.VelocityComponent;
 import ecs.components.skill.*;
 import graphic.Animation;
-import tools.Point;
 
 /**
  * The Hero is the player character. It's entity in the ECS. This class helps to setup the hero with
@@ -25,14 +24,10 @@ public class Hero extends Entity {
     private final String pathToRunRight = "knight/runRight";
     private Skill firstSkill;
 
-    /**
-     * Entity with Components
-     *
-     * @param startPosition position at start
-     */
-    public Hero(Point startPosition) {
+    /** Entity with Components */
+    public Hero() {
         super();
-        new PositionComponent(this, startPosition);
+        new PositionComponent(this);
         setupVelocityComponent();
         setupAnimationComponent();
         setupHitboxComponent();

--- a/game/src/level/elements/ILevel.java
+++ b/game/src/level/elements/ILevel.java
@@ -1,9 +1,10 @@
 package level.elements;
 
-import java.util.List;
 import level.elements.tile.*;
 import level.tools.LevelElement;
 import level.tools.TileTextureFactory;
+
+import java.util.List;
 
 public interface ILevel extends ITileable {
 
@@ -200,5 +201,12 @@ public interface ILevel extends ITileable {
                     ? getDoorTiles().get(RANDOM.nextInt(getDoorTiles().size()))
                     : null;
         };
+    }
+
+    /**
+     * @return random floor tile
+     */
+    default Tile getRandomFloorTile() {
+        return getRandomTile(LevelElement.FLOOR);
     }
 }

--- a/game/src/level/elements/ILevel.java
+++ b/game/src/level/elements/ILevel.java
@@ -1,10 +1,9 @@
 package level.elements;
 
+import java.util.List;
 import level.elements.tile.*;
 import level.tools.LevelElement;
 import level.tools.TileTextureFactory;
-
-import java.util.List;
 
 public interface ILevel extends ITileable {
 

--- a/game/src/level/elements/tile/Tile.java
+++ b/game/src/level/elements/tile/Tile.java
@@ -3,6 +3,8 @@ package level.elements.tile;
 import com.badlogic.gdx.ai.pfa.Connection;
 import com.badlogic.gdx.utils.Array;
 import ecs.entities.Entity;
+import java.util.ArrayList;
+import java.util.List;
 import level.elements.ILevel;
 import level.elements.TileLevel;
 import level.elements.astar.TileConnection;
@@ -10,9 +12,6 @@ import level.tools.Coordinate;
 import level.tools.DesignLabel;
 import level.tools.LevelElement;
 import tools.Point;
-
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * A Tile is a field of the level.

--- a/game/src/level/elements/tile/Tile.java
+++ b/game/src/level/elements/tile/Tile.java
@@ -3,14 +3,15 @@ package level.elements.tile;
 import com.badlogic.gdx.ai.pfa.Connection;
 import com.badlogic.gdx.utils.Array;
 import ecs.entities.Entity;
-import java.util.ArrayList;
-import java.util.List;
 import level.elements.ILevel;
 import level.elements.TileLevel;
 import level.elements.astar.TileConnection;
 import level.tools.Coordinate;
 import level.tools.DesignLabel;
 import level.tools.LevelElement;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * A Tile is a field of the level.
@@ -51,28 +52,19 @@ public abstract class Tile {
     public abstract void onEntering(Entity element);
 
     /**
+     * @return path to the texture of this tile
+     */
+    public String getTexturePath() {
+        return texturePath;
+    }
+
+    /**
      * Change texture of the tile.
      *
      * @param texture New texture of the tile.
      */
     public void setTexturePath(String texture) {
         this.texturePath = texture;
-    }
-
-    /**
-     * Change the type of the tile.
-     *
-     * @param newLevelElement New type of the tile.
-     */
-    public void setLevelElement(LevelElement newLevelElement) {
-        this.levelElement = newLevelElement;
-    }
-
-    /**
-     * @return path to the texture of this tile
-     */
-    public String getTexturePath() {
-        return texturePath;
     }
 
     /**
@@ -94,6 +86,15 @@ public abstract class Tile {
      */
     public LevelElement getLevelElement() {
         return levelElement;
+    }
+
+    /**
+     * Change the type of the tile.
+     *
+     * @param newLevelElement New type of the tile.
+     */
+    public void setLevelElement(LevelElement newLevelElement) {
+        this.levelElement = newLevelElement;
     }
 
     /**

--- a/game/src/level/elements/tile/Tile.java
+++ b/game/src/level/elements/tile/Tile.java
@@ -9,6 +9,7 @@ import level.elements.astar.TileConnection;
 import level.tools.Coordinate;
 import level.tools.DesignLabel;
 import level.tools.LevelElement;
+import tools.Point;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -72,6 +73,13 @@ public abstract class Tile {
      */
     public Coordinate getCoordinate() {
         return globalPosition;
+    }
+
+    /**
+     * @return The global coordinate of the tile as point.
+     */
+    public Point getCoordinateAsPoint() {
+        return getCoordinate().toPoint();
     }
 
     /**

--- a/game/src/starter/Game.java
+++ b/game/src/starter/Game.java
@@ -115,7 +115,7 @@ public class Game extends ScreenAdapter implements IOnLevelLoader {
         controller.add(systems);
         pauseMenu = new PauseMenu<>();
         controller.add(pauseMenu);
-        hero = new Hero(new Point(0, 0));
+        hero = new Hero();
         levelAPI = new LevelAPI(batch, painter, new WallGenerator(new RandomWalkGenerator()), this);
         levelAPI.loadLevel(LEVELSIZE);
         createSystems();


### PR DESCRIPTION
Bessere Konstruktionen für das `PositionComponent`
- add `new PositionComponent(Entity entity, float x, float y)`
    - Dann braucht man keinen `Pont`erzeugen
- ` new PositionComponent(Entity entity)` prüft jetzt vorher, ob das Level existiert (ohne level hat es früher gecrasht) und setzt die Position entweder auf ein random Floor-Tile (wenn das level existiert) oder auf (0,0)
- `Hero` verwendet jetzt den einfachen ctor. 


@cagix ich trag dich mal für das Review ein, da du das Feature requested hast. 