### PR TITLE
[GAME] Fix: wait for DeathAnimation onDeath

### DIFF
--- a/game/src/ecs/components/HealthComponent.java
+++ b/game/src/ecs/components/HealthComponent.java
@@ -194,6 +194,6 @@ public class HealthComponent extends Component {
     }
 
     public boolean isDead() {
-        return this.currentHealthpoints <= 0;
+        return currentHealthpoints <= 0;
     }
 }

--- a/game/src/ecs/components/HealthComponent.java
+++ b/game/src/ecs/components/HealthComponent.java
@@ -136,7 +136,7 @@ public class HealthComponent extends Component {
      *
      * @param dieAnimation new dieAnimation
      */
-    public void setDieAnimation(Animation dieAnimation) {
+    public void setDeathAnimation(Animation dieAnimation) {
         this.dieAnimation = dieAnimation;
     }
 
@@ -182,7 +182,7 @@ public class HealthComponent extends Component {
     /**
      * @return Animation to be played when dying
      */
-    public Animation getDieAnimation() {
+    public Animation getDeathAnimation() {
         return dieAnimation;
     }
 
@@ -191,5 +191,9 @@ public class HealthComponent extends Component {
      */
     public Optional<Entity> getLastDamageCause() {
         return Optional.ofNullable(this.lastCause);
+    }
+
+    public boolean isDead() {
+        return this.currentHealthpoints <= 0;
     }
 }

--- a/game/src/ecs/systems/HealthSystem.java
+++ b/game/src/ecs/systems/HealthSystem.java
@@ -32,7 +32,8 @@ public class HealthSystem extends ECS_System {
                 .filter(hsd -> hsd.hc.isDead())
                 .filter(
                         hsd -> {
-                            if (hsd.hc.getDeathAnimation() == null) return true;
+                            if (hsd.hc.getDeathAnimation() == null
+                                    || hsd.hc.getDeathAnimation().isLooping()) return true;
                             if (!hsd.ac.getCurrentAnimation().equals(hsd.hc.getDeathAnimation())) {
                                 hsd.ac.setCurrentAnimation(hsd.hc.getDeathAnimation());
                             }

--- a/game/src/ecs/systems/HealthSystem.java
+++ b/game/src/ecs/systems/HealthSystem.java
@@ -29,7 +29,15 @@ public class HealthSystem extends ECS_System {
                 // Apply damage
                 .map(this::applyDamage)
                 // Filter all dead entities
-                .filter(hsd -> hsd.hc.getCurrentHealthpoints() <= 0)
+                .filter(hsd -> hsd.hc.isDead())
+                .filter(
+                        hsd -> {
+                            if (hsd.hc.getDeathAnimation() == null) return true;
+                            if (!hsd.ac.getCurrentAnimation().equals(hsd.hc.getDeathAnimation())) {
+                                hsd.ac.setCurrentAnimation(hsd.hc.getDeathAnimation());
+                                return false;
+                            } else return hsd.ac.getCurrentAnimation().isFinished();
+                        })
                 // Remove all dead entities
                 .forEach(this::removeDeadEntities);
     }
@@ -92,7 +100,7 @@ public class HealthSystem extends ECS_System {
     private void removeDeadEntities(HSData hsd) {
         // Entity appears to be dead, so let's clean up the mess
         hsd.hc.triggerOnDeath();
-        hsd.ac.setCurrentAnimation(hsd.hc.getDieAnimation());
+        hsd.ac.setCurrentAnimation(hsd.hc.getDeathAnimation());
         // TODO: Before removing the entity, check if the animation is finished (Issue #246)
         Game.removeEntity(hsd.hc.getEntity());
 

--- a/game/src/ecs/systems/HealthSystem.java
+++ b/game/src/ecs/systems/HealthSystem.java
@@ -35,8 +35,8 @@ public class HealthSystem extends ECS_System {
                             if (hsd.hc.getDeathAnimation() == null) return true;
                             if (!hsd.ac.getCurrentAnimation().equals(hsd.hc.getDeathAnimation())) {
                                 hsd.ac.setCurrentAnimation(hsd.hc.getDeathAnimation());
-                                return false;
-                            } else return hsd.ac.getCurrentAnimation().isFinished();
+                            }
+                            return hsd.ac.getCurrentAnimation().isFinished();
                         })
                 // Remove all dead entities
                 .forEach(this::removeDeadEntities);
@@ -101,7 +101,6 @@ public class HealthSystem extends ECS_System {
         // Entity appears to be dead, so let's clean up the mess
         hsd.hc.triggerOnDeath();
         hsd.ac.setCurrentAnimation(hsd.hc.getDeathAnimation());
-        // TODO: Before removing the entity, check if the animation is finished (Issue #246)
         Game.removeEntity(hsd.hc.getEntity());
 
         // Add XP

--- a/game/src/ecs/systems/VelocitySystem.java
+++ b/game/src/ecs/systems/VelocitySystem.java
@@ -1,10 +1,10 @@
 package ecs.systems;
 
 import ecs.components.AnimationComponent;
+import ecs.components.HealthComponent;
 import ecs.components.MissingComponentException;
 import ecs.components.PositionComponent;
 import ecs.components.VelocityComponent;
-import ecs.components.health.HealthComponent;
 import ecs.components.skill.ProjectileComponent;
 import ecs.entities.Entity;
 import graphic.Animation;

--- a/game/src/ecs/systems/VelocitySystem.java
+++ b/game/src/ecs/systems/VelocitySystem.java
@@ -4,9 +4,11 @@ import ecs.components.AnimationComponent;
 import ecs.components.MissingComponentException;
 import ecs.components.PositionComponent;
 import ecs.components.VelocityComponent;
+import ecs.components.health.HealthComponent;
 import ecs.components.skill.ProjectileComponent;
 import ecs.entities.Entity;
 import graphic.Animation;
+import java.util.concurrent.atomic.AtomicBoolean;
 import starter.Game;
 import tools.Point;
 
@@ -55,6 +57,19 @@ public class VelocitySystem extends ECS_System {
     }
 
     private void movementAnimation(Entity entity) {
+
+        AtomicBoolean isDead = new AtomicBoolean(false);
+        entity.getComponent(HealthComponent.class)
+                .ifPresent(
+                        component -> {
+                            HealthComponent healthComponent = (HealthComponent) component;
+                            isDead.set(healthComponent.isDead());
+                        });
+
+        if (isDead.get()) {
+            return;
+        }
+
         AnimationComponent ac =
                 (AnimationComponent)
                         entity.getComponent(AnimationComponent.class)

--- a/game/src/graphic/Animation.java
+++ b/game/src/graphic/Animation.java
@@ -75,6 +75,13 @@ public class Animation {
     }
 
     /**
+     * @return true when looping, otherwise false
+     */
+    public boolean isLooping() {
+        return looping;
+    }
+
+    /**
      * Get the List of animation frames.
      *
      * @return List containing the paths of the single frames of the animation.

--- a/game/test/ecs/components/HealthComponentTest.java
+++ b/game/test/ecs/components/HealthComponentTest.java
@@ -105,8 +105,8 @@ public class HealthComponentTest {
         Entity entity = new Entity();
         HealthComponent hc = new HealthComponent(entity);
         Animation animation = Mockito.mock(Animation.class);
-        hc.setDieAnimation(animation);
-        assertEquals(animation, hc.getDieAnimation());
+        hc.setDeathAnimation(animation);
+        assertEquals(animation, hc.getDeathAnimation());
     }
 
     @Test

--- a/game/test/ecs/systems/HealthSystemTest.java
+++ b/game/test/ecs/systems/HealthSystemTest.java
@@ -12,6 +12,7 @@ import ecs.damage.Damage;
 import ecs.damage.DamageType;
 import ecs.entities.Entity;
 import graphic.Animation;
+import java.util.List;
 import org.junit.Test;
 import org.mockito.Mockito;
 import starter.Game;
@@ -26,7 +27,7 @@ public class HealthSystemTest {
         Game.getEntities().addAll(Game.getEntitiesToAdd());
         Game.getEntitiesToAdd().clear();
         IOnDeathFunction onDeath = Mockito.mock(IOnDeathFunction.class);
-        Animation dieAnimation = Mockito.mock(Animation.class);
+        Animation dieAnimation = new Animation(List.of("FRAME1"), 1, false);
         AnimationComponent ac = new AnimationComponent(entity);
         HealthComponent component = new HealthComponent(entity, 1, onDeath, null, dieAnimation);
         HealthSystem system = new HealthSystem();


### PR DESCRIPTION
fixes #246 

Fixt das sofortige löschen des gestorbenen Entities, bevor die Death-Animation abgespielt werden konnte.