### PR TITLE
[Game] Gradle Plugins und libs stärker beschränken

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ ext {
     gdxVersion = "1.11.0"
     aiVersion = "1.8.2"
     gsonVersion = "2.9.0"
+    checkstyleVersion = "10.11.0"
 }
 
 dependencies {
@@ -93,7 +94,7 @@ test {
 }
 
 checkstyle {
-    toolVersion = "10.2"
+    toolVersion = checkstyleVersion
     configFile = file("checks.xml")
     showViolations = true
 }

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ repositories {
 
 ext {
     // we can not use the + operator here
-    gdxVersion = "1.10.1-SNAPSHOT"
+    gdxVersion = "1.11.0"
     aiVersion = "1.8.2"
     gsonVersion = "2.9.0"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -2,8 +2,8 @@ plugins {
     // we can not use ext variables here
     id "java"
     id "checkstyle"
-    id "com.github.spotbugs" version "5.0.+"
-    id "com.diffplug.spotless" version "6.5.+"
+    id "com.github.spotbugs" version "5.0.14"
+    id "com.diffplug.spotless" version "6.5.2"
     id 'antlr'
 }
 
@@ -32,12 +32,12 @@ dependencies {
 
     // JUnit 4, Mockito and Powermock for testing:
     // https://mvnrepository.com/artifact/junit/junit
-    testImplementation "junit:junit:4.+"
+    testImplementation "junit:junit:4.13.2"
 
     // https://mvnrepository.com/artifact/org.powermock/powermock-module-junit4
-    testImplementation "org.powermock:powermock-module-junit4:2.+"
+    testImplementation "org.powermock:powermock-module-junit4:2.0.9"
     // https://mvnrepository.com/artifact/org.powermock/powermock-api-mockito2
-    testImplementation "org.powermock:powermock-api-mockito2:2.+"
+    testImplementation "org.powermock:powermock-api-mockito2:2.0.9"
 
     // https://mvnrepository.com/artifact/com.google.code.gson/gson
     implementation group: "com.google.code.gson", name: "gson", version: gsonVersion


### PR DESCRIPTION
Fixes #430
spotbugs ist die aktuellste Version 5.0.14
spotless vorher 6.5.+ wurde auf 6.5.2 festgelegt, da neuere Versionen neue regeln festlegen 6.18.0(aktuellste Version) wird viele Dateien anpassen, da sich z.b. Import regeln geändert haben.
junit war 4.+ aktuellste Version 4.13.2 ist kompatibel und eingestellt
powermock ist stale und letzte stabile Version ist 2.0.9 dies ist mit unserem Code kompatibel


Getestet wurde es wie folgt auf einem Windows 10 System.
Check ausgeführt
Check ausgeführt nach Löschen des Caches
Check ausgeführt nach Löschen des Caches und Neustart