### PR TITLE
[GAME] add DelayedSet

### DIFF
--- a/game/src/api/utils/DelayedSet.java
+++ b/game/src/api/utils/DelayedSet.java
@@ -55,7 +55,7 @@ public final class DelayedSet<T> {
     /**
      * Add the given to {@link #toAdd}.
      *
-     * <p>After the call of {@link #update}, * the objects inside this inner set will be added to
+     * <p>After the call of {@link #update}, the objects inside this inner set will be added to
      * {@link #current}
      *
      * @param t Object to add

--- a/game/src/api/utils/DelayedSet.java
+++ b/game/src/api/utils/DelayedSet.java
@@ -1,0 +1,94 @@
+package api.utils;
+
+import java.util.Collection;
+import java.util.ConcurrentModificationException;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * This class allows managing a Collection inside the System-Loops.
+ *
+ * <p>Since the Systems iterate over a Set of Entity's, a {@link ConcurrentModificationException} is
+ * normally thrown if this System adds/removes an entity of this set.
+ *
+ * <p>This class implements three different HashSets to allow delayed manipulation of the base Set.
+ *
+ * <p>{@link #current} contains the current "active" object of the collection. Use this Set to
+ * iterate over and work with. Use {@link #getSet()} to get this Set.
+ *
+ * <p>Use {@link #add} to add the given object to {@link #toAdd}. After the call of {@link #update},
+ * the objects inside this inner set will be added to {@link #current}
+ *
+ * <p>Use {@link #remove} to add the given object to {@link #toRemove}. After the call of {@link
+ * #update}, the objects inside this inner set will be removed from {@link #current}
+ *
+ * <p>Use {@link #update()} to add/remove the objects to/from {@link #current}. If you do this
+ * inside of an iteration over this Set, a {@link ConcurrentModificationException} will be thrown.
+ * It is best to use this right before or right after iterating over the set.
+ *
+ * @param <T> Type of the Elements to store in the Sets.
+ * @see ConcurrentModificationException
+ * @see HashSet
+ */
+public final class DelayedSet<T> {
+
+    private final Set<T> current = new HashSet<>();
+    private final Set<T> toAdd = new HashSet<>();
+    private final Set<T> toRemove = new HashSet<>();
+
+    /**
+     * Update the {@link #current} based on the elements in {@link #toAdd} and {@link #toRemove}.
+     *
+     * <p>Add all objects from {@link #toAdd} to {@link #current}. Remove all objects from {@link
+     * #toRemove} to {@link #current}. Clears {@link #toAdd} and {@link #toAdd}
+     */
+    public void update() {
+        current.addAll(toAdd);
+        current.removeAll(toRemove);
+        toAdd.clear();
+        toRemove.clear();
+    }
+
+    /**
+     * Add the given to {@link #toAdd}.
+     *
+     * @param t Object to add
+     */
+    public void add(T t) {
+        toAdd.add(t);
+    }
+
+    /**
+     * Add all objects of the given collection to {@link #toAdd}.
+     *
+     * @param collection contains all objects to add
+     */
+    public void addAll(Collection<T> collection) {
+        toAdd.addAll(collection);
+    }
+
+    /**
+     * Add the given to {@link #toRemove}.
+     *
+     * @param t Object to remove
+     */
+    public void remove(T t) {
+        toRemove.add(t);
+    }
+
+    /**
+     * Add all objects of the given collection to {@link #toRemove}.
+     *
+     * @param collection contains all objects to remove
+     */
+    public void removeAll(Collection<T> collection) {
+        toRemove.addAll(collection);
+    }
+
+    /**
+     * @return The Set with all currently active elements
+     */
+    public Set<T> getSet() {
+        return current;
+    }
+}

--- a/game/src/api/utils/DelayedSet.java
+++ b/game/src/api/utils/DelayedSet.java
@@ -41,6 +41,9 @@ public final class DelayedSet<T> {
      *
      * <p>Add all objects from {@link #toAdd} to {@link #current}. Remove all objects from {@link
      * #toRemove} to {@link #current}. Clears {@link #toAdd} and {@link #toAdd}
+     *
+     * <p>Note: First all elements from {@link #toAdd} will be added and than all elements from
+     * {@link #toRemove} will be removed.
      */
     public void update() {
         current.addAll(toAdd);
@@ -52,6 +55,9 @@ public final class DelayedSet<T> {
     /**
      * Add the given to {@link #toAdd}.
      *
+     * <p>After the call of {@link #update}, * the objects inside this inner set will be added to
+     * {@link #current}
+     *
      * @param t Object to add
      */
     public void add(T t) {
@@ -60,6 +66,9 @@ public final class DelayedSet<T> {
 
     /**
      * Add all objects of the given collection to {@link #toAdd}.
+     *
+     * <p>After the call of {@link #update}, the objects inside this inner set will be added to
+     * {@link #current}
      *
      * @param collection contains all objects to add
      */
@@ -70,6 +79,9 @@ public final class DelayedSet<T> {
     /**
      * Add the given to {@link #toRemove}.
      *
+     * <p>After the call of {@link #update}, the objects inside this inner set will be removed from
+     * {@link #current}
+     *
      * @param t Object to remove
      */
     public void remove(T t) {
@@ -79,6 +91,9 @@ public final class DelayedSet<T> {
     /**
      * Add all objects of the given collection to {@link #toRemove}.
      *
+     * <p>After the call of {@link #update}, the objects inside this inner set will be removed from
+     * {@link #current}
+     *
      * @param collection contains all objects to remove
      */
     public void removeAll(Collection<T> collection) {
@@ -86,9 +101,16 @@ public final class DelayedSet<T> {
     }
 
     /**
-     * @return The Set with all currently active elements
+     * @return A copy of {@link #current} with all currently active elements
      */
     public Set<T> getSet() {
-        return current;
+        return new HashSet<>(current);
+    }
+
+    /** Clear all internal Sets. */
+    public void clear() {
+        toAdd.clear();
+        toRemove.clear();
+        current.clear();
     }
 }

--- a/game/src/starter/Game.java
+++ b/game/src/starter/Game.java
@@ -231,7 +231,7 @@ public class Game extends ScreenAdapter implements IOnLevelLoader {
     }
 
     /**
-     * @return Set with all entities currently in game
+     * @return Copy of the Set with all entities currently in game
      */
     public static Set<Entity> getEntities() {
         return entities.getSet();
@@ -240,7 +240,7 @@ public class Game extends ScreenAdapter implements IOnLevelLoader {
     /**
      * @return The {@link DelayedSet} to manage all the entities in the ecs
      */
-    public static DelayedSet getDelayedSet() {
+    public static DelayedSet getDelayedEntitySet() {
         return entities;
     }
 

--- a/game/src/starter/Game.java
+++ b/game/src/starter/Game.java
@@ -156,20 +156,6 @@ public class Game extends ScreenAdapter implements IOnLevelLoader {
         getHero().ifPresent(this::placeOnLevelStart);
     }
 
-    /*  private void manageEntitiesSets() {
-        entities.update();
-        entities.uo(entitiesToRemove);
-        entities.addAll(entitiesToAdd);
-        for (Entity entity : entitiesToRemove) {
-            gameLogger.info("Entity '" + entity.getClass().getSimpleName() + "' was deleted.");
-        }
-        for (Entity entity : entitiesToAdd) {
-            gameLogger.info("Entity '" + entity.getClass().getSimpleName() + "' was added.");
-        }
-        entitiesToRemove.clear();
-        entitiesToAdd.clear();
-    }*/
-
     private void setCameraFocus() {
         if (getHero().isPresent()) {
             PositionComponent pc =

--- a/game/src/starter/Game.java
+++ b/game/src/starter/Game.java
@@ -152,7 +152,7 @@ public class Game extends ScreenAdapter implements IOnLevelLoader {
     @Override
     public void onLevelLoad() {
         currentLevel = levelAPI.getCurrentLevel();
-        entities.removeAll(entities.getSet());
+        entities.clear();
         getHero().ifPresent(this::placeOnLevelStart);
     }
 

--- a/game/test/api/utils/DelayedSetTest.java
+++ b/game/test/api/utils/DelayedSetTest.java
@@ -73,4 +73,14 @@ public class DelayedSetTest {
         assertTrue(set.getSet().contains(toAdd2));
         assertFalse(set.getSet().contains(toAdd3));
     }
+
+    @Test
+    public void clear() {
+        DelayedSet<String> set = new DelayedSet<>();
+        set.add("3");
+        set.update();
+        set.add("4");
+        set.clear();
+        assertTrue(set.getSet().isEmpty());
+    }
 }

--- a/game/test/api/utils/DelayedSetTest.java
+++ b/game/test/api/utils/DelayedSetTest.java
@@ -1,0 +1,76 @@
+package api.utils;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.Test;
+
+public class DelayedSetTest {
+
+    @Test
+    public void testAdd() {
+        DelayedSet<String> set = new DelayedSet<>();
+        String toAdd = "3";
+        set.add(toAdd);
+        assertFalse(set.getSet().contains(toAdd));
+        set.update();
+        assertTrue(set.getSet().contains(toAdd));
+    }
+
+    @Test
+    public void testAddAll() {
+        DelayedSet<String> set = new DelayedSet<>();
+        Set<String> addSet = new HashSet<>();
+        String toAdd1 = "A";
+        String toAdd2 = "B";
+        String toAdd3 = "C";
+        addSet.add(toAdd1);
+        addSet.add(toAdd2);
+        addSet.add(toAdd3);
+        set.addAll(addSet);
+        assertFalse(set.getSet().contains(toAdd1));
+        assertFalse(set.getSet().contains(toAdd2));
+        assertFalse(set.getSet().contains(toAdd3));
+        set.update();
+        assertTrue(set.getSet().contains(toAdd1));
+        assertTrue(set.getSet().contains(toAdd2));
+        assertTrue(set.getSet().contains(toAdd3));
+    }
+
+    @Test
+    public void testRemove() {
+        DelayedSet<String> set = new DelayedSet<>();
+        String toAdd = "3";
+        set.add(toAdd);
+        set.update();
+        set.remove(toAdd);
+        assertTrue(set.getSet().contains(toAdd));
+        set.update();
+        assertFalse(set.getSet().contains(toAdd));
+    }
+
+    @Test
+    public void testRemoveAll() {
+        DelayedSet<String> set = new DelayedSet<>();
+        Set<String> addSet = new HashSet<>();
+        String toAdd1 = "A";
+        String toAdd2 = "B";
+        String toAdd3 = "C";
+        addSet.add(toAdd1);
+        addSet.add(toAdd2);
+        addSet.add(toAdd3);
+        set.addAll(addSet);
+        set.update();
+        addSet.remove(toAdd2);
+        set.removeAll(addSet);
+        assertTrue(set.getSet().contains(toAdd1));
+        assertTrue(set.getSet().contains(toAdd2));
+        assertTrue(set.getSet().contains(toAdd3));
+        set.update();
+        assertFalse(set.getSet().contains(toAdd1));
+        assertTrue(set.getSet().contains(toAdd2));
+        assertFalse(set.getSet().contains(toAdd3));
+    }
+}

--- a/game/test/ecs/EntityTest.java
+++ b/game/test/ecs/EntityTest.java
@@ -17,14 +17,14 @@ public class EntityTest {
     @Before
     public void setup() {
         Game.getEntities().forEach(e -> Game.removeEntity(e));
-        Game.getDelayedSet().update();
+        Game.getDelayedEntitySet().update();
         entity = new Entity();
         entity.addComponent(testComponent);
     }
 
     @Test
     public void cTor() {
-        Game.getDelayedSet().update();
+        Game.getDelayedEntitySet().update();
         assertTrue(Game.getEntities().contains(entity));
     }
 

--- a/game/test/ecs/EntityTest.java
+++ b/game/test/ecs/EntityTest.java
@@ -16,17 +16,15 @@ public class EntityTest {
 
     @Before
     public void setup() {
-        Game.getEntities().clear();
-        Game.getEntitiesToAdd().clear();
-        Game.getEntitiesToRemove().clear();
+        Game.getEntities().forEach(e -> Game.removeEntity(e));
+        Game.getDelayedSet().update();
         entity = new Entity();
         entity.addComponent(testComponent);
     }
 
     @Test
     public void cTor() {
-        Game.getEntities().addAll(Game.getEntitiesToAdd());
-        Game.getEntitiesToAdd().clear();
+        Game.getDelayedSet().update();
         assertTrue(Game.getEntities().contains(entity));
     }
 

--- a/game/test/ecs/components/DropLootTest.java
+++ b/game/test/ecs/components/DropLootTest.java
@@ -52,12 +52,10 @@ public class DropLootTest {
         new PositionComponent(entity, entityPosition);
         InventoryComponent inventoryComponent = new InventoryComponent(entity, 10);
         inventoryComponent.addItem(new ItemData());
-        Game.getEntities().addAll(Game.getEntitiesToAdd());
-        Game.getEntitiesToAdd().clear();
+        Game.getDelayedSet().update();
         Game.getEntities().clear();
         dropLoot.onDeath(entity);
-        Game.getEntities().addAll(Game.getEntitiesToAdd());
-        Game.getEntitiesToAdd().clear();
+        Game.getDelayedSet().update();
         assertEquals(1, Game.getEntities().size());
         assertTrue(
                 Game.getEntities().stream()
@@ -84,13 +82,11 @@ public class DropLootTest {
         inventoryComponent.addItem(new ItemData());
         inventoryComponent.addItem(new ItemData());
 
-        Game.getEntities().addAll(Game.getEntitiesToAdd());
-        Game.getEntitiesToAdd().clear();
+        Game.getDelayedSet().update();
         Game.getEntities().clear();
         dropLoot.onDeath(entity);
 
-        Game.getEntities().addAll(Game.getEntitiesToAdd());
-        Game.getEntitiesToAdd().clear();
+        Game.getDelayedSet().update();
         assertEquals(2, Game.getEntities().size());
         assertTrue(
                 Game.getEntities().stream()

--- a/game/test/ecs/components/DropLootTest.java
+++ b/game/test/ecs/components/DropLootTest.java
@@ -38,7 +38,7 @@ public class DropLootTest {
         Entity entity = new Entity();
         new PositionComponent(entity, new Point(1, 2));
         new InventoryComponent(entity, 10);
-        Game.getDelayedSet().clear();
+        Game.getDelayedEntitySet().clear();
         dropLoot.onDeath(entity);
         assertTrue(Game.getEntities().isEmpty());
     }
@@ -52,9 +52,9 @@ public class DropLootTest {
         new PositionComponent(entity, entityPosition);
         InventoryComponent inventoryComponent = new InventoryComponent(entity, 10);
         inventoryComponent.addItem(new ItemData());
-        Game.getDelayedSet().clear();
+        Game.getDelayedEntitySet().clear();
         dropLoot.onDeath(entity);
-        Game.getDelayedSet().update();
+        Game.getDelayedEntitySet().update();
         assertEquals(1, Game.getEntities().size());
         assertTrue(
                 Game.getEntities().stream()
@@ -81,10 +81,10 @@ public class DropLootTest {
         inventoryComponent.addItem(new ItemData());
         inventoryComponent.addItem(new ItemData());
 
-        Game.getDelayedSet().clear();
+        Game.getDelayedEntitySet().clear();
         dropLoot.onDeath(entity);
 
-        Game.getDelayedSet().update();
+        Game.getDelayedEntitySet().update();
         assertEquals(2, Game.getEntities().size());
         assertTrue(
                 Game.getEntities().stream()

--- a/game/test/ecs/components/DropLootTest.java
+++ b/game/test/ecs/components/DropLootTest.java
@@ -38,7 +38,7 @@ public class DropLootTest {
         Entity entity = new Entity();
         new PositionComponent(entity, new Point(1, 2));
         new InventoryComponent(entity, 10);
-        Game.getEntities().clear();
+        Game.getDelayedSet().clear();
         dropLoot.onDeath(entity);
         assertTrue(Game.getEntities().isEmpty());
     }
@@ -52,8 +52,7 @@ public class DropLootTest {
         new PositionComponent(entity, entityPosition);
         InventoryComponent inventoryComponent = new InventoryComponent(entity, 10);
         inventoryComponent.addItem(new ItemData());
-        Game.getDelayedSet().update();
-        Game.getEntities().clear();
+        Game.getDelayedSet().clear();
         dropLoot.onDeath(entity);
         Game.getDelayedSet().update();
         assertEquals(1, Game.getEntities().size());
@@ -82,8 +81,7 @@ public class DropLootTest {
         inventoryComponent.addItem(new ItemData());
         inventoryComponent.addItem(new ItemData());
 
-        Game.getDelayedSet().update();
-        Game.getEntities().clear();
+        Game.getDelayedSet().clear();
         dropLoot.onDeath(entity);
 
         Game.getDelayedSet().update();

--- a/game/test/ecs/entities/ChestTest.java
+++ b/game/test/ecs/entities/ChestTest.java
@@ -18,9 +18,8 @@ public class ChestTest {
 
     /** Helper cleans up class attributes used by Chest Initializes the Item#ITEM_REGISTER */
     private static void cleanup() {
-        Game.getEntities().clear();
-        Game.getEntitiesToAdd().clear();
-        Game.getEntitiesToRemove().clear();
+        Game.getDelayedSet().removeAll(Game.getEntities());
+        Game.getDelayedSet().update();
     }
 
     /** checks the correct creation of the Chest */
@@ -30,8 +29,7 @@ public class ChestTest {
         List<ItemData> itemData = List.of();
         Point position = new Point(0, 0);
         Chest c = new Chest(itemData, position);
-        Game.getEntities().addAll(Game.getEntitiesToAdd());
-        Game.getEntitiesToAdd().clear();
+        Game.getDelayedSet().update();
         assertEquals("Chest is added to Game", 1, Game.getEntities().size());
         assertTrue(
                 "Needs the AnimationComponent to be visible to the player.",
@@ -60,15 +58,13 @@ public class ChestTest {
         List<ItemData> itemData = List.of(new ItemDataGenerator().generateItemData());
         Point position = new Point(0, 0);
         Chest c = new Chest(itemData, position);
-        Game.getEntities().addAll(Game.getEntitiesToAdd());
-        Game.getEntitiesToAdd().clear();
+        Game.getDelayedSet().update();
         assertEquals(1, Game.getEntities().size());
         c.getComponent(InteractionComponent.class)
                 .map(InteractionComponent.class::cast)
                 .get()
                 .triggerInteraction();
-        Game.getEntities().addAll(Game.getEntitiesToAdd());
-        Game.getEntitiesToAdd().clear();
+        Game.getDelayedSet().update();
         assertEquals(2, Game.getEntities().size());
 
         cleanup();
@@ -81,15 +77,13 @@ public class ChestTest {
         List<ItemData> itemData = List.of(new ItemDataGenerator().generateItemData());
         Point position = new Point(0, 0);
         Chest c = new Chest(itemData, position);
-        Game.getEntities().addAll(Game.getEntitiesToAdd());
-        Game.getEntitiesToAdd().clear();
+        Game.getDelayedSet().update();
         Game.getEntities().remove(c);
         assertEquals(0, Game.getEntities().size());
         c.getComponent(InteractionComponent.class)
                 .map(InteractionComponent.class::cast)
                 .ifPresent(InteractionComponent::triggerInteraction);
-        Game.getEntities().addAll(Game.getEntitiesToAdd());
-        Game.getEntitiesToAdd().clear();
+        Game.getDelayedSet().update();
         assertEquals(1, Game.getEntities().size());
         Entity droppedItem = Game.getEntities().iterator().next();
         assertTrue(
@@ -114,8 +108,7 @@ public class ChestTest {
                         },
                         DesignLabel.DEFAULT);
         Chest newChest = Chest.createNewChest();
-        Game.getEntities().addAll(Game.getEntitiesToAdd());
-        Game.getEntitiesToAdd().clear();
+        Game.getDelayedSet().update();
         assertTrue("Chest is added to Game", Game.getEntities().contains(newChest));
         assertTrue(
                 "Needs the AnimationComponent to be visible to the player.",

--- a/game/test/ecs/entities/ChestTest.java
+++ b/game/test/ecs/entities/ChestTest.java
@@ -18,8 +18,7 @@ public class ChestTest {
 
     /** Helper cleans up class attributes used by Chest Initializes the Item#ITEM_REGISTER */
     private static void cleanup() {
-        Game.getDelayedSet().removeAll(Game.getEntities());
-        Game.getDelayedSet().update();
+        Game.getDelayedSet().clear();
     }
 
     /** checks the correct creation of the Chest */
@@ -77,8 +76,8 @@ public class ChestTest {
         List<ItemData> itemData = List.of(new ItemDataGenerator().generateItemData());
         Point position = new Point(0, 0);
         Chest c = new Chest(itemData, position);
+        Game.removeEntity(c);
         Game.getDelayedSet().update();
-        Game.getEntities().remove(c);
         assertEquals(0, Game.getEntities().size());
         c.getComponent(InteractionComponent.class)
                 .map(InteractionComponent.class::cast)

--- a/game/test/ecs/entities/ChestTest.java
+++ b/game/test/ecs/entities/ChestTest.java
@@ -18,7 +18,7 @@ public class ChestTest {
 
     /** Helper cleans up class attributes used by Chest Initializes the Item#ITEM_REGISTER */
     private static void cleanup() {
-        Game.getDelayedSet().clear();
+        Game.getDelayedEntitySet().clear();
     }
 
     /** checks the correct creation of the Chest */
@@ -28,7 +28,7 @@ public class ChestTest {
         List<ItemData> itemData = List.of();
         Point position = new Point(0, 0);
         Chest c = new Chest(itemData, position);
-        Game.getDelayedSet().update();
+        Game.getDelayedEntitySet().update();
         assertEquals("Chest is added to Game", 1, Game.getEntities().size());
         assertTrue(
                 "Needs the AnimationComponent to be visible to the player.",
@@ -57,13 +57,13 @@ public class ChestTest {
         List<ItemData> itemData = List.of(new ItemDataGenerator().generateItemData());
         Point position = new Point(0, 0);
         Chest c = new Chest(itemData, position);
-        Game.getDelayedSet().update();
+        Game.getDelayedEntitySet().update();
         assertEquals(1, Game.getEntities().size());
         c.getComponent(InteractionComponent.class)
                 .map(InteractionComponent.class::cast)
                 .get()
                 .triggerInteraction();
-        Game.getDelayedSet().update();
+        Game.getDelayedEntitySet().update();
         assertEquals(2, Game.getEntities().size());
 
         cleanup();
@@ -77,12 +77,12 @@ public class ChestTest {
         Point position = new Point(0, 0);
         Chest c = new Chest(itemData, position);
         Game.removeEntity(c);
-        Game.getDelayedSet().update();
+        Game.getDelayedEntitySet().update();
         assertEquals(0, Game.getEntities().size());
         c.getComponent(InteractionComponent.class)
                 .map(InteractionComponent.class::cast)
                 .ifPresent(InteractionComponent::triggerInteraction);
-        Game.getDelayedSet().update();
+        Game.getDelayedEntitySet().update();
         assertEquals(1, Game.getEntities().size());
         Entity droppedItem = Game.getEntities().iterator().next();
         assertTrue(
@@ -107,7 +107,7 @@ public class ChestTest {
                         },
                         DesignLabel.DEFAULT);
         Chest newChest = Chest.createNewChest();
-        Game.getDelayedSet().update();
+        Game.getDelayedEntitySet().update();
         assertTrue("Chest is added to Game", Game.getEntities().contains(newChest));
         assertTrue(
                 "Needs the AnimationComponent to be visible to the player.",

--- a/game/test/ecs/items/ItemDataTest.java
+++ b/game/test/ecs/items/ItemDataTest.java
@@ -19,7 +19,7 @@ import tools.Point;
 public class ItemDataTest {
     @Before
     public void before() {
-        Game.getDelayedSet().clear();
+        Game.getDelayedEntitySet().clear();
     }
 
     @Test
@@ -61,7 +61,7 @@ public class ItemDataTest {
         ItemData itemData = new ItemData();
         Point point = new Point(0, 0);
         itemData.triggerDrop(null, point);
-        Game.getDelayedSet().update();
+        Game.getDelayedEntitySet().update();
         Entity e = Game.getEntities().iterator().next();
         PositionComponent pc =
                 (PositionComponent) e.getComponent(PositionComponent.class).orElseThrow();

--- a/game/test/ecs/items/ItemDataTest.java
+++ b/game/test/ecs/items/ItemDataTest.java
@@ -19,8 +19,7 @@ import tools.Point;
 public class ItemDataTest {
     @Before
     public void before() {
-        Game.getDelayedSet().removeAll(Game.getEntities());
-        Game.getDelayedSet().update();
+        Game.getDelayedSet().clear();
     }
 
     @Test

--- a/game/test/ecs/items/ItemDataTest.java
+++ b/game/test/ecs/items/ItemDataTest.java
@@ -19,7 +19,8 @@ import tools.Point;
 public class ItemDataTest {
     @Before
     public void before() {
-        Game.getEntitiesToAdd().clear();
+        Game.getDelayedSet().removeAll(Game.getEntities());
+        Game.getDelayedSet().update();
     }
 
     @Test
@@ -59,11 +60,10 @@ public class ItemDataTest {
     public void onDropCheckEntity() {
 
         ItemData itemData = new ItemData();
-        assertEquals(0, Game.getEntitiesToAdd().size());
         Point point = new Point(0, 0);
         itemData.triggerDrop(null, point);
-        assertEquals(1, Game.getEntitiesToAdd().size());
-        Entity e = Game.getEntitiesToAdd().iterator().next();
+        Game.getDelayedSet().update();
+        Entity e = Game.getEntities().iterator().next();
         PositionComponent pc =
                 (PositionComponent) e.getComponent(PositionComponent.class).orElseThrow();
         assertEquals(point.x, pc.getPosition().x, 0.001);

--- a/game/test/ecs/systems/AISystemTest.java
+++ b/game/test/ecs/systems/AISystemTest.java
@@ -20,8 +20,8 @@ public class AISystemTest {
     @Before
     public void setup() {
         Game.systems = Mockito.mock(SystemController.class);
-        Game.getDelayedSet().removeAll(Game.getEntities());
-        Game.getDelayedSet().update();
+        Game.getDelayedEntitySet().removeAll(Game.getEntities());
+        Game.getDelayedEntitySet().update();
         system = new AISystem();
         entity = new Entity();
         AIComponent component = new AIComponent(entity);
@@ -38,7 +38,7 @@ public class AISystemTest {
 
     @Test
     public void update() {
-        Game.getDelayedSet().update();
+        Game.getDelayedEntitySet().update();
         system.update();
         assertEquals(1, updateCounter);
     }

--- a/game/test/ecs/systems/AISystemTest.java
+++ b/game/test/ecs/systems/AISystemTest.java
@@ -20,9 +20,8 @@ public class AISystemTest {
     @Before
     public void setup() {
         Game.systems = Mockito.mock(SystemController.class);
-        Game.getEntities().clear();
-        Game.getEntitiesToAdd().clear();
-        Game.getEntitiesToRemove().clear();
+        Game.getDelayedSet().removeAll(Game.getEntities());
+        Game.getDelayedSet().update();
         system = new AISystem();
         entity = new Entity();
         AIComponent component = new AIComponent(entity);
@@ -39,8 +38,7 @@ public class AISystemTest {
 
     @Test
     public void update() {
-        Game.getEntities().addAll(Game.getEntitiesToAdd());
-        Game.getEntitiesToAdd().clear();
+        Game.getDelayedSet().update();
         system.update();
         assertEquals(1, updateCounter);
     }

--- a/game/test/ecs/systems/CollisionSystemTest.java
+++ b/game/test/ecs/systems/CollisionSystemTest.java
@@ -32,8 +32,8 @@ public class CollisionSystemTest {
      */
     private static void cleanUpEnvironment() {
         Game.systems = null;
-        Game.getDelayedSet().removeAll(Game.getEntities());
-        Game.getDelayedSet().update();
+        Game.getDelayedEntitySet().removeAll(Game.getEntities());
+        Game.getDelayedEntitySet().update();
     }
 
     /** Creating a clean Systemcontroller to avoid interferences */
@@ -51,7 +51,7 @@ public class CollisionSystemTest {
     private static Entity prepareEntityWithPosition(Point point1) {
         Entity e1 = new Entity();
         new PositionComponent(e1, point1);
-        Game.getDelayedSet().update();
+        Game.getDelayedEntitySet().update();
         return e1;
     }
 

--- a/game/test/ecs/systems/CollisionSystemTest.java
+++ b/game/test/ecs/systems/CollisionSystemTest.java
@@ -32,9 +32,8 @@ public class CollisionSystemTest {
      */
     private static void cleanUpEnvironment() {
         Game.systems = null;
-        Game.getEntities().clear();
-        Game.getEntitiesToAdd().clear();
-        Game.getEntitiesToRemove().clear();
+        Game.getDelayedSet().removeAll(Game.getEntities());
+        Game.getDelayedSet().update();
     }
 
     /** Creating a clean Systemcontroller to avoid interferences */
@@ -52,8 +51,7 @@ public class CollisionSystemTest {
     private static Entity prepareEntityWithPosition(Point point1) {
         Entity e1 = new Entity();
         new PositionComponent(e1, point1);
-        Game.getEntities().addAll(Game.getEntitiesToAdd());
-        Game.getEntitiesToAdd().clear();
+        Game.getDelayedSet().update();
         return e1;
     }
 

--- a/game/test/ecs/systems/DrawSystemTest.java
+++ b/game/test/ecs/systems/DrawSystemTest.java
@@ -25,8 +25,7 @@ public class DrawSystemTest {
     @Before
     public void setup() {
         Game.systems = Mockito.mock(SystemController.class);
-        Game.getEntities().clear();
-        Game.getDelayedSet().update();
+        Game.getDelayedSet().clear();
         drawSystem = new DrawSystem(painter);
         entity = new Entity();
         new AnimationComponent(entity, animation);

--- a/game/test/ecs/systems/DrawSystemTest.java
+++ b/game/test/ecs/systems/DrawSystemTest.java
@@ -25,12 +25,12 @@ public class DrawSystemTest {
     @Before
     public void setup() {
         Game.systems = Mockito.mock(SystemController.class);
-        Game.getDelayedSet().clear();
+        Game.getDelayedEntitySet().clear();
         drawSystem = new DrawSystem(painter);
         entity = new Entity();
         new AnimationComponent(entity, animation);
         new PositionComponent(entity, new Point(3, 3));
-        Game.getDelayedSet().update();
+        Game.getDelayedEntitySet().update();
     }
 
     @Test

--- a/game/test/ecs/systems/DrawSystemTest.java
+++ b/game/test/ecs/systems/DrawSystemTest.java
@@ -26,14 +26,12 @@ public class DrawSystemTest {
     public void setup() {
         Game.systems = Mockito.mock(SystemController.class);
         Game.getEntities().clear();
-        Game.getEntitiesToAdd().clear();
-        Game.getEntitiesToRemove().clear();
+        Game.getDelayedSet().update();
         drawSystem = new DrawSystem(painter);
         entity = new Entity();
         new AnimationComponent(entity, animation);
         new PositionComponent(entity, new Point(3, 3));
-        Game.getEntities().addAll(Game.getEntitiesToAdd());
-        Game.getEntitiesToAdd().clear();
+        Game.getDelayedSet().update();
     }
 
     @Test

--- a/game/test/ecs/systems/HealthSystemTest.java
+++ b/game/test/ecs/systems/HealthSystemTest.java
@@ -24,8 +24,7 @@ public class HealthSystemTest {
         Game.getEntities().clear();
         Game.systems = new SystemController();
         Entity entity = new Entity();
-        Game.getEntities().addAll(Game.getEntitiesToAdd());
-        Game.getEntitiesToAdd().clear();
+        Game.getDelayedSet().update();
         IOnDeathFunction onDeath = Mockito.mock(IOnDeathFunction.class);
         Animation dieAnimation = new Animation(List.of("FRAME1"), 1, false);
         AnimationComponent ac = new AnimationComponent(entity);
@@ -34,7 +33,8 @@ public class HealthSystemTest {
         component.setCurrentHealthpoints(0);
         system.update();
         assertEquals(dieAnimation, ac.getCurrentAnimation());
-        assertTrue(Game.getEntitiesToRemove().contains(entity));
+        Game.getDelayedSet().update();
+        assertFalse(Game.getEntities().contains(entity));
     }
 
     @Test
@@ -42,8 +42,7 @@ public class HealthSystemTest {
         Game.getEntities().clear();
         Game.systems = new SystemController();
         Entity entity = new Entity();
-        Game.getEntities().addAll(Game.getEntitiesToAdd());
-        Game.getEntitiesToAdd().clear();
+        Game.getDelayedSet().update();
         IOnDeathFunction onDeath = Mockito.mock(IOnDeathFunction.class);
         Animation hitAnimation = Mockito.mock(Animation.class);
         AnimationComponent ac = new AnimationComponent(entity);
@@ -61,8 +60,7 @@ public class HealthSystemTest {
         Game.getEntities().clear();
         Game.systems = new SystemController();
         Entity entity = new Entity();
-        Game.getEntities().addAll(Game.getEntitiesToAdd());
-        Game.getEntitiesToAdd().clear();
+        Game.getDelayedSet().update();
         IOnDeathFunction onDeath = Mockito.mock(IOnDeathFunction.class);
         Animation hitAnimation = Mockito.mock(Animation.class);
         AnimationComponent ac = new AnimationComponent(entity);
@@ -80,8 +78,7 @@ public class HealthSystemTest {
         Game.getEntities().clear();
         Game.systems = new SystemController();
         Entity entity = new Entity();
-        Game.getEntities().addAll(Game.getEntitiesToAdd());
-        Game.getEntitiesToAdd().clear();
+        Game.getDelayedSet().update();
         IOnDeathFunction onDeath = Mockito.mock(IOnDeathFunction.class);
         Animation hitAnimation = Mockito.mock(Animation.class);
         AnimationComponent ac = new AnimationComponent(entity);
@@ -98,8 +95,7 @@ public class HealthSystemTest {
         Game.getEntities().clear();
         Game.systems = new SystemController();
         Entity entity = new Entity();
-        Game.getEntities().addAll(Game.getEntitiesToAdd());
-        Game.getEntitiesToAdd().clear();
+        Game.getDelayedSet().update();
         HealthSystem system = new HealthSystem();
         system.update();
     }
@@ -109,8 +105,7 @@ public class HealthSystemTest {
         Game.getEntities().clear();
         Game.systems = new SystemController();
         Entity entity = new Entity();
-        Game.getEntities().addAll(Game.getEntitiesToAdd());
-        Game.getEntitiesToAdd().clear();
+        Game.getDelayedSet().update();
         HealthComponent component = new HealthComponent(entity);
         HealthSystem system = new HealthSystem();
         assertThrows(MissingComponentException.class, () -> system.update());
@@ -121,8 +116,7 @@ public class HealthSystemTest {
         Game.getEntities().clear();
         Game.systems = new SystemController();
         Entity entity = new Entity();
-        Game.getEntities().addAll(Game.getEntitiesToAdd());
-        Game.getEntitiesToAdd().clear();
+        Game.getDelayedSet().update();
         new AnimationComponent(entity);
         StatsComponent statsComponent = new StatsComponent(entity);
         statsComponent.getDamageModifiers().setMultiplier(DamageType.PHYSICAL, 2);
@@ -143,8 +137,7 @@ public class HealthSystemTest {
         Game.getEntities().clear();
         Game.systems = new SystemController();
         Entity entity = new Entity();
-        Game.getEntities().addAll(Game.getEntitiesToAdd());
-        Game.getEntitiesToAdd().clear();
+        Game.getDelayedSet().update();
         new AnimationComponent(entity);
         StatsComponent statsComponent = new StatsComponent(entity);
         statsComponent.getDamageModifiers().setMultiplier(DamageType.PHYSICAL, -2);
@@ -165,8 +158,7 @@ public class HealthSystemTest {
         Game.getEntities().clear();
         Game.systems = new SystemController();
         Entity entity = new Entity();
-        Game.getEntities().addAll(Game.getEntitiesToAdd());
-        Game.getEntitiesToAdd().clear();
+        Game.getDelayedSet().update();
         new AnimationComponent(entity);
         StatsComponent statsComponent = new StatsComponent(entity);
         statsComponent.getDamageModifiers().setMultiplier(DamageType.PHYSICAL, 0);
@@ -187,8 +179,7 @@ public class HealthSystemTest {
         Game.getEntities().clear();
         Game.systems = new SystemController();
         Entity entity = new Entity();
-        Game.getEntities().addAll(Game.getEntitiesToAdd());
-        Game.getEntitiesToAdd().clear();
+        Game.getDelayedSet().update();
         new AnimationComponent(entity);
         StatsComponent statsComponent = new StatsComponent(entity);
         statsComponent.getDamageModifiers().setMultiplier(DamageType.PHYSICAL, 100);

--- a/game/test/ecs/systems/HealthSystemTest.java
+++ b/game/test/ecs/systems/HealthSystemTest.java
@@ -21,10 +21,10 @@ public class HealthSystemTest {
 
     @Test
     public void updateEntityDies() {
-        Game.getDelayedSet().clear();
+        Game.getDelayedEntitySet().clear();
         Game.systems = new SystemController();
         Entity entity = new Entity();
-        Game.getDelayedSet().update();
+        Game.getDelayedEntitySet().update();
         IOnDeathFunction onDeath = Mockito.mock(IOnDeathFunction.class);
         Animation dieAnimation = new Animation(List.of("FRAME1"), 1, false);
         AnimationComponent ac = new AnimationComponent(entity);
@@ -33,16 +33,16 @@ public class HealthSystemTest {
         component.setCurrentHealthpoints(0);
         system.update();
         assertEquals(dieAnimation, ac.getCurrentAnimation());
-        Game.getDelayedSet().update();
+        Game.getDelayedEntitySet().update();
         assertFalse(Game.getEntities().contains(entity));
     }
 
     @Test
     public void updateEntityGetDamage() {
-        Game.getDelayedSet().clear();
+        Game.getDelayedEntitySet().clear();
         Game.systems = new SystemController();
         Entity entity = new Entity();
-        Game.getDelayedSet().update();
+        Game.getDelayedEntitySet().update();
         IOnDeathFunction onDeath = Mockito.mock(IOnDeathFunction.class);
         Animation hitAnimation = Mockito.mock(Animation.class);
         AnimationComponent ac = new AnimationComponent(entity);
@@ -57,10 +57,10 @@ public class HealthSystemTest {
 
     @Test
     public void updateEntityGetNegativeDamage() {
-        Game.getDelayedSet().clear();
+        Game.getDelayedEntitySet().clear();
         Game.systems = new SystemController();
         Entity entity = new Entity();
-        Game.getDelayedSet().update();
+        Game.getDelayedEntitySet().update();
         IOnDeathFunction onDeath = Mockito.mock(IOnDeathFunction.class);
         Animation hitAnimation = Mockito.mock(Animation.class);
         AnimationComponent ac = new AnimationComponent(entity);
@@ -75,10 +75,10 @@ public class HealthSystemTest {
 
     @Test
     public void updateEntityGetZeroDamage() {
-        Game.getDelayedSet().clear();
+        Game.getDelayedEntitySet().clear();
         Game.systems = new SystemController();
         Entity entity = new Entity();
-        Game.getDelayedSet().update();
+        Game.getDelayedEntitySet().update();
         IOnDeathFunction onDeath = Mockito.mock(IOnDeathFunction.class);
         Animation hitAnimation = Mockito.mock(Animation.class);
         AnimationComponent ac = new AnimationComponent(entity);
@@ -92,20 +92,20 @@ public class HealthSystemTest {
 
     @Test
     public void updateWithoutHealthComponent() {
-        Game.getDelayedSet().clear();
+        Game.getDelayedEntitySet().clear();
         Game.systems = new SystemController();
         Entity entity = new Entity();
-        Game.getDelayedSet().update();
+        Game.getDelayedEntitySet().update();
         HealthSystem system = new HealthSystem();
         system.update();
     }
 
     @Test
     public void updateWithoutAnimationComponent() {
-        Game.getDelayedSet().clear();
+        Game.getDelayedEntitySet().clear();
         Game.systems = new SystemController();
         Entity entity = new Entity();
-        Game.getDelayedSet().update();
+        Game.getDelayedEntitySet().update();
         HealthComponent component = new HealthComponent(entity);
         HealthSystem system = new HealthSystem();
         assertThrows(MissingComponentException.class, () -> system.update());
@@ -113,10 +113,10 @@ public class HealthSystemTest {
 
     @Test
     public void testDamageWithModifier() {
-        Game.getDelayedSet().clear();
+        Game.getDelayedEntitySet().clear();
         Game.systems = new SystemController();
         Entity entity = new Entity();
-        Game.getDelayedSet().update();
+        Game.getDelayedEntitySet().update();
         new AnimationComponent(entity);
         StatsComponent statsComponent = new StatsComponent(entity);
         statsComponent.getDamageModifiers().setMultiplier(DamageType.PHYSICAL, 2);
@@ -134,10 +134,10 @@ public class HealthSystemTest {
 
     @Test
     public void testDamageWithModifierNegative() {
-        Game.getDelayedSet().clear();
+        Game.getDelayedEntitySet().clear();
         Game.systems = new SystemController();
         Entity entity = new Entity();
-        Game.getDelayedSet().update();
+        Game.getDelayedEntitySet().update();
         new AnimationComponent(entity);
         StatsComponent statsComponent = new StatsComponent(entity);
         statsComponent.getDamageModifiers().setMultiplier(DamageType.PHYSICAL, -2);
@@ -155,10 +155,10 @@ public class HealthSystemTest {
 
     @Test
     public void testDamageWithModifierZero() {
-        Game.getDelayedSet().clear();
+        Game.getDelayedEntitySet().clear();
         Game.systems = new SystemController();
         Entity entity = new Entity();
-        Game.getDelayedSet().update();
+        Game.getDelayedEntitySet().update();
         new AnimationComponent(entity);
         StatsComponent statsComponent = new StatsComponent(entity);
         statsComponent.getDamageModifiers().setMultiplier(DamageType.PHYSICAL, 0);
@@ -176,10 +176,10 @@ public class HealthSystemTest {
 
     @Test
     public void testDamageWithModifierHuge() {
-        Game.getDelayedSet().clear();
+        Game.getDelayedEntitySet().clear();
         Game.systems = new SystemController();
         Entity entity = new Entity();
-        Game.getDelayedSet().update();
+        Game.getDelayedEntitySet().update();
         new AnimationComponent(entity);
         StatsComponent statsComponent = new StatsComponent(entity);
         statsComponent.getDamageModifiers().setMultiplier(DamageType.PHYSICAL, 100);

--- a/game/test/ecs/systems/HealthSystemTest.java
+++ b/game/test/ecs/systems/HealthSystemTest.java
@@ -21,7 +21,7 @@ public class HealthSystemTest {
 
     @Test
     public void updateEntityDies() {
-        Game.getEntities().clear();
+        Game.getDelayedSet().clear();
         Game.systems = new SystemController();
         Entity entity = new Entity();
         Game.getDelayedSet().update();
@@ -39,7 +39,7 @@ public class HealthSystemTest {
 
     @Test
     public void updateEntityGetDamage() {
-        Game.getEntities().clear();
+        Game.getDelayedSet().clear();
         Game.systems = new SystemController();
         Entity entity = new Entity();
         Game.getDelayedSet().update();
@@ -57,7 +57,7 @@ public class HealthSystemTest {
 
     @Test
     public void updateEntityGetNegativeDamage() {
-        Game.getEntities().clear();
+        Game.getDelayedSet().clear();
         Game.systems = new SystemController();
         Entity entity = new Entity();
         Game.getDelayedSet().update();
@@ -75,7 +75,7 @@ public class HealthSystemTest {
 
     @Test
     public void updateEntityGetZeroDamage() {
-        Game.getEntities().clear();
+        Game.getDelayedSet().clear();
         Game.systems = new SystemController();
         Entity entity = new Entity();
         Game.getDelayedSet().update();
@@ -92,7 +92,7 @@ public class HealthSystemTest {
 
     @Test
     public void updateWithoutHealthComponent() {
-        Game.getEntities().clear();
+        Game.getDelayedSet().clear();
         Game.systems = new SystemController();
         Entity entity = new Entity();
         Game.getDelayedSet().update();
@@ -102,7 +102,7 @@ public class HealthSystemTest {
 
     @Test
     public void updateWithoutAnimationComponent() {
-        Game.getEntities().clear();
+        Game.getDelayedSet().clear();
         Game.systems = new SystemController();
         Entity entity = new Entity();
         Game.getDelayedSet().update();
@@ -113,7 +113,7 @@ public class HealthSystemTest {
 
     @Test
     public void testDamageWithModifier() {
-        Game.getEntities().clear();
+        Game.getDelayedSet().clear();
         Game.systems = new SystemController();
         Entity entity = new Entity();
         Game.getDelayedSet().update();
@@ -134,7 +134,7 @@ public class HealthSystemTest {
 
     @Test
     public void testDamageWithModifierNegative() {
-        Game.getEntities().clear();
+        Game.getDelayedSet().clear();
         Game.systems = new SystemController();
         Entity entity = new Entity();
         Game.getDelayedSet().update();
@@ -155,7 +155,7 @@ public class HealthSystemTest {
 
     @Test
     public void testDamageWithModifierZero() {
-        Game.getEntities().clear();
+        Game.getDelayedSet().clear();
         Game.systems = new SystemController();
         Entity entity = new Entity();
         Game.getDelayedSet().update();
@@ -176,7 +176,7 @@ public class HealthSystemTest {
 
     @Test
     public void testDamageWithModifierHuge() {
-        Game.getEntities().clear();
+        Game.getDelayedSet().clear();
         Game.systems = new SystemController();
         Entity entity = new Entity();
         Game.getDelayedSet().update();

--- a/game/test/ecs/systems/SkillSystemTest.java
+++ b/game/test/ecs/systems/SkillSystemTest.java
@@ -20,7 +20,7 @@ public class SkillSystemTest {
         Game.systems = new SystemController();
         SkillSystem system = new SkillSystem();
         Entity entity = new Entity();
-        Game.getDelayedSet().update();
+        Game.getDelayedEntitySet().update();
         ISkillFunction skillFunction = Mockito.mock(ISkillFunction.class);
         int coolDownInSeconds = 2;
         Skill testSkill = new Skill(skillFunction, coolDownInSeconds);

--- a/game/test/ecs/systems/SkillSystemTest.java
+++ b/game/test/ecs/systems/SkillSystemTest.java
@@ -20,8 +20,7 @@ public class SkillSystemTest {
         Game.systems = new SystemController();
         SkillSystem system = new SkillSystem();
         Entity entity = new Entity();
-        Game.getEntities().addAll(Game.getEntitiesToAdd());
-        Game.getEntitiesToAdd().clear();
+        Game.getDelayedSet().update();
         ISkillFunction skillFunction = Mockito.mock(ISkillFunction.class);
         int coolDownInSeconds = 2;
         Skill testSkill = new Skill(skillFunction, coolDownInSeconds);

--- a/game/test/ecs/systems/VelocitySystemTest.java
+++ b/game/test/ecs/systems/VelocitySystemTest.java
@@ -44,9 +44,8 @@ public class VelocitySystemTest {
         Game.systems = Mockito.mock(SystemController.class);
         Game.currentLevel = level;
         Mockito.when(level.getTileAt(Mockito.any())).thenReturn(tile);
-        Game.getEntities().clear();
-        Game.getEntitiesToAdd().clear();
-        Game.getEntitiesToRemove().clear();
+        Game.getDelayedSet().removeAll(Game.getEntities());
+        Game.getDelayedSet().update();
         entity = new Entity();
 
         velocitySystem = new VelocitySystem();
@@ -55,8 +54,7 @@ public class VelocitySystemTest {
         positionComponent =
                 new PositionComponent(entity, new Point(startXPosition, startYPosition));
         animationComponent = new AnimationComponent(entity, idleLeft, idleRight);
-        Game.getEntities().addAll(Game.getEntitiesToAdd());
-        Game.getEntitiesToAdd().clear();
+        Game.getDelayedSet().update();
     }
 
     @Test

--- a/game/test/ecs/systems/VelocitySystemTest.java
+++ b/game/test/ecs/systems/VelocitySystemTest.java
@@ -44,8 +44,8 @@ public class VelocitySystemTest {
         Game.systems = Mockito.mock(SystemController.class);
         Game.currentLevel = level;
         Mockito.when(level.getTileAt(Mockito.any())).thenReturn(tile);
-        Game.getDelayedSet().removeAll(Game.getEntities());
-        Game.getDelayedSet().update();
+        Game.getDelayedEntitySet().removeAll(Game.getEntities());
+        Game.getDelayedEntitySet().update();
         entity = new Entity();
 
         velocitySystem = new VelocitySystem();
@@ -54,7 +54,7 @@ public class VelocitySystemTest {
         positionComponent =
                 new PositionComponent(entity, new Point(startXPosition, startYPosition));
         animationComponent = new AnimationComponent(entity, idleLeft, idleRight);
-        Game.getDelayedSet().update();
+        Game.getDelayedEntitySet().update();
     }
 
     @Test

--- a/game/test/ecs/systems/XPSystemTest.java
+++ b/game/test/ecs/systems/XPSystemTest.java
@@ -16,9 +16,8 @@ public class XPSystemTest {
     @Test
     public void testStartingWithZero() {
         /* Prepare */
-        Game.getEntities().clear();
-        Game.getEntitiesToAdd().clear();
-        Game.getEntitiesToRemove().clear();
+        Game.getDelayedSet().removeAll(Game.getEntities());
+        Game.getDelayedSet().update();
         Game.systems = new SystemController();
         Entity entity = new Entity();
         ILevelUp levelUp = Mockito.mock(ILevelUp.class);
@@ -36,9 +35,8 @@ public class XPSystemTest {
     @Test
     public void testNoLevelUp() {
         /* Prepare */
-        Game.getEntities().clear();
-        Game.getEntitiesToAdd().clear();
-        Game.getEntitiesToRemove().clear();
+        Game.getDelayedSet().removeAll(Game.getEntities());
+        Game.getDelayedSet().update();
         Game.systems = new SystemController();
         Entity entity = new Entity();
         ILevelUp levelUp = Mockito.mock(ILevelUp.class);
@@ -55,16 +53,14 @@ public class XPSystemTest {
     @Test
     public void testLevelUpExact() {
         /* Prepare */
-        Game.getEntities().clear();
-        Game.getEntitiesToAdd().clear();
-        Game.getEntitiesToRemove().clear();
+        Game.getDelayedSet().removeAll(Game.getEntities());
+        Game.getDelayedSet().update();
         Game.systems = new SystemController();
         Entity entity = new Entity();
         ILevelUp levelUp = Mockito.mock(ILevelUp.class);
         XPComponent xpComponent = new XPComponent(entity, levelUp);
         XPSystem xpSystem = new XPSystem();
-        Game.getEntities().addAll(Game.getEntitiesToAdd());
-        Game.getEntitiesToAdd().clear();
+        Game.getDelayedSet().update();
 
         /* Test */
         xpComponent.addXP(100); // First level is reached with 100 XP
@@ -77,16 +73,14 @@ public class XPSystemTest {
     @Test
     public void testLevelUpOverflow() {
         /* Prepare */
-        Game.getEntities().clear();
-        Game.getEntitiesToAdd().clear();
-        Game.getEntitiesToRemove().clear();
+        Game.getDelayedSet().removeAll(Game.getEntities());
+        Game.getDelayedSet().update();
         Game.systems = new SystemController();
         Entity entity = new Entity();
         ILevelUp levelUp = Mockito.mock(ILevelUp.class);
         XPComponent xpComponent = new XPComponent(entity, levelUp);
         XPSystem xpSystem = new XPSystem();
-        Game.getEntities().addAll(Game.getEntitiesToAdd());
-        Game.getEntitiesToAdd().clear();
+        Game.getDelayedSet().update();
 
         /* Test */
         xpComponent.addXP(120); // First level is reached with 100 XP
@@ -102,16 +96,14 @@ public class XPSystemTest {
     @Test
     public void testLevelUpMultipleExact() {
         /* Prepare */
-        Game.getEntities().clear();
-        Game.getEntitiesToAdd().clear();
-        Game.getEntitiesToRemove().clear();
+        Game.getDelayedSet().removeAll(Game.getEntities());
+        Game.getDelayedSet().update();
         Game.systems = new SystemController();
         Entity entity = new Entity();
         ILevelUp levelUp = Mockito.mock(ILevelUp.class);
         XPComponent xpComponent = new XPComponent(entity, levelUp);
         XPSystem xpSystem = new XPSystem();
-        Game.getEntities().addAll(Game.getEntitiesToAdd());
-        Game.getEntitiesToAdd().clear();
+        Game.getDelayedSet().update();
 
         /* Test */
         xpComponent.addXP(201);
@@ -127,9 +119,8 @@ public class XPSystemTest {
     @Test
     public void testLevelUpMultipleOverflow() {
         /* Prepare */
-        Game.getEntities().clear();
-        Game.getEntitiesToAdd().clear();
-        Game.getEntitiesToRemove().clear();
+        Game.getDelayedSet().removeAll(Game.getEntities());
+        Game.getDelayedSet().update();
         Game.systems = new SystemController();
         Entity entity = new Entity();
         ILevelUp levelUp = Mockito.mock(ILevelUp.class);
@@ -137,8 +128,7 @@ public class XPSystemTest {
         XPSystem xpSystem = new XPSystem();
 
         /* Test */
-        Game.getEntities().addAll(Game.getEntitiesToAdd());
-        Game.getEntitiesToAdd().clear();
+        Game.getDelayedSet().update();
         xpComponent.addXP(221);
         xpSystem.update();
         assertEquals(2, xpComponent.getCurrentLevel());
@@ -149,9 +139,8 @@ public class XPSystemTest {
     @Test
     public void testNegativeXP() {
         /* Prepare */
-        Game.getEntities().clear();
-        Game.getEntitiesToAdd().clear();
-        Game.getEntitiesToRemove().clear();
+        Game.getDelayedSet().removeAll(Game.getEntities());
+        Game.getDelayedSet().update();
         Game.systems = new SystemController();
         Entity entity = new Entity();
         ILevelUp levelUp = Mockito.mock(ILevelUp.class);

--- a/game/test/ecs/systems/XPSystemTest.java
+++ b/game/test/ecs/systems/XPSystemTest.java
@@ -16,8 +16,8 @@ public class XPSystemTest {
     @Test
     public void testStartingWithZero() {
         /* Prepare */
-        Game.getDelayedSet().removeAll(Game.getEntities());
-        Game.getDelayedSet().update();
+        Game.getDelayedEntitySet().removeAll(Game.getEntities());
+        Game.getDelayedEntitySet().update();
         Game.systems = new SystemController();
         Entity entity = new Entity();
         ILevelUp levelUp = Mockito.mock(ILevelUp.class);
@@ -35,8 +35,8 @@ public class XPSystemTest {
     @Test
     public void testNoLevelUp() {
         /* Prepare */
-        Game.getDelayedSet().removeAll(Game.getEntities());
-        Game.getDelayedSet().update();
+        Game.getDelayedEntitySet().removeAll(Game.getEntities());
+        Game.getDelayedEntitySet().update();
         Game.systems = new SystemController();
         Entity entity = new Entity();
         ILevelUp levelUp = Mockito.mock(ILevelUp.class);
@@ -53,14 +53,14 @@ public class XPSystemTest {
     @Test
     public void testLevelUpExact() {
         /* Prepare */
-        Game.getDelayedSet().removeAll(Game.getEntities());
-        Game.getDelayedSet().update();
+        Game.getDelayedEntitySet().removeAll(Game.getEntities());
+        Game.getDelayedEntitySet().update();
         Game.systems = new SystemController();
         Entity entity = new Entity();
         ILevelUp levelUp = Mockito.mock(ILevelUp.class);
         XPComponent xpComponent = new XPComponent(entity, levelUp);
         XPSystem xpSystem = new XPSystem();
-        Game.getDelayedSet().update();
+        Game.getDelayedEntitySet().update();
 
         /* Test */
         xpComponent.addXP(100); // First level is reached with 100 XP
@@ -73,14 +73,14 @@ public class XPSystemTest {
     @Test
     public void testLevelUpOverflow() {
         /* Prepare */
-        Game.getDelayedSet().removeAll(Game.getEntities());
-        Game.getDelayedSet().update();
+        Game.getDelayedEntitySet().removeAll(Game.getEntities());
+        Game.getDelayedEntitySet().update();
         Game.systems = new SystemController();
         Entity entity = new Entity();
         ILevelUp levelUp = Mockito.mock(ILevelUp.class);
         XPComponent xpComponent = new XPComponent(entity, levelUp);
         XPSystem xpSystem = new XPSystem();
-        Game.getDelayedSet().update();
+        Game.getDelayedEntitySet().update();
 
         /* Test */
         xpComponent.addXP(120); // First level is reached with 100 XP
@@ -96,14 +96,14 @@ public class XPSystemTest {
     @Test
     public void testLevelUpMultipleExact() {
         /* Prepare */
-        Game.getDelayedSet().removeAll(Game.getEntities());
-        Game.getDelayedSet().update();
+        Game.getDelayedEntitySet().removeAll(Game.getEntities());
+        Game.getDelayedEntitySet().update();
         Game.systems = new SystemController();
         Entity entity = new Entity();
         ILevelUp levelUp = Mockito.mock(ILevelUp.class);
         XPComponent xpComponent = new XPComponent(entity, levelUp);
         XPSystem xpSystem = new XPSystem();
-        Game.getDelayedSet().update();
+        Game.getDelayedEntitySet().update();
 
         /* Test */
         xpComponent.addXP(201);
@@ -119,8 +119,8 @@ public class XPSystemTest {
     @Test
     public void testLevelUpMultipleOverflow() {
         /* Prepare */
-        Game.getDelayedSet().removeAll(Game.getEntities());
-        Game.getDelayedSet().update();
+        Game.getDelayedEntitySet().removeAll(Game.getEntities());
+        Game.getDelayedEntitySet().update();
         Game.systems = new SystemController();
         Entity entity = new Entity();
         ILevelUp levelUp = Mockito.mock(ILevelUp.class);
@@ -128,7 +128,7 @@ public class XPSystemTest {
         XPSystem xpSystem = new XPSystem();
 
         /* Test */
-        Game.getDelayedSet().update();
+        Game.getDelayedEntitySet().update();
         xpComponent.addXP(221);
         xpSystem.update();
         assertEquals(2, xpComponent.getCurrentLevel());
@@ -139,8 +139,8 @@ public class XPSystemTest {
     @Test
     public void testNegativeXP() {
         /* Prepare */
-        Game.getDelayedSet().removeAll(Game.getEntities());
-        Game.getDelayedSet().update();
+        Game.getDelayedEntitySet().removeAll(Game.getEntities());
+        Game.getDelayedEntitySet().update();
         Game.systems = new SystemController();
         Entity entity = new Entity();
         ILevelUp levelUp = Mockito.mock(ILevelUp.class);

--- a/game/test/ecs/tools/interaction/InteractionToolTest.java
+++ b/game/test/ecs/tools/interaction/InteractionToolTest.java
@@ -54,8 +54,8 @@ public class InteractionToolTest {
 
     /** cleanup to reset static Attributes from Game used by the InteractionTool */
     private static void cleanup() {
-        Game.getDelayedSet().removeAll(Game.getEntities());
-        Game.getDelayedSet().update();
+        Game.getDelayedEntitySet().removeAll(Game.getEntities());
+        Game.getDelayedEntitySet().update();
         Game.setHero(null);
         Game.currentLevel = null;
     }
@@ -91,7 +91,7 @@ public class InteractionToolTest {
         cleanup();
         Game.setHero(fullMockedHero(true));
         Game.currentLevel = prepareLevel();
-        Game.getDelayedSet().update();
+        Game.getDelayedEntitySet().update();
         InteractionTool.interactWithClosestInteractable(Game.getHero().get());
         cleanup();
     }
@@ -147,7 +147,7 @@ public class InteractionToolTest {
         SimpleCounter sc_e = new SimpleCounter();
         new InteractionComponent(e, 5f, false, (x) -> sc_e.inc());
 
-        Game.getDelayedSet().update();
+        Game.getDelayedEntitySet().update();
 
         InteractionTool.interactWithClosestInteractable(Game.getHero().get());
         assertEquals("One interaction should happen", 1, sc_e.getCount());
@@ -167,7 +167,7 @@ public class InteractionToolTest {
         SimpleCounter sc_e = new SimpleCounter();
         new InteractionComponent(e, 5f, false, (x) -> sc_e.inc());
 
-        Game.getDelayedSet().update();
+        Game.getDelayedEntitySet().update();
 
         MissingComponentException exception =
                 assertThrows(
@@ -210,7 +210,7 @@ public class InteractionToolTest {
         Entity eFar = new Entity();
         new PositionComponent(eFar, new Point(3, 0));
 
-        Game.getDelayedSet().update();
+        Game.getDelayedEntitySet().update();
 
         SimpleCounter sc_eFar = new SimpleCounter();
         new InteractionComponent(eFar, 5f, false, (x) -> sc_eFar.inc());
@@ -246,7 +246,7 @@ public class InteractionToolTest {
         SimpleCounter sc_eClose = new SimpleCounter();
         new InteractionComponent(eClose, 5f, false, (x) -> sc_eClose.inc());
 
-        Game.getDelayedSet().update();
+        Game.getDelayedEntitySet().update();
 
         InteractionTool.interactWithClosestInteractable(Game.getHero().get());
         assertEquals("One interaction should happen", 1, sc_eClose.getCount());

--- a/game/test/ecs/tools/interaction/InteractionToolTest.java
+++ b/game/test/ecs/tools/interaction/InteractionToolTest.java
@@ -54,9 +54,8 @@ public class InteractionToolTest {
 
     /** cleanup to reset static Attributes from Game used by the InteractionTool */
     private static void cleanup() {
-        Game.getEntities().clear();
-        Game.getEntitiesToAdd().clear();
-        Game.getEntitiesToRemove().clear();
+        Game.getDelayedSet().removeAll(Game.getEntities());
+        Game.getDelayedSet().update();
         Game.setHero(null);
         Game.currentLevel = null;
     }
@@ -92,8 +91,7 @@ public class InteractionToolTest {
         cleanup();
         Game.setHero(fullMockedHero(true));
         Game.currentLevel = prepareLevel();
-        Game.getEntities().addAll(Game.getEntitiesToAdd());
-        Game.getEntitiesToAdd().clear();
+        Game.getDelayedSet().update();
         InteractionTool.interactWithClosestInteractable(Game.getHero().get());
         cleanup();
     }
@@ -149,8 +147,7 @@ public class InteractionToolTest {
         SimpleCounter sc_e = new SimpleCounter();
         new InteractionComponent(e, 5f, false, (x) -> sc_e.inc());
 
-        Game.getEntities().addAll(Game.getEntitiesToAdd());
-        Game.getEntitiesToAdd().clear();
+        Game.getDelayedSet().update();
 
         InteractionTool.interactWithClosestInteractable(Game.getHero().get());
         assertEquals("One interaction should happen", 1, sc_e.getCount());
@@ -170,8 +167,7 @@ public class InteractionToolTest {
         SimpleCounter sc_e = new SimpleCounter();
         new InteractionComponent(e, 5f, false, (x) -> sc_e.inc());
 
-        Game.getEntities().addAll(Game.getEntitiesToAdd());
-        Game.getEntitiesToAdd().clear();
+        Game.getDelayedSet().update();
 
         MissingComponentException exception =
                 assertThrows(
@@ -214,8 +210,7 @@ public class InteractionToolTest {
         Entity eFar = new Entity();
         new PositionComponent(eFar, new Point(3, 0));
 
-        Game.getEntities().addAll(Game.getEntitiesToAdd());
-        Game.getEntitiesToAdd().clear();
+        Game.getDelayedSet().update();
 
         SimpleCounter sc_eFar = new SimpleCounter();
         new InteractionComponent(eFar, 5f, false, (x) -> sc_eFar.inc());
@@ -251,8 +246,7 @@ public class InteractionToolTest {
         SimpleCounter sc_eClose = new SimpleCounter();
         new InteractionComponent(eClose, 5f, false, (x) -> sc_eClose.inc());
 
-        Game.getEntities().addAll(Game.getEntitiesToAdd());
-        Game.getEntitiesToAdd().clear();
+        Game.getDelayedSet().update();
 
         InteractionTool.interactWithClosestInteractable(Game.getHero().get());
         assertEquals("One interaction should happen", 1, sc_eClose.getCount());

--- a/game/test/ecs/tools/interaction/InteractionToolTest.java
+++ b/game/test/ecs/tools/interaction/InteractionToolTest.java
@@ -54,8 +54,7 @@ public class InteractionToolTest {
 
     /** cleanup to reset static Attributes from Game used by the InteractionTool */
     private static void cleanup() {
-        Game.getDelayedEntitySet().removeAll(Game.getEntities());
-        Game.getDelayedEntitySet().update();
+        Game.getDelayedEntitySet().clear();
         Game.setHero(null);
         Game.currentLevel = null;
     }

--- a/game/test/graphic/DungeonCameraTest.java
+++ b/game/test/graphic/DungeonCameraTest.java
@@ -46,8 +46,8 @@ public class DungeonCameraTest {
                 camera.position); // Because it follows the positionComponent
 
         // Cleanup
-        Game.getEntities().clear();
-        Game.getEntitiesToRemove().clear();
+        Game.getDelayedSet().removeAll(Game.getEntities());
+        Game.getDelayedSet().update();
     }
 
     @Test
@@ -71,8 +71,8 @@ public class DungeonCameraTest {
                 camera.position);
 
         // Cleanup
-        Game.getEntities().clear();
-        Game.getEntitiesToRemove().clear();
+        Game.getDelayedSet().removeAll(Game.getEntities());
+        Game.getDelayedSet().update();
     }
 
     @Test
@@ -98,8 +98,8 @@ public class DungeonCameraTest {
                 camera.position);
 
         // Cleanup
-        Game.getEntities().clear();
-        Game.getEntitiesToRemove().clear();
+        Game.getDelayedSet().removeAll(Game.getEntities());
+        Game.getDelayedSet().update();
     }
 
     @Test
@@ -121,8 +121,8 @@ public class DungeonCameraTest {
         assertNull("Camera should not follow anything", camera.getFollowedObject());
 
         // Cleanup
-        Game.getEntities().clear();
-        Game.getEntitiesToRemove().clear();
+        Game.getDelayedSet().removeAll(Game.getEntities());
+        Game.getDelayedSet().update();
     }
 
     @Test
@@ -138,8 +138,8 @@ public class DungeonCameraTest {
         assertSame("Camera should follow entity.", positionComponent, camera.getFollowedObject());
 
         // Cleanup
-        Game.getEntities().clear();
-        Game.getEntitiesToRemove().clear();
+        Game.getDelayedSet().removeAll(Game.getEntities());
+        Game.getDelayedSet().update();
     }
 
     @Test
@@ -152,8 +152,8 @@ public class DungeonCameraTest {
         assertNull("Camera should not follow anything", camera.getFollowedObject());
 
         // Cleanup
-        Game.getEntities().clear();
-        Game.getEntitiesToRemove().clear();
+        Game.getDelayedSet().removeAll(Game.getEntities());
+        Game.getDelayedSet().update();
     }
 
     @Test
@@ -178,8 +178,8 @@ public class DungeonCameraTest {
         assertNull("Camera should not follow anything", camera.getFollowedObject());
 
         // Cleanup
-        Game.getEntities().clear();
-        Game.getEntitiesToRemove().clear();
+        Game.getDelayedSet().removeAll(Game.getEntities());
+        Game.getDelayedSet().update();
     }
 
     @Test
@@ -200,8 +200,8 @@ public class DungeonCameraTest {
         assertNull("Camera should not follow anything", camera.getFollowedObject());
 
         // Cleanup
-        Game.getEntities().clear();
-        Game.getEntitiesToRemove().clear();
+        Game.getDelayedSet().removeAll(Game.getEntities());
+        Game.getDelayedSet().update();
     }
 
     @Test
@@ -226,7 +226,7 @@ public class DungeonCameraTest {
                         camera.position.y + Constants.VIEWPORT_HEIGHT / 2 + 1));
 
         // Cleanup
-        Game.getEntities().clear();
-        Game.getEntitiesToRemove().clear();
+        Game.getDelayedSet().removeAll(Game.getEntities());
+        Game.getDelayedSet().update();
     }
 }

--- a/game/test/graphic/DungeonCameraTest.java
+++ b/game/test/graphic/DungeonCameraTest.java
@@ -46,8 +46,8 @@ public class DungeonCameraTest {
                 camera.position); // Because it follows the positionComponent
 
         // Cleanup
-        Game.getDelayedSet().removeAll(Game.getEntities());
-        Game.getDelayedSet().update();
+        Game.getDelayedEntitySet().removeAll(Game.getEntities());
+        Game.getDelayedEntitySet().update();
     }
 
     @Test
@@ -71,8 +71,8 @@ public class DungeonCameraTest {
                 camera.position);
 
         // Cleanup
-        Game.getDelayedSet().removeAll(Game.getEntities());
-        Game.getDelayedSet().update();
+        Game.getDelayedEntitySet().removeAll(Game.getEntities());
+        Game.getDelayedEntitySet().update();
     }
 
     @Test
@@ -98,8 +98,8 @@ public class DungeonCameraTest {
                 camera.position);
 
         // Cleanup
-        Game.getDelayedSet().removeAll(Game.getEntities());
-        Game.getDelayedSet().update();
+        Game.getDelayedEntitySet().removeAll(Game.getEntities());
+        Game.getDelayedEntitySet().update();
     }
 
     @Test
@@ -121,8 +121,8 @@ public class DungeonCameraTest {
         assertNull("Camera should not follow anything", camera.getFollowedObject());
 
         // Cleanup
-        Game.getDelayedSet().removeAll(Game.getEntities());
-        Game.getDelayedSet().update();
+        Game.getDelayedEntitySet().removeAll(Game.getEntities());
+        Game.getDelayedEntitySet().update();
     }
 
     @Test
@@ -138,8 +138,8 @@ public class DungeonCameraTest {
         assertSame("Camera should follow entity.", positionComponent, camera.getFollowedObject());
 
         // Cleanup
-        Game.getDelayedSet().removeAll(Game.getEntities());
-        Game.getDelayedSet().update();
+        Game.getDelayedEntitySet().removeAll(Game.getEntities());
+        Game.getDelayedEntitySet().update();
     }
 
     @Test
@@ -152,8 +152,8 @@ public class DungeonCameraTest {
         assertNull("Camera should not follow anything", camera.getFollowedObject());
 
         // Cleanup
-        Game.getDelayedSet().removeAll(Game.getEntities());
-        Game.getDelayedSet().update();
+        Game.getDelayedEntitySet().removeAll(Game.getEntities());
+        Game.getDelayedEntitySet().update();
     }
 
     @Test
@@ -178,8 +178,8 @@ public class DungeonCameraTest {
         assertNull("Camera should not follow anything", camera.getFollowedObject());
 
         // Cleanup
-        Game.getDelayedSet().removeAll(Game.getEntities());
-        Game.getDelayedSet().update();
+        Game.getDelayedEntitySet().removeAll(Game.getEntities());
+        Game.getDelayedEntitySet().update();
     }
 
     @Test
@@ -200,8 +200,8 @@ public class DungeonCameraTest {
         assertNull("Camera should not follow anything", camera.getFollowedObject());
 
         // Cleanup
-        Game.getDelayedSet().removeAll(Game.getEntities());
-        Game.getDelayedSet().update();
+        Game.getDelayedEntitySet().removeAll(Game.getEntities());
+        Game.getDelayedEntitySet().update();
     }
 
     @Test
@@ -226,7 +226,7 @@ public class DungeonCameraTest {
                         camera.position.y + Constants.VIEWPORT_HEIGHT / 2 + 1));
 
         // Cleanup
-        Game.getDelayedSet().removeAll(Game.getEntities());
-        Game.getDelayedSet().update();
+        Game.getDelayedEntitySet().removeAll(Game.getEntities());
+        Game.getDelayedEntitySet().update();
     }
 }

--- a/game/test/starter/GameTest.java
+++ b/game/test/starter/GameTest.java
@@ -1,7 +1,6 @@
 package starter;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.GL20;
@@ -33,9 +32,8 @@ class GameTest {
 
     @Before
     public void setUp() throws Exception {
-        Game.getEntities().clear();
-        Game.getEntitiesToAdd().clear();
-        Game.getEntitiesToRemove().clear();
+        Game.getDelayedSet().removeAll(Game.getEntities());
+        Game.getDelayedSet().update();
 
         game = Mockito.spy(Game.class);
         batch = Mockito.mock(SpriteBatch.class);
@@ -98,20 +96,21 @@ class GameTest {
     public void addEntity() {
         Entity e1 = Mockito.mock(Entity.class);
         Game.addEntity(e1);
-        assertTrue(Game.getEntitiesToAdd().contains(e1));
-        assertEquals(1, Game.getEntitiesToAdd().size());
-        Game.getEntities().clear();
-        Game.getEntitiesToAdd().clear();
+        assertFalse(Game.getEntities().contains(e1));
+        Game.getDelayedSet().update();
+        assertTrue(Game.getEntities().contains(e1));
+        assertEquals(1, Game.getEntities().size());
     }
 
     @Test
     public void removeEntity() {
         Entity e1 = Mockito.mock(Entity.class);
+        Game.addEntity(e1);
+        Game.getDelayedSet().update();
         Game.removeEntity(e1);
-        assertTrue(Game.getEntitiesToRemove().contains(e1));
-        assertEquals(1, Game.getEntitiesToRemove().size());
-        Game.getEntities().clear();
-        Game.getEntitiesToRemove().clear();
+        Game.getDelayedSet().update();
+        assertFalse(Game.getEntities().contains(e1));
+        assertEquals(0, Game.getEntities().size());
     }
 
     /*

--- a/game/test/starter/GameTest.java
+++ b/game/test/starter/GameTest.java
@@ -32,8 +32,8 @@ class GameTest {
 
     @Before
     public void setUp() throws Exception {
-        Game.getDelayedSet().removeAll(Game.getEntities());
-        Game.getDelayedSet().update();
+        Game.getDelayedEntitySet().removeAll(Game.getEntities());
+        Game.getDelayedEntitySet().update();
 
         game = Mockito.spy(Game.class);
         batch = Mockito.mock(SpriteBatch.class);
@@ -97,7 +97,7 @@ class GameTest {
         Entity e1 = Mockito.mock(Entity.class);
         Game.addEntity(e1);
         assertFalse(Game.getEntities().contains(e1));
-        Game.getDelayedSet().update();
+        Game.getDelayedEntitySet().update();
         assertTrue(Game.getEntities().contains(e1));
         assertEquals(1, Game.getEntities().size());
     }
@@ -106,9 +106,9 @@ class GameTest {
     public void removeEntity() {
         Entity e1 = Mockito.mock(Entity.class);
         Game.addEntity(e1);
-        Game.getDelayedSet().update();
+        Game.getDelayedEntitySet().update();
         Game.removeEntity(e1);
-        Game.getDelayedSet().update();
+        Game.getDelayedEntitySet().update();
         assertFalse(Game.getEntities().contains(e1));
         assertEquals(0, Game.getEntities().size());
     }


### PR DESCRIPTION
fixes #635 

- hinzufügen von `DelayedSet` als Hilfsklasse, um die verschiedenen Sets `current`, `toAdd` und `toRemove` zu gruppieren und das handeln dieser zu vereinheitlichen. 
- Einbauen von `DelayedSet` in `Game` um die Entitäten des ECS zu verwalten
- Anpassen der Test-Fälle 


---
Ich habe zuerst mit dem Gedanken gespielt, `DelayedSet` von `Set` abzuleiten (wäre den Namen auch gerechter).
Ich habe mich dagegen entschieden, da wir sonst die ganzen `Set` Funktionalitäten selbst implementieren müssten.
Hier mal der Ausschnitt: 
![image](https://github.com/Programmiermethoden/Dungeon/assets/32962412/b6e921a2-6e59-4424-849b-3f2bcd6b4b6c)
In der Regel würden wir die Funktionen nur auf `current` anwenden und nicht auf die "Hilfe-Sets". 
Das müssten wir dann aber wieder Umfangreich dokumentieren und testen und und und...
Ich sehe dabei auch keinen Gewinn für unsere Sache und würde (für den seltenen Fall, dass man eine der Funktionen brauch) den User direkt auf `current` agieren lassen. 