### PR TITLE
[GAME] Refactor PlayerComponent

### DIFF
--- a/game/src/contrib/entities/EntityFactory.java
+++ b/game/src/contrib/entities/EntityFactory.java
@@ -1,7 +1,9 @@
 package contrib.entities;
 
 import contrib.components.*;
+import contrib.configuration.KeyboardConfig;
 import contrib.utils.components.interaction.DropItemsInteraction;
+import contrib.utils.components.interaction.InteractionTool;
 import contrib.utils.components.item.ItemData;
 import contrib.utils.components.item.ItemDataGenerator;
 import contrib.utils.components.skill.FireballSkill;
@@ -59,7 +61,44 @@ public class EntityFactory {
         Skill fireball =
                 new Skill(
                         new FireballSkill(SkillTools::getCursorPositionAsPoint), fireballCoolDown);
-        pc.setSkillSlot1(fireball);
+
+        // hero movement
+        pc.registerFunction(
+                KeyboardConfig.MOVEMENT_UP.get(),
+                entity -> {
+                    VelocityComponent vc =
+                            (VelocityComponent) entity.getComponent(VelocityComponent.class).get();
+                    vc.setCurrentYVelocity(1 * vc.getYVelocity());
+                });
+        pc.registerFunction(
+                KeyboardConfig.MOVEMENT_DOWN.get(),
+                entity -> {
+                    VelocityComponent vc =
+                            (VelocityComponent) entity.getComponent(VelocityComponent.class).get();
+                    vc.setCurrentYVelocity(-1 * vc.getYVelocity());
+                });
+        pc.registerFunction(
+                KeyboardConfig.MOVEMENT_RIGHT.get(),
+                entity -> {
+                    VelocityComponent vc =
+                            (VelocityComponent) entity.getComponent(VelocityComponent.class).get();
+                    vc.setCurrentXVelocity(1 * vc.getXVelocity());
+                });
+        pc.registerFunction(
+                KeyboardConfig.MOVEMENT_LEFT.get(),
+                entity -> {
+                    VelocityComponent vc =
+                            (VelocityComponent) entity.getComponent(VelocityComponent.class).get();
+                    vc.setCurrentXVelocity(-1 * vc.getXVelocity());
+                });
+
+        pc.registerFunction(
+                KeyboardConfig.INTERACT_WORLD.get(),
+                InteractionTool::interactWithClosestInteractable);
+
+        // skills
+        pc.registerFunction(KeyboardConfig.FIRST_SKILL.get(), fireball::execute);
+
         return hero;
     }
 

--- a/game/src/core/components/PlayerComponent.java
+++ b/game/src/core/components/PlayerComponent.java
@@ -1,121 +1,80 @@
 package core.components;
 
-import com.badlogic.gdx.utils.Null;
-
-import contrib.utils.components.skill.Skill;
+import com.badlogic.gdx.Gdx;
 
 import core.Component;
 import core.Entity;
-import core.utils.logging.CustomLogLevel;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
+import java.util.function.Consumer;
 import java.util.logging.Logger;
 
 /**
  * Component that marks an entity as playable.
  *
- * <p>This component is used to mark an entity as playable by the player. It also contains skills
- * that can be used by the player to interact with the game world. The skills are stored in two
- * slots. The skills can be null if the entity does not have any skills.
+ * <p>This component is used to mark an entity as playable by the player.
  *
- * <p>This component is used by the {@link core.systems.PlayerSystem PlayerSystem} to determine if
- * an entity is playable or not.
+ * <p>It also contains a map of keys/buttons (Map-Key-Value) and functions (Map-Value). The {@link
+ * core.systems.PlayerSystem} will trigger {@link #execute}. This method will check each entry in
+ * the map and check if the given key is pressed. If so, the function registered to this key will be
+ * executed.
+ *
+ * <p>Use {@link #registerFunction} to add a new function for a button press, for example, add
+ * movement controls.
+ *
+ * <p>In the dungeon, keys/buttons are represented by an integer value.
  */
 public class PlayerComponent extends Component {
 
-    private boolean playable;
-    private final Logger playableCompLogger = Logger.getLogger(this.getClass().getName());
-
-    private Skill skillSlot1;
-    private Skill skillSlot2;
-
-    /**
-     * Creates a new PlayerComponent with specific skills.
-     *
-     * <p>This constructor can be used if the entity has skills. By default, the associated entity
-     * is playable.
-     *
-     * @param entity - the entity this component belongs to
-     * @param skillSlot1 - the first skill slot (can be null)
-     * @param skillSlot2 - the second skill slot (can be null)
-     */
-    public PlayerComponent(Entity entity, @Null Skill skillSlot1, @Null Skill skillSlot2) {
-        super(entity);
-        playable = true;
-        this.skillSlot1 = skillSlot1;
-        this.skillSlot2 = skillSlot2;
-    }
+    private final Logger LOGGER = Logger.getLogger(this.getClass().getName());
+    private Map<Integer, Consumer<Entity>> functions;
 
     /**
      * Creates a new PlayerComponent.
-     *
-     * <p>This constructor can be used if the entity does not have any skills. By default, the
-     * associated entity is playable.
      *
      * @param entity - the entity this component belongs to
      */
     public PlayerComponent(Entity entity) {
         super(entity);
-        playable = true;
+        functions = new HashMap<>();
     }
 
     /**
-     * Checks if the entity is playable or not
+     * Add a new function to this component.
      *
-     * @return true if the entity
+     * <p>If a function is already registered on this key, the old function will be replaced.
+     *
+     * @param key The key-value on which the function should be executed
+     * @param function Function to execute if the key is pressed
+     * @return Optional<Consumer<Entity>> The old function, if one was existing. Can be null.
+     * @see com.badlogic.gdx.Gdx#input
      */
-    public boolean isPlayable() {
-        playableCompLogger.log(
-                CustomLogLevel.DEBUG,
-                "Checking if entity '"
-                        + entity.getClass().getSimpleName()
-                        + "' is playable: "
-                        + playable);
-        return playable;
+    public Optional<Consumer<Entity>> registerFunction(int key, Consumer<Entity> function) {
+        Optional<Consumer<Entity>> oldFunction = Optional.ofNullable(functions.get(key));
+        functions.put(key, function);
+        return oldFunction;
     }
 
     /**
-     * Sets the playable property.
+     * Remove the registered function on the given key.
      *
-     * @param playable - true to play false to
+     * @param key Value of the key.
      */
-    public void setPlayable(boolean playable) {
-        this.playable = playable;
+    public void removeFunction(int key) {
+        functions.remove(key);
     }
 
     /**
-     * Sets the first skill slot
-     *
-     * @param skillSlot1 - the first skill slot
+     * Will check each entry in the function map, and if the key is just pressed, the function will
+     * be executed.
      */
-    public void setSkillSlot1(Skill skillSlot1) {
-        this.skillSlot1 = skillSlot1;
+    public void execute() {
+        functions.forEach((k, f) -> execute(k, f));
     }
 
-    /**
-     * Sets the second skill slot
-     *
-     * @param skillSlot2 - the second skill slot
-     */
-    public void setSkillSlot2(Skill skillSlot2) {
-        this.skillSlot2 = skillSlot2;
-    }
-
-    /**
-     * Returns the first skill this slot participates in.
-     *
-     * @return An Optional of the first skill this slot participates in
-     */
-    public Optional<Skill> getSkillSlot1() {
-        return Optional.ofNullable(skillSlot1);
-    }
-
-    /**
-     * Returns the second skill in this slot if there is one.
-     *
-     * @return An {@link Optional<Skill>} of the second skill
-     */
-    public Optional<Skill> getSkillSlot2() {
-        return Optional.ofNullable(skillSlot2);
+    private void execute(Integer key, Consumer<Entity> function) {
+        if (Gdx.input.isKeyPressed(key)) function.accept(entity);
     }
 }

--- a/game/src/core/systems/PlayerSystem.java
+++ b/game/src/core/systems/PlayerSystem.java
@@ -1,53 +1,26 @@
 package core.systems;
 
-import com.badlogic.gdx.Gdx;
-
-import contrib.configuration.KeyboardConfig;
-import contrib.utils.components.interaction.InteractionTool;
-
 import core.Entity;
 import core.System;
 import core.components.PlayerComponent;
-import core.components.VelocityComponent;
 
-/** Used to control the player */
+/**
+ * The PlayerSystem is used to control the player, it will trigger the {@link
+ * PlayerComponent#execute()}-Method to execute the Functions registered to Keys.
+ */
 public class PlayerSystem extends System {
 
     public PlayerSystem() {
-        super(PlayerComponent.class, VelocityComponent.class);
+        super(PlayerComponent.class);
     }
 
     @Override
     public void execute() {
-        getEntityStream().map(this::buildDataObject).forEach(this::checkKeystroke);
+        getEntityStream().forEach(this::execute);
     }
 
-    private void checkKeystroke(PSData ksd) {
-        if (Gdx.input.isKeyPressed(KeyboardConfig.MOVEMENT_UP.get()))
-            ksd.vc.setCurrentYVelocity(1 * ksd.vc.getYVelocity());
-        else if (Gdx.input.isKeyPressed(KeyboardConfig.MOVEMENT_DOWN.get()))
-            ksd.vc.setCurrentYVelocity(-1 * ksd.vc.getYVelocity());
-        else if (Gdx.input.isKeyPressed(KeyboardConfig.MOVEMENT_RIGHT.get()))
-            ksd.vc.setCurrentXVelocity(1 * ksd.vc.getXVelocity());
-        else if (Gdx.input.isKeyPressed(KeyboardConfig.MOVEMENT_LEFT.get()))
-            ksd.vc.setCurrentXVelocity(-1 * ksd.vc.getXVelocity());
-
-        if (Gdx.input.isKeyPressed(KeyboardConfig.INTERACT_WORLD.get()))
-            InteractionTool.interactWithClosestInteractable(ksd.e);
-
-        // check skills
-        else if (Gdx.input.isKeyPressed(KeyboardConfig.FIRST_SKILL.get()))
-            ksd.pc.getSkillSlot1().ifPresent(skill -> skill.execute(ksd.e));
-        else if (Gdx.input.isKeyPressed(KeyboardConfig.SECOND_SKILL.get()))
-            ksd.pc.getSkillSlot2().ifPresent(skill -> skill.execute(ksd.e));
+    private void execute(Entity entity) {
+        PlayerComponent pc = (PlayerComponent) (entity.getComponent(PlayerComponent.class).get());
+        pc.execute();
     }
-
-    private PSData buildDataObject(Entity e) {
-        PlayerComponent pc = (PlayerComponent) e.getComponent(PlayerComponent.class).get();
-        VelocityComponent vc = (VelocityComponent) e.getComponent(VelocityComponent.class).get();
-
-        return new PSData(e, pc, vc);
-    }
-
-    private record PSData(Entity e, PlayerComponent pc, VelocityComponent vc) {}
 }

--- a/game/test/core/components/PlayerComponentTest.java
+++ b/game/test/core/components/PlayerComponentTest.java
@@ -2,16 +2,16 @@ package core.components;
 
 import static org.junit.Assert.*;
 
-import contrib.utils.components.skill.Skill;
-
 import core.Entity;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mockito;
+
+import java.util.function.Consumer;
 
 public class PlayerComponentTest {
 
+    private static int counter = 0;
     private PlayerComponent playableComponent;
 
     @Before
@@ -20,29 +20,27 @@ public class PlayerComponentTest {
     }
 
     @Test
-    public void isPlayable() {
-        assertTrue(playableComponent.isPlayable());
-        playableComponent.setPlayable(false);
-        assertFalse(playableComponent.isPlayable());
+    public void addFunction() {
+        Consumer<Entity> function =
+                new Consumer<Entity>() {
+                    @Override
+                    public void accept(Entity entity) {}
+                };
+        assertTrue(playableComponent.registerFunction(1, function).isEmpty());
     }
 
-    @Test
-    public void setSkillSlot1() {
-        Skill s = Mockito.mock(Skill.class);
-        playableComponent.setSkillSlot1(s);
-        assertEquals(s, playableComponent.getSkillSlot1().get());
-        Skill s2 = Mockito.mock(Skill.class);
-        playableComponent.setSkillSlot1(s2);
-        assertEquals(s2, playableComponent.getSkillSlot1().get());
-    }
-
-    @Test
-    public void setSkillSlot2() {
-        Skill s = Mockito.mock(Skill.class);
-        playableComponent.setSkillSlot2(s);
-        assertEquals(s, playableComponent.getSkillSlot2().get());
-        Skill s2 = Mockito.mock(Skill.class);
-        playableComponent.setSkillSlot2(s2);
-        assertEquals(s2, playableComponent.getSkillSlot2().get());
+    public void addFunction_exisitng() {
+        Consumer<Entity> function =
+                new Consumer<Entity>() {
+                    @Override
+                    public void accept(Entity entity) {}
+                };
+        Consumer<Entity> newfunction =
+                new Consumer<Entity>() {
+                    @Override
+                    public void accept(Entity entity) {}
+                };
+        playableComponent.registerFunction(1, function).get();
+        assertEquals(function, playableComponent.registerFunction(1, newfunction).get());
     }
 }


### PR DESCRIPTION
fixes #658 

- PlayerComponent speichert nun die Tastaturbelegung und die Funktionalität nach Druck der Taste in einer Hashmap
    - zum Hinzufügen einer neuen Funktionalität (z.B. neuer Skill), existiert die Methode `registerFunction`, zum Entfernen `removeFunction`

- Hero bekommt in "EntityFactory` durch nutzen der neuen Methoden seine Bewegungsfähigkeit und seine Skills.

- Tests angepasst