### PR TITLE
[Game] Implement ITransition: ProtectOnApproach

### DIFF
--- a/game/src/ecs/components/ai/transition/ProtectOnApproach.java
+++ b/game/src/ecs/components/ai/transition/ProtectOnApproach.java
@@ -1,0 +1,46 @@
+package ecs.components.ai.transition;
+
+import ecs.components.ai.AITools;
+import ecs.entities.Entity;
+
+/**
+ * Implements an AI that protects an entity if hero is in the given range
+ *
+ * <p>Entity will stay in fight mode once entered
+ */
+public class ProtectOnApproach implements ITransition {
+    private final float range;
+
+    private final Entity toProtect;
+
+    private boolean isInFight = false;
+
+    /**
+     * Constructor needs a range and the entity to protect.
+     *
+     * @param range     - The range in which the entity should in fight mode
+     * @param toProtect - The entity which should be protected
+     */
+    public ProtectOnApproach(float range, Entity toProtect) {
+        this.range = range;
+        this.toProtect = toProtect;
+    }
+
+    /**
+     * If protecting entity isn't in fight mode yet, check if player is in range of the protected
+     * entity
+     *
+     * @param entity that protects
+     * @return boolean
+     */
+    @Override
+    public boolean isInFightMode(Entity entity) {
+        if (isInFight) {
+            return true;
+        }
+
+        isInFight = AITools.playerInRange(toProtect, range);
+
+        return isInFight;
+    }
+}

--- a/game/test/ecs/components/ai/transition/ProtectOnApproachTest.java
+++ b/game/test/ecs/components/ai/transition/ProtectOnApproachTest.java
@@ -1,0 +1,75 @@
+package ecs.components.ai.transition;
+
+import ecs.components.PositionComponent;
+import ecs.components.ai.AIComponent;
+import ecs.components.ai.fight.CollideAI;
+import ecs.components.ai.idle.RadiusWalk;
+import ecs.entities.Entity;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import starter.Game;
+import tools.Point;
+
+import static org.junit.Assert.assertTrue;
+
+public class ProtectOnApproachTest {
+    private Entity entity;
+    private AIComponent entityAI;
+    private Entity protectedEntity;
+    private Entity hero;
+    private final Point pointOfProtect = new Point(0, 0);
+
+    @Before
+    public void setUpEntityToProtect() {
+        protectedEntity = new Entity();
+
+        // Add AI Component
+        AIComponent protectedAI =
+            new AIComponent(
+                protectedEntity,
+                new CollideAI(0.2f),
+                new RadiusWalk(0, 50),
+                new RangeTransition(2));
+
+        protectedEntity.addComponent(protectedAI);
+
+        // Add Position Component
+        protectedEntity.addComponent(new PositionComponent(protectedEntity, pointOfProtect));
+    }
+
+    @Before
+    public void setUpEntityThatProtects() {
+        entity = new Entity();
+
+        // Add AI Component
+        entityAI =
+            new AIComponent(
+                entity,
+                new CollideAI(0.2f),
+                new RadiusWalk(0, 50),
+                new ProtectOnApproach(2f, protectedEntity));
+        entity.addComponent(entityAI);
+
+        // Add Position Component
+        entity.addComponent(new PositionComponent(entity, new Point(0f, 0f)));
+    }
+
+    @Before
+    public void setUpHero() {
+        hero = Game.getHero().orElse(new Entity());
+    }
+
+
+    //Ignore because no solution to create hero during tests at the moment
+    @Test
+    @Ignore
+    public void testHeroInRange() {
+        // when
+        hero.removeComponent(PositionComponent.class);
+        hero.addComponent(new PositionComponent(hero, pointOfProtect));
+
+        // then
+        assertTrue(entityAI.getTransitionAI().isInFightMode(entity));
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/Programmiermethoden/Dungeon/issues/144 - Habe ich mal umbenannt in ProtectOnApproach, klingt allgemeingültiger, ProtectTreasure klang so als könnte man nur Chests damit beschützen.

Die ITransition wird ausgelöst sobald sich der Held in einer vorbestimmten Range einer ebenso vorgegebenen Entity nähert. Nach einmaligen triggern wechselt diese auch nicht mehr zurück in den Idle-Mode.

**Anmerkung:** Die Tests gestalten sich hier schwierig, ich kriege ständig NullPointerExceptions beim initalisieren des Heros, ein Hero ist aber zum testen nötig. Ich bin leider noch unerfahren mit Mocking, habe aber nicht das Gefühl das es hier eine gute Alternative ist da das Problem tiefer greift. Über Anreize wie man die Tests besser gestalten kann würde ich mich freuen. Hat wohl irgendetwas mit LibGDX zutun. Hab die Tests vorerst ignoriert hier.

Ist kein neuer PR, sondern wurde nur ausgelagert in Absprache mit @cagix 