### PR TITLE
[DSL] Varargs in `load`-Methoden von `IEnvironment` ermöglichen

### DIFF
--- a/dsl/src/runtime/GameEnvironment.java
+++ b/dsl/src/runtime/GameEnvironment.java
@@ -17,6 +17,7 @@ import semanticanalysis.types.IType;
 import semanticanalysis.types.TypeBuilder;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 
@@ -90,6 +91,11 @@ public class GameEnvironment implements IEvironment {
     }
 
     @Override
+    public void loadTypes(IType... types) {
+        loadTypes(Arrays.stream(types).toList());
+    }
+
+    @Override
     public void loadTypes(List<IType> types) {
         for (IType type : types) {
             if (!(type instanceof IType)) {
@@ -104,6 +110,11 @@ public class GameEnvironment implements IEvironment {
             loadedTypes.put(type.getName(), type);
             this.globalScope.bind((Symbol) type);
         }
+    }
+
+    @Override
+    public void loadFunctions(ScopedSymbol... functions) {
+        loadFunctions(Arrays.stream(functions).toList());
     }
 
     @Override

--- a/dsl/src/runtime/IEvironment.java
+++ b/dsl/src/runtime/IEvironment.java
@@ -26,11 +26,20 @@ public interface IEvironment {
     }
 
     // default Symbol lookupFunction(String name) { return Symbol.NULL; }
+    /**
+     * @param types AggregateTypes to load into the environment
+     */
+    default void loadTypes(IType... types) {}
 
     /**
      * @param types AggregateTypes to load into the environment
      */
     default void loadTypes(List<IType> types) {}
+
+    /**
+     * @param functionDefinitions FunctionSymbols to load into the environment
+     */
+    default void loadFunctions(ScopedSymbol... functionDefinitions) {}
 
     /**
      * @param functionDefinitions FunctionSymbols to load into the environment

--- a/dsl/src/semanticanalysis/types/TypeBinder.java
+++ b/dsl/src/semanticanalysis/types/TypeBinder.java
@@ -10,8 +10,6 @@ import runtime.IEvironment;
 import semanticanalysis.Symbol;
 import semanticanalysis.SymbolTable;
 
-import java.util.List;
-
 public class TypeBinder implements AstVisitor<Object> {
 
     private StringBuilder errorStringBuilder;
@@ -67,9 +65,8 @@ public class TypeBinder implements AstVisitor<Object> {
                 symbolTable().addSymbolNodeRelation(memberSymbol, compDefNode);
             }
         }
-        var typesToLoad = new AggregateType[] {newType};
 
-        this.environment.loadTypes(List.of(typesToLoad));
+        this.environment.loadTypes(newType);
         return newType;
     }
 

--- a/dsl/test/helpers/Helpers.java
+++ b/dsl/test/helpers/Helpers.java
@@ -109,8 +109,7 @@ public class Helpers {
             parser.ast.Node ast, IType[] types) {
         var symTableParser = new SemanticAnalyzer();
         var env = new GameEnvironment();
-        var typesToLoad = types;
-        env.loadTypes(List.of(typesToLoad));
+        env.loadTypes(List.of(types));
         symTableParser.setup(env);
         return symTableParser.walk(ast);
     }

--- a/dsl/test/interpreter/TestDSLInterpreter.java
+++ b/dsl/test/interpreter/TestDSLInterpreter.java
@@ -25,7 +25,6 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.util.List;
 
 public class TestDSLInterpreter {
     /** Tests, if a native function call is evaluated by the DSLInterpreter */
@@ -171,8 +170,7 @@ public class TestDSLInterpreter {
         var otherCompType = tb.createTypeFromClass(new Scope(), OtherComponent.class);
 
         var env = new GameEnvironment();
-        var typesToLoad = new IType[] {testCompType, otherCompType};
-        env.loadTypes(List.of(typesToLoad));
+        env.loadTypes(testCompType, otherCompType);
 
         SemanticAnalyzer symbolTableParser = new SemanticAnalyzer();
         symbolTableParser.setup(env);
@@ -234,8 +232,7 @@ public class TestDSLInterpreter {
         var otherCompType = tb.createTypeFromClass(new Scope(), TestComponent2.class);
 
         var env = new TestEnvironment();
-        var typesToLoad = new IType[] {entityType, testCompType, otherCompType};
-        env.loadTypes(List.of(typesToLoad));
+        env.loadTypes(entityType, testCompType, otherCompType);
 
         SemanticAnalyzer symbolTableParser = new SemanticAnalyzer();
         symbolTableParser.setup(env);
@@ -308,8 +305,7 @@ public class TestDSLInterpreter {
         var compType = tb.createTypeFromClass(new Scope(), ComponentWithExternalTypeMember.class);
 
         var env = new TestEnvironment();
-        var typesToLoad = new IType[] {entityType, compType};
-        env.loadTypes(List.of(typesToLoad));
+        env.loadTypes(entityType, compType);
 
         SemanticAnalyzer symbolTableParser = new SemanticAnalyzer();
         symbolTableParser.setup(env);
@@ -369,11 +365,7 @@ public class TestDSLInterpreter {
                 env.getTypeBuilder()
                         .createTypeFromClass(Scope.NULL, TestComponentWithExternalType.class);
         var externalType = env.getTypeBuilder().createTypeFromClass(Scope.NULL, ExternalType.class);
-        env.loadTypes(
-                List.of(
-                        new IType[] {
-                            entityType, testCompType, externalComponentType, externalType
-                        }));
+        env.loadTypes(entityType, testCompType, externalComponentType, externalType);
 
         SemanticAnalyzer symbolTableParser = new SemanticAnalyzer();
         symbolTableParser.setup(env);
@@ -426,11 +418,7 @@ public class TestDSLInterpreter {
                 env.getTypeBuilder()
                         .createTypeFromClass(Scope.NULL, TestComponentWithExternalType.class);
         var adapterType = env.getTypeBuilder().createTypeFromClass(Scope.NULL, ExternalType.class);
-        env.loadTypes(
-                List.of(
-                        new IType[] {
-                            entityType, testCompType, externalComponentType, adapterType
-                        }));
+        env.loadTypes(entityType, testCompType, externalComponentType, adapterType);
 
         SemanticAnalyzer symbolTableParser = new SemanticAnalyzer();
         symbolTableParser.setup(env);

--- a/dsl/test/interpreter/TestEnvironment.java
+++ b/dsl/test/interpreter/TestEnvironment.java
@@ -6,8 +6,6 @@ import semanticanalysis.Scope;
 import semanticanalysis.Symbol;
 import semanticanalysis.types.IType;
 
-import java.util.List;
-
 public class TestEnvironment extends GameEnvironment {
 
     public TestEnvironment() {
@@ -25,8 +23,7 @@ public class TestEnvironment extends GameEnvironment {
 
         var questConfigType =
                 this.getTypeBuilder().createTypeFromClass(Scope.NULL, CustomQuestConfig.class);
-        var typesToLoad = new semanticanalysis.types.IType[] {questConfigType};
-        loadTypes(List.of(typesToLoad));
+        loadTypes(questConfigType);
 
         for (Symbol func : NATIVE_FUNCTIONS) {
             globalScope.bind(func);

--- a/dsl/test/semanticanalysis/TestSymbolTableParser.java
+++ b/dsl/test/semanticanalysis/TestSymbolTableParser.java
@@ -81,8 +81,7 @@ public class TestSymbolTableParser {
         var testComponentType = tb.createTypeFromClass(Scope.NULL, TestComponent.class);
 
         var env = new GameEnvironment();
-        var typesToLoad = new IType[] {testComponentType};
-        env.loadTypes(List.of(typesToLoad));
+        env.loadTypes(testComponentType);
         symbolTableParser.setup(env);
         var symbolTable = symbolTableParser.walk(ast).symbolTable;
 

--- a/dsl/test/semanticanalysis/TestTypeBinder.java
+++ b/dsl/test/semanticanalysis/TestTypeBinder.java
@@ -11,8 +11,6 @@ import runtime.GameEnvironment;
 
 import semanticanalysis.types.*;
 
-import java.util.List;
-
 public class TestTypeBinder {
     @DSLType
     private record TestComponent(
@@ -40,8 +38,7 @@ public class TestTypeBinder {
         var symTableParser = new SemanticAnalyzer();
 
         var env = new GameEnvironment();
-        var types = new IType[] {testCompType};
-        env.loadTypes(List.of(types));
+        env.loadTypes(testCompType);
         symTableParser.setup(env);
 
         SymbolTable symbolTable = symTableParser.walk(ast).symbolTable;
@@ -83,8 +80,7 @@ public class TestTypeBinder {
         var symTableParser = new SemanticAnalyzer();
 
         var env = new GameEnvironment();
-        var types = new IType[] {testCompType};
-        env.loadTypes(List.of(types));
+        env.loadTypes(testCompType);
         symTableParser.setup(env);
 
         SymbolTable symbolTable = symTableParser.walk(ast).symbolTable;
@@ -125,8 +121,7 @@ public class TestTypeBinder {
         env.getTypeBuilder().registerTypeAdapter(RecordBuilder.class, Scope.NULL);
         var type = env.getTypeBuilder().createTypeFromClass(new Scope(), TestRecordUser.class);
 
-        var types = new IType[] {type};
-        env.loadTypes(List.of(types));
+        env.loadTypes(type);
         symTableParser.setup(env);
 
         SymbolTable symbolTable = symTableParser.walk(ast).symbolTable;


### PR DESCRIPTION
Aktuell muss für das Laden von Datentypen oder Funktionsdefinitionen in ein `IEnvironment` immer folgende umständliche Konstruktion verwendet werden:

```java
var types = new IType[] {type1, type2};
env.loadTypes(List.of(types));
```

Das händische Laden von Datentypen ist insbesondere für Tests (z.B. in `TestDSLInterpreter`, `TestTypeBinder`) wichtig. Um den Code etwas lesbarer und handlicher zu gestalten, fügt dieser PR die Möglichkeit hinzu, `varargs` für die `loadTypes` und `loadFunctions`-Methoden von `IEnvironment` zu verwenden:

```java
env.loadTypes(type1, type2);
```