### PR TITLE
[GAME] rename Entity#getComponent into #fetch and add class cast and throw MissingComponentException if Component is missing, make some classes and method parameter final

### DIFF
--- a/game/src/contrib/components/CollideComponent.java
+++ b/game/src/contrib/components/CollideComponent.java
@@ -105,7 +105,7 @@ public class CollideComponent extends Component {
         PositionComponent pc =
                 (PositionComponent)
                         getEntity()
-                                .getComponent(PositionComponent.class)
+                                .fetch(PositionComponent.class)
                                 .orElseThrow(
                                         CollideComponent::getMissingPositionComponentException);
         return new Point(pc.position().x + offset.x, pc.position().y + offset.y);
@@ -118,7 +118,7 @@ public class CollideComponent extends Component {
         PositionComponent pc =
                 (PositionComponent)
                         getEntity()
-                                .getComponent(PositionComponent.class)
+                                .fetch(PositionComponent.class)
                                 .orElseThrow(
                                         CollideComponent::getMissingPositionComponentException);
         return new Point(pc.position().x + offset.x + size.x, pc.position().y + offset.y + size.y);
@@ -131,7 +131,7 @@ public class CollideComponent extends Component {
         PositionComponent pc =
                 (PositionComponent)
                         getEntity()
-                                .getComponent(PositionComponent.class)
+                                .fetch(PositionComponent.class)
                                 .orElseThrow(
                                         CollideComponent::getMissingPositionComponentException);
         return new Point(

--- a/game/src/contrib/components/CollideComponent.java
+++ b/game/src/contrib/components/CollideComponent.java
@@ -15,7 +15,7 @@ import semanticanalysis.types.DSLType;
 import java.util.logging.Logger;
 
 @DSLType(name = "hitbox_component")
-public class CollideComponent extends Component {
+public final class CollideComponent extends Component {
     public static final Point DEFAULT_OFFSET = new Point(0.25f, 0.25f);
     public static final Point DEFAULT_SIZE = new Point(0.5f, 0.5f);
     public static final TriConsumer<Entity, Entity, Tile.Direction> DEFAULT_COLLIDER =
@@ -36,11 +36,11 @@ public class CollideComponent extends Component {
      * @param collideLeave behaviour if a collision stopped
      */
     public CollideComponent(
-            Entity entity,
-            Point offset,
-            Point size,
-            TriConsumer<Entity, Entity, Tile.Direction> collideEnter,
-            TriConsumer<Entity, Entity, Tile.Direction> collideLeave) {
+            final Entity entity,
+            final Point offset,
+            final Point size,
+            final TriConsumer<Entity, Entity, Tile.Direction> collideEnter,
+            final TriConsumer<Entity, Entity, Tile.Direction> collideLeave) {
         super(entity);
         this.offset = offset;
         this.size = size;
@@ -56,9 +56,9 @@ public class CollideComponent extends Component {
      * @param collideLeave behaviour if a collision stopped
      */
     public CollideComponent(
-            Entity entity,
-            TriConsumer<Entity, Entity, Tile.Direction> collideEnter,
-            TriConsumer<Entity, Entity, Tile.Direction> collideLeave) {
+            final Entity entity,
+            final TriConsumer<Entity, Entity, Tile.Direction> collideEnter,
+            final TriConsumer<Entity, Entity, Tile.Direction> collideLeave) {
         this(entity, DEFAULT_OFFSET, DEFAULT_SIZE, collideEnter, collideLeave);
     }
 
@@ -68,7 +68,7 @@ public class CollideComponent extends Component {
      *
      * @param entity associated entity
      */
-    public CollideComponent(@DSLContextMember(name = "entity") Entity entity) {
+    public CollideComponent(@DSLContextMember(name = "entity") final Entity entity) {
         this(entity, CollideComponent.DEFAULT_COLLIDER, CollideComponent.DEFAULT_COLLIDER);
     }
 
@@ -76,7 +76,7 @@ public class CollideComponent extends Component {
      * @param other hitbox of another entity
      * @param direction direction in which the collision happens
      */
-    public void onEnter(CollideComponent other, Tile.Direction direction) {
+    public void onEnter(final CollideComponent other, final Tile.Direction direction) {
         if (collideEnter != null) collideEnter.accept(this.entity, other.entity, direction);
     }
 
@@ -84,7 +84,7 @@ public class CollideComponent extends Component {
      * @param other hitbox of another entity
      * @param direction direction in which the collision happens
      */
-    public void onLeave(CollideComponent other, Tile.Direction direction) {
+    public void onLeave(final CollideComponent other, final Tile.Direction direction) {
         if (collideLeave != null) {
             hitboxLogger.log(
                     CustomLogLevel.DEBUG,
@@ -101,39 +101,42 @@ public class CollideComponent extends Component {
     /**
      * @return bottom left point of entity's hitbox
      */
-    public Point getBottomLeft() {
+    public Point bottomLeft() {
         PositionComponent pc =
-                (PositionComponent)
-                        getEntity()
-                                .fetch(PositionComponent.class)
-                                .orElseThrow(
-                                        CollideComponent::getMissingPositionComponentException);
+                getEntity()
+                        .fetch(PositionComponent.class)
+                        .orElseThrow(
+                                () ->
+                                        MissingComponentException.build(
+                                                getEntity(), PositionComponent.class));
         return new Point(pc.position().x + offset.x, pc.position().y + offset.y);
     }
 
     /**
      * @return top right point of entity's hitbox
      */
-    public Point getTopRight() {
+    public Point topRight() {
         PositionComponent pc =
-                (PositionComponent)
-                        getEntity()
-                                .fetch(PositionComponent.class)
-                                .orElseThrow(
-                                        CollideComponent::getMissingPositionComponentException);
+                getEntity()
+                        .fetch(PositionComponent.class)
+                        .orElseThrow(
+                                () ->
+                                        MissingComponentException.build(
+                                                getEntity(), PositionComponent.class));
         return new Point(pc.position().x + offset.x + size.x, pc.position().y + offset.y + size.y);
     }
 
     /**
      * @return center point of entity's hitbox
      */
-    public Point getCenter() {
+    public Point center() {
         PositionComponent pc =
-                (PositionComponent)
-                        getEntity()
-                                .fetch(PositionComponent.class)
-                                .orElseThrow(
-                                        CollideComponent::getMissingPositionComponentException);
+                getEntity()
+                        .fetch(PositionComponent.class)
+                        .orElseThrow(
+                                () ->
+                                        MissingComponentException.build(
+                                                getEntity(), PositionComponent.class));
         return new Point(
                 pc.position().x + offset.x + size.x / 2, pc.position().y + offset.y + size.y / 2);
     }
@@ -141,19 +144,14 @@ public class CollideComponent extends Component {
     /**
      * @param collideEnter new collideMethod of the associated entity
      */
-    public void setCollideEnter(TriConsumer<Entity, Entity, Tile.Direction> collideEnter) {
+    public void collideEnter(TriConsumer<Entity, Entity, Tile.Direction> collideEnter) {
         this.collideEnter = collideEnter;
     }
 
     /**
      * @param collideLeave new collideMethod of the associated entity
      */
-    public void setCollideLeave(TriConsumer<Entity, Entity, Tile.Direction> collideLeave) {
+    public void collideLeave(TriConsumer<Entity, Entity, Tile.Direction> collideLeave) {
         this.collideLeave = collideLeave;
-    }
-
-    private static MissingComponentException getMissingPositionComponentException() {
-        return new MissingComponentException(
-                PositionComponent.class.getName() + " in " + CollideComponent.class.getName());
     }
 }

--- a/game/src/contrib/entities/EntityFactory.java
+++ b/game/src/contrib/entities/EntityFactory.java
@@ -61,28 +61,28 @@ public class EntityFactory {
                 KeyboardConfig.MOVEMENT_UP.get(),
                 entity -> {
                     VelocityComponent vc =
-                            (VelocityComponent) entity.getComponent(VelocityComponent.class).get();
+                            (VelocityComponent) entity.fetch(VelocityComponent.class).get();
                     vc.setCurrentYVelocity(1 * vc.getYVelocity());
                 });
         pc.registerFunction(
                 KeyboardConfig.MOVEMENT_DOWN.get(),
                 entity -> {
                     VelocityComponent vc =
-                            (VelocityComponent) entity.getComponent(VelocityComponent.class).get();
+                            (VelocityComponent) entity.fetch(VelocityComponent.class).get();
                     vc.setCurrentYVelocity(-1 * vc.getYVelocity());
                 });
         pc.registerFunction(
                 KeyboardConfig.MOVEMENT_RIGHT.get(),
                 entity -> {
                     VelocityComponent vc =
-                            (VelocityComponent) entity.getComponent(VelocityComponent.class).get();
+                            (VelocityComponent) entity.fetch(VelocityComponent.class).get();
                     vc.setCurrentXVelocity(1 * vc.getXVelocity());
                 });
         pc.registerFunction(
                 KeyboardConfig.MOVEMENT_LEFT.get(),
                 entity -> {
                     VelocityComponent vc =
-                            (VelocityComponent) entity.getComponent(VelocityComponent.class).get();
+                            (VelocityComponent) entity.fetch(VelocityComponent.class).get();
                     vc.setCurrentXVelocity(-1 * vc.getXVelocity());
                 });
 

--- a/game/src/contrib/entities/EntityFactory.java
+++ b/game/src/contrib/entities/EntityFactory.java
@@ -15,6 +15,7 @@ import core.Game;
 import core.components.*;
 import core.level.utils.LevelElement;
 import core.utils.Point;
+import core.utils.components.MissingComponentException;
 import core.utils.components.draw.CoreAnimations;
 
 import java.io.IOException;
@@ -61,28 +62,47 @@ public class EntityFactory {
                 KeyboardConfig.MOVEMENT_UP.get(),
                 entity -> {
                     VelocityComponent vc =
-                            (VelocityComponent) entity.fetch(VelocityComponent.class).get();
+                            entity.fetch(VelocityComponent.class)
+                                    .orElseThrow(
+                                            () ->
+                                                    MissingComponentException.build(
+                                                            entity, VelocityComponent.class));
                     vc.setCurrentYVelocity(1 * vc.getYVelocity());
                 });
         pc.registerFunction(
                 KeyboardConfig.MOVEMENT_DOWN.get(),
                 entity -> {
                     VelocityComponent vc =
-                            (VelocityComponent) entity.fetch(VelocityComponent.class).get();
+                            entity.fetch(VelocityComponent.class)
+                                    .orElseThrow(
+                                            () ->
+                                                    MissingComponentException.build(
+                                                            entity, VelocityComponent.class));
+
                     vc.setCurrentYVelocity(-1 * vc.getYVelocity());
                 });
         pc.registerFunction(
                 KeyboardConfig.MOVEMENT_RIGHT.get(),
                 entity -> {
                     VelocityComponent vc =
-                            (VelocityComponent) entity.fetch(VelocityComponent.class).get();
+                            entity.fetch(VelocityComponent.class)
+                                    .orElseThrow(
+                                            () ->
+                                                    MissingComponentException.build(
+                                                            entity, VelocityComponent.class));
+
                     vc.setCurrentXVelocity(1 * vc.getXVelocity());
                 });
         pc.registerFunction(
                 KeyboardConfig.MOVEMENT_LEFT.get(),
                 entity -> {
                     VelocityComponent vc =
-                            (VelocityComponent) entity.fetch(VelocityComponent.class).get();
+                            entity.fetch(VelocityComponent.class)
+                                    .orElseThrow(
+                                            () ->
+                                                    MissingComponentException.build(
+                                                            entity, VelocityComponent.class));
+
                     vc.setCurrentXVelocity(-1 * vc.getXVelocity());
                 });
 

--- a/game/src/contrib/entities/WorldItemBuilder.java
+++ b/game/src/contrib/entities/WorldItemBuilder.java
@@ -21,7 +21,7 @@ public class WorldItemBuilder {
     public static Entity buildWorldItem(ItemData itemData) {
         Entity droppedItem = new Entity();
         new PositionComponent(droppedItem, new Point(0, 0));
-        new DrawComponent(droppedItem, itemData.getWorldTexture());
+        new DrawComponent(droppedItem, itemData.worldTexture());
         new ItemComponent(droppedItem, itemData);
         CollideComponent component = new CollideComponent(droppedItem);
         component.collideEnter(

--- a/game/src/contrib/entities/WorldItemBuilder.java
+++ b/game/src/contrib/entities/WorldItemBuilder.java
@@ -24,7 +24,7 @@ public class WorldItemBuilder {
         new DrawComponent(droppedItem, itemData.getWorldTexture());
         new ItemComponent(droppedItem, itemData);
         CollideComponent component = new CollideComponent(droppedItem);
-        component.setCollideEnter(
+        component.collideEnter(
                 (a, b, direction) -> {
                     itemData.triggerCollect(a, b);
                 });

--- a/game/src/contrib/systems/AISystem.java
+++ b/game/src/contrib/systems/AISystem.java
@@ -11,7 +11,7 @@ import java.util.function.Consumer;
 public class AISystem extends System {
 
     private static final Consumer<Entity> executeAI =
-            entity -> ((AIComponent) entity.getComponent(AIComponent.class).get()).execute();
+            entity -> ((AIComponent) entity.fetch(AIComponent.class).get()).execute();
 
     public AISystem() {
         super(AIComponent.class);

--- a/game/src/contrib/systems/AISystem.java
+++ b/game/src/contrib/systems/AISystem.java
@@ -4,14 +4,21 @@ import contrib.components.AIComponent;
 
 import core.Entity;
 import core.System;
+import core.utils.components.MissingComponentException;
 
 import java.util.function.Consumer;
 
 /** Controls the AI */
-public class AISystem extends System {
+public final class AISystem extends System {
 
     private static final Consumer<Entity> executeAI =
-            entity -> ((AIComponent) entity.fetch(AIComponent.class).get()).execute();
+            entity ->
+                    entity.fetch(AIComponent.class)
+                            .orElseThrow(
+                                    () ->
+                                            MissingComponentException.build(
+                                                    entity, AIComponent.class))
+                            .execute();
 
     public AISystem() {
         super(AIComponent.class);

--- a/game/src/contrib/systems/CollisionSystem.java
+++ b/game/src/contrib/systems/CollisionSystem.java
@@ -34,8 +34,7 @@ public class CollisionSystem extends System {
                                         .flatMap(
                                                 b ->
                                                         b
-                                                                .fetch(
-                                                                        CollideComponent.class)
+                                                                .fetch(CollideComponent.class)
                                                                 .map(CollideComponent.class::cast)
                                                                 .stream())
                                         .map(b -> buildData(a, b)))
@@ -86,10 +85,10 @@ public class CollisionSystem extends System {
      * @return true if intersection exists otherwise false
      */
     protected boolean checkForCollision(CollideComponent hitbox1, CollideComponent hitbox2) {
-        return hitbox1.getBottomLeft().x < hitbox2.getTopRight().x
-                && hitbox1.getTopRight().x > hitbox2.getBottomLeft().x
-                && hitbox1.getBottomLeft().y < hitbox2.getTopRight().y
-                && hitbox1.getTopRight().y > hitbox2.getBottomLeft().y;
+        return hitbox1.bottomLeft().x < hitbox2.topRight().x
+                && hitbox1.topRight().x > hitbox2.bottomLeft().x
+                && hitbox1.bottomLeft().y < hitbox2.topRight().y
+                && hitbox1.topRight().y > hitbox2.bottomLeft().y;
     }
 
     /**
@@ -101,8 +100,8 @@ public class CollisionSystem extends System {
      */
     protected Tile.Direction checkDirectionOfCollision(
             CollideComponent hitbox1, CollideComponent hitbox2) {
-        float y = hitbox2.getCenter().y - hitbox1.getCenter().y;
-        float x = hitbox2.getCenter().x - hitbox1.getCenter().x;
+        float y = hitbox2.center().y - hitbox1.center().y;
+        float x = hitbox2.center().x - hitbox1.center().x;
         float rads = (float) Math.atan2(y, x);
         double piQuarter = Math.PI / 4;
         if (rads < 3 * -piQuarter) {

--- a/game/src/contrib/systems/CollisionSystem.java
+++ b/game/src/contrib/systems/CollisionSystem.java
@@ -24,7 +24,7 @@ public class CollisionSystem extends System {
                 .flatMap(
                         a ->
                                 a
-                                        .getComponent(CollideComponent.class)
+                                        .fetch(CollideComponent.class)
                                         .map(CollideComponent.class::cast)
                                         .stream())
                 .flatMap(
@@ -34,7 +34,7 @@ public class CollisionSystem extends System {
                                         .flatMap(
                                                 b ->
                                                         b
-                                                                .getComponent(
+                                                                .fetch(
                                                                         CollideComponent.class)
                                                                 .map(CollideComponent.class::cast)
                                                                 .stream())

--- a/game/src/contrib/systems/DebuggerSystem.java
+++ b/game/src/contrib/systems/DebuggerSystem.java
@@ -42,7 +42,7 @@ import java.util.logging.Logger;
  * @see System
  * @see KeyboardConfig
  */
-public class DebuggerSystem extends System {
+public final class DebuggerSystem extends System {
 
     private static final Logger LOGGER = Logger.getLogger(DebuggerSystem.class.getName());
 
@@ -121,14 +121,13 @@ public class DebuggerSystem extends System {
     public static void TELEPORT(Point targetLocation) {
         if (Game.hero().isPresent()) {
             PositionComponent pc =
-                    (PositionComponent)
-                            Game.hero()
-                                    .get()
-                                    .fetch(PositionComponent.class)
-                                    .orElseThrow(
-                                            () ->
-                                                    new MissingComponentException(
-                                                            "Hero is missing PositionComponent"));
+                    Game.hero()
+                            .get()
+                            .fetch(PositionComponent.class)
+                            .orElseThrow(
+                                    () ->
+                                            MissingComponentException.build(
+                                                    Game.hero().get(), PositionComponent.class));
 
             // Attempt to teleport to targetLocation
             LOGGER.log(

--- a/game/src/contrib/systems/DebuggerSystem.java
+++ b/game/src/contrib/systems/DebuggerSystem.java
@@ -124,7 +124,7 @@ public class DebuggerSystem extends System {
                     (PositionComponent)
                             Game.hero()
                                     .get()
-                                    .getComponent(PositionComponent.class)
+                                    .fetch(PositionComponent.class)
                                     .orElseThrow(
                                             () ->
                                                     new MissingComponentException(

--- a/game/src/contrib/systems/HealthSystem.java
+++ b/game/src/contrib/systems/HealthSystem.java
@@ -10,6 +10,7 @@ import core.Entity;
 import core.Game;
 import core.System;
 import core.components.DrawComponent;
+import core.utils.components.MissingComponentException;
 
 import java.util.stream.Stream;
 
@@ -17,7 +18,7 @@ import java.util.stream.Stream;
  * The HealthSystem offsets the damage to be done to all entities with the HealthComponent. Triggers
  * the death of an entity when the health-points have fallen below 0.
  */
-public class HealthSystem extends System {
+public final class HealthSystem extends System {
 
     public HealthSystem() {
         super(HealthComponent.class, DrawComponent.class);
@@ -49,22 +50,26 @@ public class HealthSystem extends System {
                 .forEach(this::removeDeadEntities);
     }
 
-    private HSData buildDataObject(Entity e) {
+    private HSData buildDataObject(Entity entity) {
 
-        HealthComponent hc = (HealthComponent) e.fetch(HealthComponent.class).get();
-        DrawComponent ac = (DrawComponent) e.fetch(DrawComponent.class).get();
-
-        return new HSData(e, hc, ac);
+        HealthComponent hc =
+                entity.fetch(HealthComponent.class)
+                        .orElseThrow(
+                                () ->
+                                        MissingComponentException.build(
+                                                entity, HealthComponent.class));
+        DrawComponent ac =
+                entity.fetch(DrawComponent.class)
+                        .orElseThrow(
+                                () -> MissingComponentException.build(entity, DrawComponent.class));
+        return new HSData(entity, hc, ac);
     }
 
     private HSData applyDamage(HSData hsd) {
         hsd.e
                 .fetch(StatsComponent.class)
                 .ifPresentOrElse(
-                        sc -> {
-                            StatsComponent scomp = (StatsComponent) sc;
-                            doDamageAndAnimation(hsd, calculateDamageWithMultipliers(scomp, hsd));
-                        },
+                        sc -> doDamageAndAnimation(hsd, calculateDamageWithMultipliers(sc, hsd)),
                         () ->
                                 doDamageAndAnimation(
                                         hsd,
@@ -110,18 +115,11 @@ public class HealthSystem extends System {
         hsd.e
                 .fetch(XPComponent.class)
                 .ifPresent(
-                        component -> {
-                            XPComponent deadXPComponent = (XPComponent) component;
-                            hsd.hc
-                                    .getLastDamageCause()
-                                    .flatMap(entity -> entity.fetch(XPComponent.class))
-                                    .ifPresent(
-                                            c -> {
-                                                XPComponent killerXPComponent = (XPComponent) c;
-                                                killerXPComponent.addXP(
-                                                        deadXPComponent.getLootXP());
-                                            });
-                        });
+                        component ->
+                                hsd.hc
+                                        .getLastDamageCause()
+                                        .flatMap(entity -> entity.fetch(XPComponent.class))
+                                        .ifPresent(c -> c.addXP(component.getLootXP())));
     }
 
     // private record to hold all data during streaming

--- a/game/src/contrib/systems/HealthSystem.java
+++ b/game/src/contrib/systems/HealthSystem.java
@@ -51,15 +51,15 @@ public class HealthSystem extends System {
 
     private HSData buildDataObject(Entity e) {
 
-        HealthComponent hc = (HealthComponent) e.getComponent(HealthComponent.class).get();
-        DrawComponent ac = (DrawComponent) e.getComponent(DrawComponent.class).get();
+        HealthComponent hc = (HealthComponent) e.fetch(HealthComponent.class).get();
+        DrawComponent ac = (DrawComponent) e.fetch(DrawComponent.class).get();
 
         return new HSData(e, hc, ac);
     }
 
     private HSData applyDamage(HSData hsd) {
         hsd.e
-                .getComponent(StatsComponent.class)
+                .fetch(StatsComponent.class)
                 .ifPresentOrElse(
                         sc -> {
                             StatsComponent scomp = (StatsComponent) sc;
@@ -108,13 +108,13 @@ public class HealthSystem extends System {
 
         // Add XP
         hsd.e
-                .getComponent(XPComponent.class)
+                .fetch(XPComponent.class)
                 .ifPresent(
                         component -> {
                             XPComponent deadXPComponent = (XPComponent) component;
                             hsd.hc
                                     .getLastDamageCause()
-                                    .flatMap(entity -> entity.getComponent(XPComponent.class))
+                                    .flatMap(entity -> entity.fetch(XPComponent.class))
                                     .ifPresent(
                                             c -> {
                                                 XPComponent killerXPComponent = (XPComponent) c;

--- a/game/src/contrib/systems/ProjectileSystem.java
+++ b/game/src/contrib/systems/ProjectileSystem.java
@@ -46,8 +46,7 @@ public class ProjectileSystem extends System {
 
     private PSData buildDataObject(Entity e) {
 
-        ProjectileComponent prc =
-                (ProjectileComponent) e.fetch(ProjectileComponent.class).get();
+        ProjectileComponent prc = (ProjectileComponent) e.fetch(ProjectileComponent.class).get();
 
         PositionComponent pc = (PositionComponent) e.fetch(PositionComponent.class).get();
         VelocityComponent vc = (VelocityComponent) e.fetch(VelocityComponent.class).get();

--- a/game/src/contrib/systems/ProjectileSystem.java
+++ b/game/src/contrib/systems/ProjectileSystem.java
@@ -47,10 +47,10 @@ public class ProjectileSystem extends System {
     private PSData buildDataObject(Entity e) {
 
         ProjectileComponent prc =
-                (ProjectileComponent) e.getComponent(ProjectileComponent.class).get();
+                (ProjectileComponent) e.fetch(ProjectileComponent.class).get();
 
-        PositionComponent pc = (PositionComponent) e.getComponent(PositionComponent.class).get();
-        VelocityComponent vc = (VelocityComponent) e.getComponent(VelocityComponent.class).get();
+        PositionComponent pc = (PositionComponent) e.fetch(PositionComponent.class).get();
+        VelocityComponent vc = (VelocityComponent) e.fetch(VelocityComponent.class).get();
 
         return new PSData(e, prc, pc, vc);
     }

--- a/game/src/contrib/systems/ProjectileSystem.java
+++ b/game/src/contrib/systems/ProjectileSystem.java
@@ -8,6 +8,7 @@ import core.System;
 import core.components.PositionComponent;
 import core.components.VelocityComponent;
 import core.utils.Point;
+import core.utils.components.MissingComponentException;
 
 /**
  * The ProjectileSystem class represents a system responsible for managing {@link
@@ -44,14 +45,27 @@ public class ProjectileSystem extends System {
                 .forEach(this::removeEntitiesOnEndpoint);
     }
 
-    private PSData buildDataObject(Entity e) {
+    private PSData buildDataObject(Entity entity) {
 
-        ProjectileComponent prc = (ProjectileComponent) e.fetch(ProjectileComponent.class).get();
-
-        PositionComponent pc = (PositionComponent) e.fetch(PositionComponent.class).get();
-        VelocityComponent vc = (VelocityComponent) e.fetch(VelocityComponent.class).get();
-
-        return new PSData(e, prc, pc, vc);
+        ProjectileComponent prc =
+                entity.fetch(ProjectileComponent.class)
+                        .orElseThrow(
+                                () ->
+                                        MissingComponentException.build(
+                                                entity, ProjectileComponent.class));
+        PositionComponent pc =
+                entity.fetch(PositionComponent.class)
+                        .orElseThrow(
+                                () ->
+                                        MissingComponentException.build(
+                                                entity, PositionComponent.class));
+        VelocityComponent vc =
+                entity.fetch(VelocityComponent.class)
+                        .orElseThrow(
+                                () ->
+                                        MissingComponentException.build(
+                                                entity, VelocityComponent.class));
+        return new PSData(entity, prc, pc, vc);
     }
 
     private PSData setVelocity(PSData data) {

--- a/game/src/contrib/systems/XPSystem.java
+++ b/game/src/contrib/systems/XPSystem.java
@@ -4,8 +4,9 @@ import contrib.components.XPComponent;
 
 import core.Entity;
 import core.System;
+import core.utils.components.MissingComponentException;
 
-public class XPSystem extends System {
+public final class XPSystem extends System {
 
     public XPSystem() {
         super(XPComponent.class);
@@ -17,7 +18,9 @@ public class XPSystem extends System {
     }
 
     private void checkForLevelUP(Entity entity) {
-        XPComponent comp = (XPComponent) entity.fetch(XPComponent.class).get();
+        XPComponent comp =
+                entity.fetch(XPComponent.class)
+                        .orElseThrow(() -> MissingComponentException.build(entity, XPSystem.class));
         long xpLeft;
         while ((xpLeft = comp.getXPToNextLevel()) <= 0) {
             this.performLevelUp(comp, (int) xpLeft);

--- a/game/src/contrib/systems/XPSystem.java
+++ b/game/src/contrib/systems/XPSystem.java
@@ -17,7 +17,7 @@ public class XPSystem extends System {
     }
 
     private void checkForLevelUP(Entity entity) {
-        XPComponent comp = (XPComponent) entity.getComponent(XPComponent.class).get();
+        XPComponent comp = (XPComponent) entity.fetch(XPComponent.class).get();
         long xpLeft;
         while ((xpLeft = comp.getXPToNextLevel()) <= 0) {
             this.performLevelUp(comp, (int) xpLeft);

--- a/game/src/contrib/utils/components/ai/AITools.java
+++ b/game/src/contrib/utils/components/ai/AITools.java
@@ -23,21 +23,23 @@ public class AITools {
      * @param entity Entity moving on the path
      * @param path Path on which the entity moves
      */
-    public static void move(Entity entity, GraphPath<Tile> path) {
+    public static void move(final Entity entity, final GraphPath<Tile> path) {
         // entity is already at the end
         if (pathFinishedOrLeft(entity, path)) {
             return;
         }
         PositionComponent pc =
-                (PositionComponent)
-                        entity.fetch(PositionComponent.class)
-                                .orElseThrow(
-                                        () -> new MissingComponentException("PositionComponent"));
+                entity.fetch(PositionComponent.class)
+                        .orElseThrow(
+                                () ->
+                                        MissingComponentException.build(
+                                                entity, PositionComponent.class));
         VelocityComponent vc =
-                (VelocityComponent)
-                        entity.fetch(VelocityComponent.class)
-                                .orElseThrow(
-                                        () -> new MissingComponentException("VelocityComponent"));
+                entity.fetch(VelocityComponent.class)
+                        .orElseThrow(
+                                () ->
+                                        MissingComponentException.build(
+                                                entity, VelocityComponent.class));
         Tile currentTile = Game.tileAT(pc.position());
         int i = 0;
         Tile nextTile = null;
@@ -72,7 +74,7 @@ public class AITools {
      * @param radius Search radius
      * @return List of tiles in the given radius arround the center point
      */
-    public static List<Tile> tilesInRange(Point center, float radius) {
+    public static List<Tile> tilesInRange(final Point center, final float radius) {
         List<Tile> tiles = new ArrayList<>();
         for (float x = center.x - radius; x <= center.x + radius; x++) {
             for (float y = center.y - radius; y <= center.y + radius; y++) {
@@ -88,7 +90,7 @@ public class AITools {
      * @param radius Search radius
      * @return List of accessible tiles in the given radius arround the center point
      */
-    public static List<Tile> accessibleTilesInRange(Point center, float radius) {
+    public static List<Tile> accessibleTilesInRange(final Point center, final float radius) {
         List<Tile> tiles = tilesInRange(center, radius);
         tiles.removeIf(tile -> !tile.isAccessible());
         return tiles;
@@ -99,7 +101,8 @@ public class AITools {
      * @param radius search radius
      * @return random tile in given range
      */
-    public static Coordinate randomAccessibleTileCoordinateInRange(Point center, float radius) {
+    public static Coordinate randomAccessibleTileCoordinateInRange(
+            final Point center, final float radius) {
         List<Tile> tiles = accessibleTilesInRange(center, radius);
         Coordinate newPosition = tiles.get(random.nextInt(tiles.size())).coordinate();
         return newPosition;
@@ -110,7 +113,7 @@ public class AITools {
      * @param to end point
      * @return Path from the start point to the end point
      */
-    public static GraphPath<Tile> calculatePath(Point from, Point to) {
+    public static GraphPath<Tile> calculatePath(final Point from, final Point to) {
         return calculatePath(from.toCoordinate(), to.toCoordinate());
     }
 
@@ -119,7 +122,7 @@ public class AITools {
      * @param to end coordinate
      * @return Path from the start coordinate to the end coordinate
      */
-    public static GraphPath<Tile> calculatePath(Coordinate from, Coordinate to) {
+    public static GraphPath<Tile> calculatePath(final Coordinate from, final Coordinate to) {
         return Game.findPath(Game.tileAT(from), Game.tileAT(to));
     }
 
@@ -131,7 +134,8 @@ public class AITools {
      * @param radius Search radius
      * @return Path from the center point to the randomly selected tile
      */
-    public static GraphPath<Tile> calculatePathToRandomTileInRange(Point point, float radius) {
+    public static GraphPath<Tile> calculatePathToRandomTileInRange(
+            final Point point, final float radius) {
         Coordinate newPosition = randomAccessibleTileCoordinateInRange(point, radius);
         return calculatePath(point.toCoordinate(), newPosition);
     }
@@ -144,14 +148,14 @@ public class AITools {
      * @param radius Search radius
      * @return Path from the position of the entity to the randomly selected tile
      */
-    public static GraphPath<Tile> calculatePathToRandomTileInRange(Entity entity, float radius) {
+    public static GraphPath<Tile> calculatePathToRandomTileInRange(
+            final Entity entity, final float radius) {
         Point point =
-                ((PositionComponent)
-                                entity.fetch(PositionComponent.class)
-                                        .orElseThrow(
-                                                () ->
-                                                        new MissingComponentException(
-                                                                "PositionComponent")))
+                entity.fetch(PositionComponent.class)
+                        .orElseThrow(
+                                () ->
+                                        MissingComponentException.build(
+                                                entity, PositionComponent.class))
                         .position();
         return calculatePathToRandomTileInRange(point, radius);
     }
@@ -163,17 +167,20 @@ public class AITools {
      * @param to Entity whose position is the goal point
      * @return Path
      */
-    public static GraphPath<Tile> calculatePath(Entity from, Entity to) {
+    public static GraphPath<Tile> calculatePath(final Entity from, final Entity to) {
         PositionComponent fromPositionComponent =
-                (PositionComponent)
-                        from.fetch(PositionComponent.class)
-                                .orElseThrow(
-                                        () -> new MissingComponentException("PositionComponent"));
+                from.fetch(PositionComponent.class)
+                        .orElseThrow(
+                                () ->
+                                        MissingComponentException.build(
+                                                from, PositionComponent.class));
         PositionComponent positionComponent =
                 (PositionComponent)
                         to.fetch(PositionComponent.class)
                                 .orElseThrow(
-                                        () -> new MissingComponentException("PositionComponent"));
+                                        () ->
+                                                MissingComponentException.build(
+                                                        to, PositionComponent.class));
         return calculatePath(fromPositionComponent.position(), positionComponent.position());
     }
 
@@ -181,7 +188,7 @@ public class AITools {
      * @param entity
      * @return Path from the entity to the hero, if there is no hero, path from the entity to itself
      */
-    public static GraphPath<Tile> calculatePathToHero(Entity entity) {
+    public static GraphPath<Tile> calculatePathToHero(final Entity entity) {
         Optional<Entity> hero = Game.hero();
         if (hero.isPresent()) return calculatePath(entity, hero.get());
         else return calculatePath(entity, entity);
@@ -193,7 +200,7 @@ public class AITools {
      * @param range Radius
      * @return if the distance between the two points is within the radius
      */
-    public static boolean inRange(Point p1, Point p2, float range) {
+    public static boolean inRange(final Point p1, final Point p2, final float range) {
         return Point.calculateDistance(p1, p2) <= range;
     }
 
@@ -203,23 +210,22 @@ public class AITools {
      * @param range search radius
      * @return if the position of the two entities is within the given radius
      */
-    public static boolean entityInRange(Entity entity1, Entity entity2, float range) {
+    public static boolean entityInRange(
+            final Entity entity1, final Entity entity2, final float range) {
 
         Point entity1Position =
-                ((PositionComponent)
-                                entity1.fetch(PositionComponent.class)
-                                        .orElseThrow(
-                                                () ->
-                                                        new MissingComponentException(
-                                                                "PositionComponent")))
+                entity1.fetch(PositionComponent.class)
+                        .orElseThrow(
+                                () ->
+                                        MissingComponentException.build(
+                                                entity1, PositionComponent.class))
                         .position();
         Point entity2Position =
-                ((PositionComponent)
-                                entity2.fetch(PositionComponent.class)
-                                        .orElseThrow(
-                                                () ->
-                                                        new MissingComponentException(
-                                                                "PositionComponent")))
+                entity2.fetch(PositionComponent.class)
+                        .orElseThrow(
+                                () ->
+                                        MissingComponentException.build(
+                                                entity2, PositionComponent.class))
                         .position();
         return inRange(entity1Position, entity2Position, range);
     }
@@ -230,7 +236,7 @@ public class AITools {
      * @return if the position of the player is within the given radius of the position of the given
      *     entity. If there is no hero, return false.
      */
-    public static boolean playerInRange(Entity entity, float range) {
+    public static boolean playerInRange(final Entity entity, final float range) {
 
         Optional<Entity> hero = Game.hero();
         if (hero.isPresent()) return entityInRange(entity, hero.get(), range);
@@ -244,12 +250,13 @@ public class AITools {
      * @param path Path
      * @return true, if the entity is on the end of the path or has left the path
      */
-    public static boolean pathFinishedOrLeft(Entity entity, GraphPath<Tile> path) {
+    public static boolean pathFinishedOrLeft(final Entity entity, final GraphPath<Tile> path) {
         PositionComponent pc =
-                (PositionComponent)
-                        entity.fetch(PositionComponent.class)
-                                .orElseThrow(
-                                        () -> new MissingComponentException("PositionComponent"));
+                entity.fetch(PositionComponent.class)
+                        .orElseThrow(
+                                () ->
+                                        MissingComponentException.build(
+                                                entity, PositionComponent.class));
         boolean finished = lastTile(path).equals(Game.tileAT(pc.position()));
 
         boolean onPath = false;
@@ -268,12 +275,13 @@ public class AITools {
      * @param path Path
      * @return true, if the entity is on the end of the path.
      */
-    public static boolean pathFinished(Entity entity, GraphPath<Tile> path) {
+    public static boolean pathFinished(final Entity entity, final GraphPath<Tile> path) {
         PositionComponent pc =
-                (PositionComponent)
-                        entity.fetch(PositionComponent.class)
-                                .orElseThrow(
-                                        () -> new MissingComponentException("PositionComponent"));
+                entity.fetch(PositionComponent.class)
+                        .orElseThrow(
+                                () ->
+                                        MissingComponentException.build(
+                                                entity, PositionComponent.class));
         return lastTile(path).equals(Game.tileAT(pc.position()));
     }
 
@@ -284,12 +292,13 @@ public class AITools {
      * @param path Path
      * @return true, if the entity has left the path.
      */
-    public static boolean pathLeft(Entity entity, GraphPath<Tile> path) {
+    public static boolean pathLeft(final Entity entity, final GraphPath<Tile> path) {
         PositionComponent pc =
-                (PositionComponent)
-                        entity.fetch(PositionComponent.class)
-                                .orElseThrow(
-                                        () -> new MissingComponentException("PositionComponent"));
+                entity.fetch(PositionComponent.class)
+                        .orElseThrow(
+                                () ->
+                                        MissingComponentException.build(
+                                                entity, PositionComponent.class));
         boolean onPath = false;
         Tile currentTile = Game.tileAT(pc.position());
         for (Tile tile : path) {
@@ -305,7 +314,7 @@ public class AITools {
      * @return last Tile in the given path
      * @see GraphPath
      */
-    public static Tile lastTile(GraphPath<Tile> path) {
+    public static Tile lastTile(final GraphPath<Tile> path) {
         return path.get(path.getCount() - 1);
     }
 }

--- a/game/src/contrib/utils/components/ai/AITools.java
+++ b/game/src/contrib/utils/components/ai/AITools.java
@@ -30,12 +30,12 @@ public class AITools {
         }
         PositionComponent pc =
                 (PositionComponent)
-                        entity.getComponent(PositionComponent.class)
+                        entity.fetch(PositionComponent.class)
                                 .orElseThrow(
                                         () -> new MissingComponentException("PositionComponent"));
         VelocityComponent vc =
                 (VelocityComponent)
-                        entity.getComponent(VelocityComponent.class)
+                        entity.fetch(VelocityComponent.class)
                                 .orElseThrow(
                                         () -> new MissingComponentException("VelocityComponent"));
         Tile currentTile = Game.tileAT(pc.position());
@@ -147,7 +147,7 @@ public class AITools {
     public static GraphPath<Tile> calculatePathToRandomTileInRange(Entity entity, float radius) {
         Point point =
                 ((PositionComponent)
-                                entity.getComponent(PositionComponent.class)
+                                entity.fetch(PositionComponent.class)
                                         .orElseThrow(
                                                 () ->
                                                         new MissingComponentException(
@@ -166,12 +166,12 @@ public class AITools {
     public static GraphPath<Tile> calculatePath(Entity from, Entity to) {
         PositionComponent fromPositionComponent =
                 (PositionComponent)
-                        from.getComponent(PositionComponent.class)
+                        from.fetch(PositionComponent.class)
                                 .orElseThrow(
                                         () -> new MissingComponentException("PositionComponent"));
         PositionComponent positionComponent =
                 (PositionComponent)
-                        to.getComponent(PositionComponent.class)
+                        to.fetch(PositionComponent.class)
                                 .orElseThrow(
                                         () -> new MissingComponentException("PositionComponent"));
         return calculatePath(fromPositionComponent.position(), positionComponent.position());
@@ -207,7 +207,7 @@ public class AITools {
 
         Point entity1Position =
                 ((PositionComponent)
-                                entity1.getComponent(PositionComponent.class)
+                                entity1.fetch(PositionComponent.class)
                                         .orElseThrow(
                                                 () ->
                                                         new MissingComponentException(
@@ -215,7 +215,7 @@ public class AITools {
                         .position();
         Point entity2Position =
                 ((PositionComponent)
-                                entity2.getComponent(PositionComponent.class)
+                                entity2.fetch(PositionComponent.class)
                                         .orElseThrow(
                                                 () ->
                                                         new MissingComponentException(
@@ -247,7 +247,7 @@ public class AITools {
     public static boolean pathFinishedOrLeft(Entity entity, GraphPath<Tile> path) {
         PositionComponent pc =
                 (PositionComponent)
-                        entity.getComponent(PositionComponent.class)
+                        entity.fetch(PositionComponent.class)
                                 .orElseThrow(
                                         () -> new MissingComponentException("PositionComponent"));
         boolean finished = lastTile(path).equals(Game.tileAT(pc.position()));
@@ -271,7 +271,7 @@ public class AITools {
     public static boolean pathFinished(Entity entity, GraphPath<Tile> path) {
         PositionComponent pc =
                 (PositionComponent)
-                        entity.getComponent(PositionComponent.class)
+                        entity.fetch(PositionComponent.class)
                                 .orElseThrow(
                                         () -> new MissingComponentException("PositionComponent"));
         return lastTile(path).equals(Game.tileAT(pc.position()));
@@ -287,7 +287,7 @@ public class AITools {
     public static boolean pathLeft(Entity entity, GraphPath<Tile> path) {
         PositionComponent pc =
                 (PositionComponent)
-                        entity.getComponent(PositionComponent.class)
+                        entity.fetch(PositionComponent.class)
                                 .orElseThrow(
                                         () -> new MissingComponentException("PositionComponent"));
         boolean onPath = false;

--- a/game/src/contrib/utils/components/ai/fight/CollideAI.java
+++ b/game/src/contrib/utils/components/ai/fight/CollideAI.java
@@ -22,12 +22,12 @@ public class CollideAI implements Consumer<Entity> {
      *
      * @param rushRange Range in which the faster collide logic should be executed
      */
-    public CollideAI(float rushRange) {
+    public CollideAI(final float rushRange) {
         this.rushRange = rushRange;
     }
 
     @Override
-    public void accept(Entity entity) {
+    public void accept(final Entity entity) {
         if (AITools.playerInRange(entity, rushRange)) {
             // the faster pathing once a certain range is reached
             path = AITools.calculatePathToHero(entity);

--- a/game/src/contrib/utils/components/ai/fight/MeleeAI.java
+++ b/game/src/contrib/utils/components/ai/fight/MeleeAI.java
@@ -25,13 +25,13 @@ public class MeleeAI implements Consumer<Entity> {
      * @param attackRange Range in which the attack skill should be executed
      * @param fightSkill Skill to be used when an attack is performed
      */
-    public MeleeAI(float attackRange, Skill fightSkill) {
+    public MeleeAI(final float attackRange, final Skill fightSkill) {
         this.attackRange = attackRange;
         this.fightSkill = fightSkill;
     }
 
     @Override
-    public void accept(Entity entity) {
+    public void accept(final Entity entity) {
         if (AITools.playerInRange(entity, attackRange)) {
             fightSkill.execute(entity);
         } else {

--- a/game/src/contrib/utils/components/ai/fight/RangeAI.java
+++ b/game/src/contrib/utils/components/ai/fight/RangeAI.java
@@ -15,7 +15,7 @@ import core.utils.Point;
 import java.util.List;
 import java.util.function.Consumer;
 
-public class RangeAI implements Consumer<Entity> {
+public final class RangeAI implements Consumer<Entity> {
 
     private final float attackRange;
     private final float distance;
@@ -30,7 +30,7 @@ public class RangeAI implements Consumer<Entity> {
      * @param distance min. Range in which the attack skill should be executed
      * @param skill Skill to be used when an attack is performed
      */
-    public RangeAI(float attackRange, float distance, Skill skill) {
+    public RangeAI(final float attackRange, final float distance, final Skill skill) {
         if (attackRange <= distance || distance < 0) {
             throw new Error(
                     "attackRange must be greater than distance and distance must be 0 or greater than 0");
@@ -44,7 +44,7 @@ public class RangeAI implements Consumer<Entity> {
     }
 
     @Override
-    public void accept(Entity entity) {
+    public void accept(final Entity entity) {
         boolean playerInDistanceRange = AITools.playerInRange(entity, distance);
         boolean playerInAttackRange = AITools.playerInRange(entity, attackRange);
 

--- a/game/src/contrib/utils/components/ai/idle/PatrouilleWalk.java
+++ b/game/src/contrib/utils/components/ai/idle/PatrouilleWalk.java
@@ -63,7 +63,7 @@ public class PatrouilleWalk implements Consumer<Entity> {
         initialized = true;
         PositionComponent position =
                 (PositionComponent)
-                        entity.getComponent(PositionComponent.class)
+                        entity.fetch(PositionComponent.class)
                                 .orElseThrow(
                                         () -> new MissingComponentException("PositionComponent"));
         Point center = position.position();
@@ -97,7 +97,7 @@ public class PatrouilleWalk implements Consumer<Entity> {
 
         PositionComponent position =
                 (PositionComponent)
-                        entity.getComponent(PositionComponent.class)
+                        entity.fetch(PositionComponent.class)
                                 .orElseThrow(
                                         () -> new MissingComponentException("PositionComponent"));
 

--- a/game/src/contrib/utils/components/ai/idle/PatrouilleWalk.java
+++ b/game/src/contrib/utils/components/ai/idle/PatrouilleWalk.java
@@ -52,20 +52,22 @@ public class PatrouilleWalk implements Consumer<Entity> {
      * @param pauseTime Max time in milliseconds to wait on a checkpoint. The actual time is a
      *     random number between 0 and this value
      */
-    public PatrouilleWalk(float radius, int numberCheckpoints, int pauseTime, MODE mode) {
+    public PatrouilleWalk(
+            final float radius, final int numberCheckpoints, final int pauseTime, final MODE mode) {
         this.radius = radius;
         this.numberCheckpoints = numberCheckpoints;
         this.pauseFrames = pauseTime / (1000 / Game.frameRate());
         this.mode = mode;
     }
 
-    private void init(Entity entity) {
+    private void init(final Entity entity) {
         initialized = true;
         PositionComponent position =
-                (PositionComponent)
-                        entity.fetch(PositionComponent.class)
-                                .orElseThrow(
-                                        () -> new MissingComponentException("PositionComponent"));
+                entity.fetch(PositionComponent.class)
+                        .orElseThrow(
+                                () ->
+                                        MissingComponentException.build(
+                                                entity, PositionComponent.class));
         Point center = position.position();
         Tile tile = Game.tileAT(position.position());
 
@@ -92,14 +94,15 @@ public class PatrouilleWalk implements Consumer<Entity> {
     }
 
     @Override
-    public void accept(Entity entity) {
+    public void accept(final Entity entity) {
         if (!initialized) this.init(entity);
 
         PositionComponent position =
-                (PositionComponent)
-                        entity.fetch(PositionComponent.class)
-                                .orElseThrow(
-                                        () -> new MissingComponentException("PositionComponent"));
+                entity.fetch(PositionComponent.class)
+                        .orElseThrow(
+                                () ->
+                                        MissingComponentException.build(
+                                                entity, PositionComponent.class));
 
         if (currentPath != null && !AITools.pathFinished(entity, currentPath)) {
             if (AITools.pathLeft(entity, currentPath)) {

--- a/game/src/contrib/utils/components/ai/idle/RadiusWalk.java
+++ b/game/src/contrib/utils/components/ai/idle/RadiusWalk.java
@@ -23,13 +23,13 @@ public class RadiusWalk implements Consumer<Entity> {
      * @param radius Radius in which a target point is to be searched for
      * @param breakTimeInSeconds how long to wait (in seconds) before searching a new goal
      */
-    public RadiusWalk(float radius, int breakTimeInSeconds) {
+    public RadiusWalk(final float radius, final int breakTimeInSeconds) {
         this.radius = radius;
         this.breakTime = breakTimeInSeconds * Game.frameRate();
     }
 
     @Override
-    public void accept(Entity entity) {
+    public void accept(final Entity entity) {
         if (path == null || AITools.pathFinishedOrLeft(entity, path)) {
             if (currentBreak >= breakTime) {
                 currentBreak = 0;

--- a/game/src/contrib/utils/components/ai/idle/StaticRadiusWalk.java
+++ b/game/src/contrib/utils/components/ai/idle/StaticRadiusWalk.java
@@ -9,6 +9,7 @@ import core.Game;
 import core.components.PositionComponent;
 import core.level.Tile;
 import core.utils.Point;
+import core.utils.components.MissingComponentException;
 
 import java.util.function.Consumer;
 
@@ -28,24 +29,32 @@ public class StaticRadiusWalk implements Consumer<Entity> {
      * @param radius Radius in which a target point is to be searched for
      * @param breakTimeInSeconds how long to wait (in seconds) before searching a new goal
      */
-    public StaticRadiusWalk(float radius, int breakTimeInSeconds) {
+    public StaticRadiusWalk(final float radius, final int breakTimeInSeconds) {
         this.radius = radius;
         this.breakTime = breakTimeInSeconds * Game.frameRate();
     }
 
     @Override
-    public void accept(Entity entity) {
+    public void accept(final Entity entity) {
         if (path == null || AITools.pathFinishedOrLeft(entity, path)) {
             if (center == null) {
                 PositionComponent pc =
-                        (PositionComponent) entity.fetch(PositionComponent.class).orElseThrow();
+                        entity.fetch(PositionComponent.class)
+                                .orElseThrow(
+                                        () ->
+                                                MissingComponentException.build(
+                                                        entity, PositionComponent.class));
                 center = pc.position();
             }
 
             if (currentBreak >= breakTime) {
                 currentBreak = 0;
                 PositionComponent pc2 =
-                        (PositionComponent) entity.fetch(PositionComponent.class).orElseThrow();
+                        entity.fetch(PositionComponent.class)
+                                .orElseThrow(
+                                        () ->
+                                                MissingComponentException.build(
+                                                        entity, PositionComponent.class));
                 currentPosition = pc2.position();
                 newEndTile =
                         AITools.randomAccessibleTileCoordinateInRange(center, radius).toPoint();

--- a/game/src/contrib/utils/components/ai/idle/StaticRadiusWalk.java
+++ b/game/src/contrib/utils/components/ai/idle/StaticRadiusWalk.java
@@ -38,16 +38,14 @@ public class StaticRadiusWalk implements Consumer<Entity> {
         if (path == null || AITools.pathFinishedOrLeft(entity, path)) {
             if (center == null) {
                 PositionComponent pc =
-                        (PositionComponent)
-                                entity.fetch(PositionComponent.class).orElseThrow();
+                        (PositionComponent) entity.fetch(PositionComponent.class).orElseThrow();
                 center = pc.position();
             }
 
             if (currentBreak >= breakTime) {
                 currentBreak = 0;
                 PositionComponent pc2 =
-                        (PositionComponent)
-                                entity.fetch(PositionComponent.class).orElseThrow();
+                        (PositionComponent) entity.fetch(PositionComponent.class).orElseThrow();
                 currentPosition = pc2.position();
                 newEndTile =
                         AITools.randomAccessibleTileCoordinateInRange(center, radius).toPoint();

--- a/game/src/contrib/utils/components/ai/idle/StaticRadiusWalk.java
+++ b/game/src/contrib/utils/components/ai/idle/StaticRadiusWalk.java
@@ -39,7 +39,7 @@ public class StaticRadiusWalk implements Consumer<Entity> {
             if (center == null) {
                 PositionComponent pc =
                         (PositionComponent)
-                                entity.getComponent(PositionComponent.class).orElseThrow();
+                                entity.fetch(PositionComponent.class).orElseThrow();
                 center = pc.position();
             }
 
@@ -47,7 +47,7 @@ public class StaticRadiusWalk implements Consumer<Entity> {
                 currentBreak = 0;
                 PositionComponent pc2 =
                         (PositionComponent)
-                                entity.getComponent(PositionComponent.class).orElseThrow();
+                                entity.fetch(PositionComponent.class).orElseThrow();
                 currentPosition = pc2.position();
                 newEndTile =
                         AITools.randomAccessibleTileCoordinateInRange(center, radius).toPoint();

--- a/game/src/contrib/utils/components/ai/transition/ProtectOnApproach.java
+++ b/game/src/contrib/utils/components/ai/transition/ProtectOnApproach.java
@@ -24,7 +24,7 @@ public class ProtectOnApproach implements Function<Entity, Boolean> {
      * @param range - The range in which the entity should in fight mode
      * @param toProtect - The entity which should be protected
      */
-    public ProtectOnApproach(float range, Entity toProtect) {
+    public ProtectOnApproach(final float range, final Entity toProtect) {
         this.range = range;
         this.toProtect = toProtect;
     }
@@ -37,7 +37,7 @@ public class ProtectOnApproach implements Function<Entity, Boolean> {
      * @return boolean
      */
     @Override
-    public Boolean apply(Entity entity) {
+    public Boolean apply(final Entity entity) {
         if (isInFight) return true;
 
         isInFight = AITools.playerInRange(toProtect, range);

--- a/game/src/contrib/utils/components/ai/transition/ProtectOnAttack.java
+++ b/game/src/contrib/utils/components/ai/transition/ProtectOnAttack.java
@@ -45,7 +45,13 @@ public class ProtectOnAttack implements Function<Entity, Boolean> {
      */
     public ProtectOnAttack(final Collection<Entity> entities) {
         entities.stream()
-                .peek(e -> e.fetch(HealthComponent.class).orElseThrow())
+                .peek(
+                        entity ->
+                                entity.fetch(HealthComponent.class)
+                                        .orElseThrow(
+                                                () ->
+                                                        MissingComponentException.build(
+                                                                entity, HealthComponent.class)))
                 .forEach(this.toProtect::add);
     }
 
@@ -61,11 +67,23 @@ public class ProtectOnAttack implements Function<Entity, Boolean> {
 
         isInFight =
                 toProtect.stream()
-                        .map(e -> (HealthComponent) e.fetch(HealthComponent.class).get())
+                        .map(
+                                toProtect ->
+                                        toProtect
+                                                .fetch(HealthComponent.class)
+                                                .orElseThrow(
+                                                        () ->
+                                                                MissingComponentException.build(
+                                                                        toProtect,
+                                                                        HealthComponent.class)))
                         .anyMatch(
-                                e ->
-                                        e.getLastDamageCause()
-                                                .map(t -> t.fetch(PlayerComponent.class))
+                                toProtect ->
+                                        toProtect
+                                                .getLastDamageCause()
+                                                .map(
+                                                        causeEntity ->
+                                                                causeEntity.fetch(
+                                                                        PlayerComponent.class))
                                                 .isPresent());
 
         return isInFight;

--- a/game/src/contrib/utils/components/ai/transition/ProtectOnAttack.java
+++ b/game/src/contrib/utils/components/ai/transition/ProtectOnAttack.java
@@ -45,7 +45,7 @@ public class ProtectOnAttack implements Function<Entity, Boolean> {
      */
     public ProtectOnAttack(Collection<Entity> entities) {
         entities.stream()
-                .peek(e -> e.getComponent(HealthComponent.class).orElseThrow())
+                .peek(e -> e.fetch(HealthComponent.class).orElseThrow())
                 .forEach(this.toProtect::add);
     }
 
@@ -61,11 +61,11 @@ public class ProtectOnAttack implements Function<Entity, Boolean> {
 
         isInFight =
                 toProtect.stream()
-                        .map(e -> (HealthComponent) e.getComponent(HealthComponent.class).get())
+                        .map(e -> (HealthComponent) e.fetch(HealthComponent.class).get())
                         .anyMatch(
                                 e ->
                                         e.getLastDamageCause()
-                                                .map(t -> t.getComponent(PlayerComponent.class))
+                                                .map(t -> t.fetch(PlayerComponent.class))
                                                 .isPresent());
 
         return isInFight;

--- a/game/src/contrib/utils/components/ai/transition/ProtectOnAttack.java
+++ b/game/src/contrib/utils/components/ai/transition/ProtectOnAttack.java
@@ -28,7 +28,7 @@ public class ProtectOnAttack implements Function<Entity, Boolean> {
      *
      * @param entity to protect
      */
-    public ProtectOnAttack(Entity entity) {
+    public ProtectOnAttack(final Entity entity) {
         if (!entity.isPresent(HealthComponent.class)) {
             throw (new MissingComponentException("HealthComponent"));
         }
@@ -43,7 +43,7 @@ public class ProtectOnAttack implements Function<Entity, Boolean> {
      *
      * @param entities - Entities that are protected
      */
-    public ProtectOnAttack(Collection<Entity> entities) {
+    public ProtectOnAttack(final Collection<Entity> entities) {
         entities.stream()
                 .peek(e -> e.fetch(HealthComponent.class).orElseThrow())
                 .forEach(this.toProtect::add);
@@ -56,7 +56,7 @@ public class ProtectOnAttack implements Function<Entity, Boolean> {
      * @return True if entity is in fight mode, false if entity is not
      */
     @Override
-    public Boolean apply(Entity entity) {
+    public Boolean apply(final Entity entity) {
         if (isInFight) return true;
 
         isInFight =

--- a/game/src/contrib/utils/components/ai/transition/RangeTransition.java
+++ b/game/src/contrib/utils/components/ai/transition/RangeTransition.java
@@ -15,12 +15,12 @@ public class RangeTransition implements Function<Entity, Boolean> {
      *
      * @param range Range of the entity.
      */
-    public RangeTransition(float range) {
+    public RangeTransition(final float range) {
         this.range = range;
     }
 
     @Override
-    public Boolean apply(Entity entity) {
+    public Boolean apply(final Entity entity) {
         return AITools.playerInRange(entity, range);
     }
 }

--- a/game/src/contrib/utils/components/ai/transition/SelfDefendTransition.java
+++ b/game/src/contrib/utils/components/ai/transition/SelfDefendTransition.java
@@ -11,16 +11,11 @@ public class SelfDefendTransition implements Function<Entity, Boolean> {
     @Override
     public Boolean apply(final Entity entity) {
         HealthComponent component =
-                (HealthComponent)
-                        entity.fetch(HealthComponent.class)
-                                .orElseThrow(
-                                        () ->
-                                                new MissingComponentException(
-                                                        "Missing "
-                                                                + HealthComponent.class.getName()
-                                                                + " which is required for the "
-                                                                + SelfDefendTransition.class
-                                                                        .getName()));
+                entity.fetch(HealthComponent.class)
+                        .orElseThrow(
+                                () ->
+                                        MissingComponentException.build(
+                                                entity, HealthComponent.class));
         return component.getCurrentHealthpoints() < component.getMaximalHealthpoints();
     }
 }

--- a/game/src/contrib/utils/components/ai/transition/SelfDefendTransition.java
+++ b/game/src/contrib/utils/components/ai/transition/SelfDefendTransition.java
@@ -9,7 +9,7 @@ import java.util.function.Function;
 
 public class SelfDefendTransition implements Function<Entity, Boolean> {
     @Override
-    public Boolean apply(Entity entity) {
+    public Boolean apply(final Entity entity) {
         HealthComponent component =
                 (HealthComponent)
                         entity.fetch(HealthComponent.class)

--- a/game/src/contrib/utils/components/ai/transition/SelfDefendTransition.java
+++ b/game/src/contrib/utils/components/ai/transition/SelfDefendTransition.java
@@ -12,7 +12,7 @@ public class SelfDefendTransition implements Function<Entity, Boolean> {
     public Boolean apply(Entity entity) {
         HealthComponent component =
                 (HealthComponent)
-                        entity.getComponent(HealthComponent.class)
+                        entity.fetch(HealthComponent.class)
                                 .orElseThrow(
                                         () ->
                                                 new MissingComponentException(

--- a/game/src/contrib/utils/components/health/DropLoot.java
+++ b/game/src/contrib/utils/components/health/DropLoot.java
@@ -35,11 +35,11 @@ public class DropLoot implements Consumer<Entity> {
      */
     private Components prepareComponent(Entity entity) {
         InventoryComponent ic =
-                entity.getComponent(InventoryComponent.class)
+                entity.fetch(InventoryComponent.class)
                         .map(InventoryComponent.class::cast)
                         .orElseThrow(DropLoot::missingInventoryComponentException);
         PositionComponent pc =
-                entity.getComponent(PositionComponent.class)
+                entity.fetch(PositionComponent.class)
                         .map(PositionComponent.class::cast)
                         .orElseThrow(DropLoot::missingPositionsComponentException);
 

--- a/game/src/contrib/utils/components/health/DropLoot.java
+++ b/game/src/contrib/utils/components/health/DropLoot.java
@@ -11,7 +11,7 @@ import core.utils.components.MissingComponentException;
 import java.util.function.Consumer;
 
 /** a simple implementation of dropping all items of an Entity when it is dying. */
-public class DropLoot implements Consumer<Entity> {
+public final class DropLoot implements Consumer<Entity> {
     private record DLData(Entity e, Components dlc, ItemData i) {}
 
     private record Components(InventoryComponent ic, PositionComponent pc) {}
@@ -22,7 +22,7 @@ public class DropLoot implements Consumer<Entity> {
      * @param entity Entity that has died
      */
     @Override
-    public void accept(Entity entity) {
+    public void accept(final Entity entity) {
         Components dlc = prepareComponent(entity);
         dlc.ic.getItems().stream().map(x -> new DLData(entity, dlc, x)).forEach(this::dropItem);
     }
@@ -36,40 +36,18 @@ public class DropLoot implements Consumer<Entity> {
     private Components prepareComponent(Entity entity) {
         InventoryComponent ic =
                 entity.fetch(InventoryComponent.class)
-                        .map(InventoryComponent.class::cast)
-                        .orElseThrow(DropLoot::missingInventoryComponentException);
+                        .orElseThrow(
+                                () ->
+                                        MissingComponentException.build(
+                                                entity, InventoryComponent.class));
         PositionComponent pc =
                 entity.fetch(PositionComponent.class)
-                        .map(PositionComponent.class::cast)
-                        .orElseThrow(DropLoot::missingPositionsComponentException);
+                        .orElseThrow(
+                                () ->
+                                        MissingComponentException.build(
+                                                entity, PositionComponent.class));
 
         return new Components(ic, pc);
-    }
-
-    /**
-     * Default Message when PositionComponent is missing
-     *
-     * @return MissingComponentException with a predefined Message
-     */
-    private static MissingComponentException missingPositionsComponentException() {
-        return new MissingComponentException(
-                "Missing "
-                        + PositionComponent.class.getName()
-                        + " which is required for "
-                        + DropLoot.class.getName());
-    }
-
-    /**
-     * Default Message when InventoryComponent is missing
-     *
-     * @return MissingComponentException with a predefined Message
-     */
-    private static MissingComponentException missingInventoryComponentException() {
-        return new MissingComponentException(
-                "Missing "
-                        + InventoryComponent.class.getName()
-                        + " which is required for "
-                        + DropLoot.class.getName());
     }
 
     /**

--- a/game/src/contrib/utils/components/interaction/ControlPointReachable.java
+++ b/game/src/contrib/utils/components/interaction/ControlPointReachable.java
@@ -9,7 +9,7 @@ import java.util.function.Function;
 public class ControlPointReachable implements Function<InteractionData, Boolean> {
 
     @Override
-    public Boolean apply(InteractionData interactionData) {
+    public Boolean apply(final InteractionData interactionData) {
         boolean reachable = false;
         boolean pathBlocked = false;
         if ((interactionData.ic().getRadius() - interactionData.dist()) > 0) {

--- a/game/src/contrib/utils/components/interaction/DropItemsInteraction.java
+++ b/game/src/contrib/utils/components/interaction/DropItemsInteraction.java
@@ -49,14 +49,14 @@ public class DropItemsInteraction implements Consumer<Entity> {
      */
     public void accept(Entity entity) {
         InventoryComponent inventoryComponent =
-                entity.getComponent(InventoryComponent.class)
+                entity.fetch(InventoryComponent.class)
                         .map(InventoryComponent.class::cast)
                         .orElseThrow(
                                 () ->
                                         createMissingComponentException(
                                                 InventoryComponent.class.getName(), entity));
         PositionComponent positionComponent =
-                entity.getComponent(PositionComponent.class)
+                entity.fetch(PositionComponent.class)
                         .map(PositionComponent.class::cast)
                         .orElseThrow(
                                 () ->
@@ -74,7 +74,7 @@ public class DropItemsInteraction implements Consumer<Entity> {
                                                 calculateDropPosition(
                                                         positionComponent, index / count)));
 
-        entity.getComponent(DrawComponent.class)
+        entity.fetch(DrawComponent.class)
                 .map(DrawComponent.class::cast)
                 .ifPresent(x -> x.setCurrentAnimation(CoreAnimations.IDLE_RIGHT));
     }

--- a/game/src/contrib/utils/components/interaction/DropItemsInteraction.java
+++ b/game/src/contrib/utils/components/interaction/DropItemsInteraction.java
@@ -47,21 +47,19 @@ public class DropItemsInteraction implements Consumer<Entity> {
      *
      * @param entity associated entity
      */
-    public void accept(Entity entity) {
+    public void accept(final Entity entity) {
         InventoryComponent inventoryComponent =
                 entity.fetch(InventoryComponent.class)
-                        .map(InventoryComponent.class::cast)
                         .orElseThrow(
                                 () ->
-                                        createMissingComponentException(
-                                                InventoryComponent.class.getName(), entity));
+                                        MissingComponentException.build(
+                                                entity, InventoryComponent.class));
         PositionComponent positionComponent =
                 entity.fetch(PositionComponent.class)
-                        .map(PositionComponent.class::cast)
                         .orElseThrow(
                                 () ->
-                                        createMissingComponentException(
-                                                PositionComponent.class.getName(), entity));
+                                        MissingComponentException.build(
+                                                entity, PositionComponent.class));
         List<ItemData> itemData = inventoryComponent.getItems();
         double count = itemData.size();
 
@@ -75,7 +73,6 @@ public class DropItemsInteraction implements Consumer<Entity> {
                                                         positionComponent, index / count)));
 
         entity.fetch(DrawComponent.class)
-                .map(DrawComponent.class::cast)
                 .ifPresent(x -> x.setCurrentAnimation(CoreAnimations.IDLE_RIGHT));
     }
 
@@ -90,22 +87,5 @@ public class DropItemsInteraction implements Consumer<Entity> {
         return new Point(
                 (float) Math.cos(radian * Math.PI) + positionComponent.position().x,
                 (float) Math.sin(radian * Math.PI) + positionComponent.position().y);
-    }
-
-    /**
-     * Helper to create a MissingComponentException with a bit more information
-     *
-     * @param Component the name of the Component which is missing
-     * @param e the Entity which did miss the Component
-     * @return the newly created Exception
-     */
-    private static MissingComponentException createMissingComponentException(
-            String Component, Entity e) {
-        return new MissingComponentException(
-                Component
-                        + " missing in "
-                        + DropItemsInteraction.class.getName()
-                        + " in Entity "
-                        + e.getClass().getName());
     }
 }

--- a/game/src/contrib/utils/components/interaction/InteractionTool.java
+++ b/game/src/contrib/utils/components/interaction/InteractionTool.java
@@ -27,14 +27,14 @@ public class InteractionTool {
             Entity entity, Function<InteractionData, Boolean> iReachable) {
         PositionComponent heroPosition =
                 (PositionComponent)
-                        entity.getComponent(PositionComponent.class)
+                        entity.fetch(PositionComponent.class)
                                 .orElseThrow(() -> MissingPCFromEntity(Entity.class.getName()));
         Optional<InteractionData> data =
                 Game.entityStream()
                         .flatMap(
                                 x ->
                                         x
-                                                .getComponent(InteractionComponent.class)
+                                                .fetch(InteractionComponent.class)
                                                 .map(InteractionComponent.class::cast)
                                                 .stream())
                         .map(ic1 -> convertToData(ic1, heroPosition))
@@ -49,7 +49,7 @@ public class InteractionTool {
 
         PositionComponent pc =
                 ((PositionComponent)
-                        entity.getComponent(PositionComponent.class)
+                        entity.fetch(PositionComponent.class)
                                 .orElseThrow(
                                         () -> MissingPCFromEntity(entity.getClass().getName())));
         return new InteractionData(

--- a/game/src/contrib/utils/components/interaction/InteractionTool.java
+++ b/game/src/contrib/utils/components/interaction/InteractionTool.java
@@ -24,19 +24,16 @@ public class InteractionTool {
     }
 
     public static void interactWithClosestInteractable(
-            Entity entity, Function<InteractionData, Boolean> iReachable) {
+            final Entity entity, final Function<InteractionData, Boolean> iReachable) {
         PositionComponent heroPosition =
-                (PositionComponent)
-                        entity.fetch(PositionComponent.class)
-                                .orElseThrow(() -> MissingPCFromEntity(Entity.class.getName()));
+                entity.fetch(PositionComponent.class)
+                        .orElseThrow(
+                                () ->
+                                        MissingComponentException.build(
+                                                entity, PositionComponent.class));
         Optional<InteractionData> data =
                 Game.entityStream()
-                        .flatMap(
-                                x ->
-                                        x
-                                                .fetch(InteractionComponent.class)
-                                                .map(InteractionComponent.class::cast)
-                                                .stream())
+                        .flatMap(x -> x.fetch(InteractionComponent.class).stream())
                         .map(ic1 -> convertToData(ic1, heroPosition))
                         .filter(iReachable::apply)
                         .min((x, y) -> Float.compare(x.dist(), y.dist()));
@@ -48,25 +45,16 @@ public class InteractionTool {
         Entity entity = ic.getEntity();
 
         PositionComponent pc =
-                ((PositionComponent)
-                        entity.fetch(PositionComponent.class)
-                                .orElseThrow(
-                                        () -> MissingPCFromEntity(entity.getClass().getName())));
+                entity.fetch(PositionComponent.class)
+                        .orElseThrow(
+                                () ->
+                                        MissingComponentException.build(
+                                                entity, PositionComponent.class));
         return new InteractionData(
                 entity,
                 pc,
                 ic,
                 Point.calculateDistance(heroPosition.position(), pc.position()),
                 Point.getUnitDirectionalVector(heroPosition.position(), pc.position()));
-    }
-
-    private static MissingComponentException MissingPCFromEntity(String entity) {
-        return new MissingComponentException(
-                "Missing "
-                        + PositionComponent.class.getName()
-                        + " from "
-                        + entity
-                        + " in "
-                        + InteractionTool.class.getName());
     }
 }

--- a/game/src/contrib/utils/components/item/ItemData.java
+++ b/game/src/contrib/utils/components/item/ItemData.java
@@ -208,7 +208,7 @@ public class ItemData {
         new PositionComponent(droppedItem, position);
         new DrawComponent(droppedItem, which.getWorldTexture());
         CollideComponent component = new CollideComponent(droppedItem);
-        component.setCollideEnter((a, b, direction) -> which.triggerCollect(a, b));
+        component.collideEnter((a, b, direction) -> which.triggerCollect(a, b));
     }
 
     /**

--- a/game/src/contrib/utils/components/item/ItemData.java
+++ b/game/src/contrib/utils/components/item/ItemData.java
@@ -12,6 +12,7 @@ import core.components.DrawComponent;
 import core.components.PositionComponent;
 import core.utils.Point;
 import core.utils.TriConsumer;
+import core.utils.components.MissingComponentException;
 import core.utils.components.draw.Animation;
 
 import java.util.List;
@@ -29,12 +30,12 @@ import java.util.function.BiConsumer;
  *
  * <p>Lastly it holds a {@link #damageModifier}
  */
-public class ItemData {
-    private ItemType itemType;
-    private Animation inventoryTexture;
-    private Animation worldTexture;
-    private String itemName;
-    private String description;
+public final class ItemData {
+    private final ItemType itemType;
+    private final Animation inventoryTexture;
+    private final Animation worldTexture;
+    private final String itemName;
+    private final String description;
 
     private BiConsumer<Entity, Entity> onCollect;
     private TriConsumer<Entity, ItemData, Point> onDrop;
@@ -42,7 +43,7 @@ public class ItemData {
     private BiConsumer<Entity, ItemData> onUse;
 
     // passive
-    private DamageModifier damageModifier;
+    private final DamageModifier damageModifier;
 
     /**
      * creates a new item data object.
@@ -58,15 +59,15 @@ public class ItemData {
      * @param damageModifier Defining if dealt damage is altered.
      */
     public ItemData(
-            ItemType itemType,
-            Animation inventoryTexture,
-            Animation worldTexture,
-            String itemName,
-            String description,
-            BiConsumer<Entity, Entity> onCollect,
-            TriConsumer<Entity, ItemData, Point> onDrop,
-            BiConsumer<Entity, ItemData> onUse,
-            DamageModifier damageModifier) {
+            final ItemType itemType,
+            final Animation inventoryTexture,
+            final Animation worldTexture,
+            final String itemName,
+            final String description,
+            final BiConsumer<Entity, Entity> onCollect,
+            final TriConsumer<Entity, ItemData, Point> onDrop,
+            final BiConsumer<Entity, ItemData> onUse,
+            final DamageModifier damageModifier) {
         this.itemType = itemType;
         this.inventoryTexture = inventoryTexture;
         this.worldTexture = worldTexture;
@@ -88,11 +89,11 @@ public class ItemData {
      * @param description String giving a description of the item
      */
     public ItemData(
-            ItemType itemType,
-            Animation inventoryTexture,
-            Animation worldTexture,
-            String itemName,
-            String description) {
+            final ItemType itemType,
+            final Animation inventoryTexture,
+            final Animation worldTexture,
+            final String itemName,
+            final String description) {
         this(
                 itemType,
                 inventoryTexture,
@@ -121,7 +122,7 @@ public class ItemData {
      * @param worldItemEntity Item which is collected
      * @param whoTriesCollects Entity that tries to collect item
      */
-    public void triggerCollect(Entity worldItemEntity, Entity whoTriesCollects) {
+    public void triggerCollect(final Entity worldItemEntity, final Entity whoTriesCollects) {
         if (getOnCollect() != null) getOnCollect().accept(worldItemEntity, whoTriesCollects);
     }
 
@@ -130,7 +131,7 @@ public class ItemData {
      *
      * @param position the location of the drop
      */
-    public void triggerDrop(Entity e, Point position) {
+    public void triggerDrop(final Entity e, final Point position) {
         if (getOnDrop() != null) getOnDrop().accept(e, this, position);
     }
 
@@ -139,7 +140,7 @@ public class ItemData {
      *
      * @param entity Entity that uses the item
      */
-    public void triggerUse(Entity entity) {
+    public void triggerUse(final Entity entity) {
         if (getOnUse() == null) return;
         getOnUse().accept(entity, this);
     }
@@ -147,35 +148,35 @@ public class ItemData {
     /**
      * @return The current itemType.
      */
-    public ItemType getItemType() {
+    public ItemType itemType() {
         return itemType;
     }
 
     /**
      * @return The current inventory animation
      */
-    public Animation getInventoryTexture() {
+    public Animation inventoryTexture() {
         return inventoryTexture;
     }
 
     /**
      * @return The current world animation
      */
-    public Animation getWorldTexture() {
+    public Animation worldTexture() {
         return worldTexture;
     }
 
     /**
      * @return The current item name.
      */
-    public String getItemName() {
+    public String itemName() {
         return itemName;
     }
 
     /**
      * @return The current item description.
      */
-    public String getDescription() {
+    public String description() {
         return description;
     }
 
@@ -187,13 +188,8 @@ public class ItemData {
      * @param item Item that is used
      */
     private static void defaultUseCallback(Entity e, ItemData item) {
-        e.fetch(InventoryComponent.class)
-                .ifPresent(
-                        component -> {
-                            InventoryComponent invComp = (InventoryComponent) component;
-                            invComp.removeItem(item);
-                        });
-        System.out.printf("Item \"%s\" used by entity %d\n", item.getItemName(), e.id());
+        e.fetch(InventoryComponent.class).ifPresent(component -> component.removeItem(item));
+        System.out.printf("Item \"%s\" used by entity %d\n", item.itemName(), e.id());
     }
 
     /**
@@ -206,7 +202,7 @@ public class ItemData {
     private static void defaultDrop(Entity who, ItemData which, Point position) {
         Entity droppedItem = new Entity();
         new PositionComponent(droppedItem, position);
-        new DrawComponent(droppedItem, which.getWorldTexture());
+        new DrawComponent(droppedItem, which.worldTexture());
         CollideComponent component = new CollideComponent(droppedItem);
         component.collideEnter((a, b, direction) -> which.triggerCollect(a, b));
     }
@@ -229,17 +225,19 @@ public class ItemData {
                                         .ifPresent(
                                                 (x) -> {
                                                     // check if Item can be added to hero Inventory
-                                                    if (((InventoryComponent) x)
+                                                    if ((x)
                                                             .addItem(
                                                                     worldItem
                                                                             .fetch(
                                                                                     ItemComponent
                                                                                             .class)
-                                                                            .map(
-                                                                                    ItemComponent
-                                                                                                    .class
-                                                                                            ::cast)
-                                                                            .get()
+                                                                            .orElseThrow(
+                                                                                    () ->
+                                                                                            MissingComponentException
+                                                                                                    .build(
+                                                                                                            worldItem,
+                                                                                                            ItemComponent
+                                                                                                                    .class))
                                                                             .getItemData()))
                                                         // if added to hero Inventory
                                                         // remove Item from World

--- a/game/src/contrib/utils/components/item/ItemData.java
+++ b/game/src/contrib/utils/components/item/ItemData.java
@@ -187,7 +187,7 @@ public class ItemData {
      * @param item Item that is used
      */
     private static void defaultUseCallback(Entity e, ItemData item) {
-        e.getComponent(InventoryComponent.class)
+        e.fetch(InventoryComponent.class)
                 .ifPresent(
                         component -> {
                             InventoryComponent invComp = (InventoryComponent) component;
@@ -225,14 +225,14 @@ public class ItemData {
                             // check if entity picking up Item is the Hero
                             if (whoCollected.equals(hero)) {
                                 // check if Hero has an Inventory Component
-                                hero.getComponent(InventoryComponent.class)
+                                hero.fetch(InventoryComponent.class)
                                         .ifPresent(
                                                 (x) -> {
                                                     // check if Item can be added to hero Inventory
                                                     if (((InventoryComponent) x)
                                                             .addItem(
                                                                     worldItem
-                                                                            .getComponent(
+                                                                            .fetch(
                                                                                     ItemComponent
                                                                                             .class)
                                                                             .map(

--- a/game/src/contrib/utils/components/skill/DamageProjectile.java
+++ b/game/src/contrib/utils/components/skill/DamageProjectile.java
@@ -76,7 +76,7 @@ public abstract class DamageProjectile implements Consumer<Entity> {
         // Get the PositionComponent of the entity
         PositionComponent epc =
                 (PositionComponent)
-                        entity.getComponent(PositionComponent.class)
+                        entity.fetch(PositionComponent.class)
                                 .orElseThrow(
                                         () -> new MissingComponentException("PositionComponent"));
         new PositionComponent(projectile, epc.position());
@@ -110,7 +110,7 @@ public abstract class DamageProjectile implements Consumer<Entity> {
         TriConsumer<Entity, Entity, Tile.Direction> collide =
                 (a, b, from) -> {
                     if (b != entity) {
-                        b.getComponent(HealthComponent.class)
+                        b.fetch(HealthComponent.class)
                                 .ifPresent(
                                         hc -> {
                                             // Apply the projectile damage to the collided entity

--- a/game/src/contrib/utils/components/skill/DamageProjectile.java
+++ b/game/src/contrib/utils/components/skill/DamageProjectile.java
@@ -75,10 +75,11 @@ public abstract class DamageProjectile implements Consumer<Entity> {
         Entity projectile = new Entity("Projectile");
         // Get the PositionComponent of the entity
         PositionComponent epc =
-                (PositionComponent)
-                        entity.fetch(PositionComponent.class)
-                                .orElseThrow(
-                                        () -> new MissingComponentException("PositionComponent"));
+                entity.fetch(PositionComponent.class)
+                        .orElseThrow(
+                                () ->
+                                        MissingComponentException.build(
+                                                entity, PositionComponent.class));
         new PositionComponent(projectile, epc.position());
 
         try {
@@ -114,7 +115,7 @@ public abstract class DamageProjectile implements Consumer<Entity> {
                                 .ifPresent(
                                         hc -> {
                                             // Apply the projectile damage to the collided entity
-                                            ((HealthComponent) hc).receiveHit(projectileDamage);
+                                            hc.receiveHit(projectileDamage);
 
                                             // Remove the projectile entity from the game
                                             Game.removeEntity(projectile);

--- a/game/src/core/Entity.java
+++ b/game/src/core/Entity.java
@@ -104,8 +104,8 @@ public final class Entity {
      * @return Optional that can contain the requested component
      * @see Optional
      */
-    public Optional<Component> getComponent(Class<? extends Component> klass) {
-        return Optional.ofNullable(components.get(klass));
+    public <T extends Component> Optional<T> getComponent(Class<T> klass) {
+        return Optional.ofNullable(klass.cast(components.get(klass)));
     }
 
     /**

--- a/game/src/core/Entity.java
+++ b/game/src/core/Entity.java
@@ -24,7 +24,7 @@ import java.util.logging.Logger;
  * <p>If you want to remove a component from an entity, use {@link #removeComponent} and provide the
  * Class of the component you want to remove as a parameter.
  *
- * <p>With {@link #getComponent}, you can check if the entity has a component of the given class.
+ * <p>With {@link #fetch}, you can check if the entity has a component of the given class.
  *
  * @see Component
  * @see System
@@ -104,7 +104,7 @@ public final class Entity {
      * @return Optional that can contain the requested component
      * @see Optional
      */
-    public <T extends Component> Optional<T> getComponent(final Class<T> klass) {
+    public <T extends Component> Optional<T> fetch(final Class<T> klass) {
         return Optional.ofNullable(klass.cast(components.get(klass)));
     }
 

--- a/game/src/core/Entity.java
+++ b/game/src/core/Entity.java
@@ -44,7 +44,7 @@ public final class Entity {
      *
      * @param name the name of the entity, used for better logging and debugging
      */
-    public Entity(String name) {
+    public Entity(final String name) {
         id = nextId++;
         components = new HashMap<>();
         this.name = name;
@@ -72,7 +72,7 @@ public final class Entity {
      *
      * @param component The component to add
      */
-    public void addComponent(Component component) {
+    public void addComponent(final Component component) {
         components.put(component.getClass(), component);
         Game.informAboutChanges(this);
         LOGGER.info(
@@ -90,7 +90,7 @@ public final class Entity {
      *
      * @param klass the Class of the component
      */
-    public void removeComponent(Class<? extends Component> klass) {
+    public void removeComponent(final Class<? extends Component> klass) {
         if (components.remove(klass) != null) {
             Game.informAboutChanges(this);
             LOGGER.info(klass.getName() + " from " + name + " was removed.");
@@ -104,7 +104,7 @@ public final class Entity {
      * @return Optional that can contain the requested component
      * @see Optional
      */
-    public <T extends Component> Optional<T> getComponent(Class<T> klass) {
+    public <T extends Component> Optional<T> getComponent(final Class<T> klass) {
         return Optional.ofNullable(klass.cast(components.get(klass)));
     }
 
@@ -114,7 +114,7 @@ public final class Entity {
      * @param klass class of the component to check for
      * @return true if the component is present in the entity, false if not
      */
-    public boolean isPresent(Class<? extends Component> klass) {
+    public boolean isPresent(final Class<? extends Component> klass) {
         return components.containsKey(klass);
     }
 

--- a/game/src/core/Game.java
+++ b/game/src/core/Game.java
@@ -664,7 +664,7 @@ public final class Game extends ScreenAdapter implements IOnLevelLoader {
 
     private Entity newPauseMenu() {
         Entity entity = UITools.generateNewTextDialog("Pause", "Continue", "Pausemenu");
-        entity.getComponent(UIComponent.class)
+        entity.fetch(UIComponent.class)
                 .map(UIComponent.class::cast)
                 .ifPresent(y -> y.getDialog().setVisible(true));
         return entity;
@@ -713,7 +713,7 @@ public final class Game extends ScreenAdapter implements IOnLevelLoader {
     private boolean isOnEndTile(Entity entity) {
         PositionComponent pc =
                 (PositionComponent)
-                        entity.getComponent(PositionComponent.class)
+                        entity.fetch(PositionComponent.class)
                                 .orElseThrow(
                                         () -> new MissingComponentException("PositionComponent"));
         Tile currentTile = tileAT(pc.position());
@@ -731,7 +731,7 @@ public final class Game extends ScreenAdapter implements IOnLevelLoader {
         entities.add(hero);
         PositionComponent pc =
                 (PositionComponent)
-                        hero.getComponent(PositionComponent.class)
+                        hero.fetch(PositionComponent.class)
                                 .orElseThrow(
                                         () -> new MissingComponentException("PositionComponent"));
         pc.position(startTile());

--- a/game/src/core/Game.java
+++ b/game/src/core/Game.java
@@ -664,9 +664,7 @@ public final class Game extends ScreenAdapter implements IOnLevelLoader {
 
     private Entity newPauseMenu() {
         Entity entity = UITools.generateNewTextDialog("Pause", "Continue", "Pausemenu");
-        entity.fetch(UIComponent.class)
-                .map(UIComponent.class::cast)
-                .ifPresent(y -> y.getDialog().setVisible(true));
+        entity.fetch(UIComponent.class).ifPresent(y -> y.getDialog().setVisible(true));
         return entity;
     }
 
@@ -712,10 +710,11 @@ public final class Game extends ScreenAdapter implements IOnLevelLoader {
      */
     private boolean isOnEndTile(Entity entity) {
         PositionComponent pc =
-                (PositionComponent)
-                        entity.fetch(PositionComponent.class)
-                                .orElseThrow(
-                                        () -> new MissingComponentException("PositionComponent"));
+                entity.fetch(PositionComponent.class)
+                        .orElseThrow(
+                                () ->
+                                        MissingComponentException.build(
+                                                entity, PositionComponent.class));
         Tile currentTile = tileAT(pc.position());
         return currentTile.equals(endTile());
     }
@@ -725,15 +724,16 @@ public final class Game extends ScreenAdapter implements IOnLevelLoader {
      *
      * <p>A {@link PositionComponent} is needed.
      *
-     * @param hero entity to set on the start of the level, normally this is the hero.
+     * @param entity entity to set on the start of the level, normally this is the hero.
      */
-    private void placeOnLevelStart(Entity hero) {
-        entities.add(hero);
+    private void placeOnLevelStart(Entity entity) {
+        entities.add(entity);
         PositionComponent pc =
-                (PositionComponent)
-                        hero.fetch(PositionComponent.class)
-                                .orElseThrow(
-                                        () -> new MissingComponentException("PositionComponent"));
+                entity.fetch(PositionComponent.class)
+                        .orElseThrow(
+                                () ->
+                                        MissingComponentException.build(
+                                                entity, PositionComponent.class));
         pc.position(startTile());
     }
 

--- a/game/src/core/level/elements/IPathable.java
+++ b/game/src/core/level/elements/IPathable.java
@@ -59,7 +59,7 @@ public interface IPathable extends IndexedGraph<Tile> {
      */
     default Point getPosition(Entity entity) {
         return ((PositionComponent)
-                        entity.getComponent(PositionComponent.class)
+                        entity.fetch(PositionComponent.class)
                                 .orElseThrow(
                                         () ->
                                                 new MissingComponentException(

--- a/game/src/core/level/elements/ITileable.java
+++ b/game/src/core/level/elements/ITileable.java
@@ -73,8 +73,7 @@ public interface ITileable extends IPathable {
      * @return tile at the coordinate of the entity
      */
     default Tile tileAtEntity(Entity entity) {
-        PositionComponent pc =
-                (PositionComponent) entity.fetch(PositionComponent.class).get();
+        PositionComponent pc = (PositionComponent) entity.fetch(PositionComponent.class).get();
         return tileAt(pc.position().toCoordinate());
     }
 

--- a/game/src/core/level/elements/ITileable.java
+++ b/game/src/core/level/elements/ITileable.java
@@ -74,7 +74,7 @@ public interface ITileable extends IPathable {
      */
     default Tile tileAtEntity(Entity entity) {
         PositionComponent pc =
-                (PositionComponent) entity.getComponent(PositionComponent.class).get();
+                (PositionComponent) entity.fetch(PositionComponent.class).get();
         return tileAt(pc.position().toCoordinate());
     }
 

--- a/game/src/core/systems/CameraSystem.java
+++ b/game/src/core/systems/CameraSystem.java
@@ -11,6 +11,7 @@ import core.components.CameraComponent;
 import core.components.PositionComponent;
 import core.utils.Constants;
 import core.utils.Point;
+import core.utils.components.MissingComponentException;
 
 /**
  * The CameraSystem sets the focus point of the game. It is responsible for what is visible on
@@ -24,7 +25,7 @@ import core.utils.Point;
  *
  * @see CameraComponent
  */
-public class CameraSystem extends System {
+public final class CameraSystem extends System {
 
     private static final OrthographicCamera CAMERA =
             new OrthographicCamera(Constants.viewportWidth(), Constants.viewportHeight());
@@ -48,7 +49,12 @@ public class CameraSystem extends System {
     }
 
     private void focus(Entity entity) {
-        PositionComponent pc = (PositionComponent) entity.fetch(PositionComponent.class).get();
+        PositionComponent pc =
+                entity.fetch(PositionComponent.class)
+                        .orElseThrow(
+                                () ->
+                                        MissingComponentException.build(
+                                                entity, PositionComponent.class));
         focus(pc.position());
     }
 

--- a/game/src/core/systems/CameraSystem.java
+++ b/game/src/core/systems/CameraSystem.java
@@ -49,7 +49,7 @@ public class CameraSystem extends System {
 
     private void focus(Entity entity) {
         PositionComponent pc =
-                (PositionComponent) entity.getComponent(PositionComponent.class).get();
+                (PositionComponent) entity.fetch(PositionComponent.class).get();
         focus(pc.position());
     }
 

--- a/game/src/core/systems/CameraSystem.java
+++ b/game/src/core/systems/CameraSystem.java
@@ -48,8 +48,7 @@ public class CameraSystem extends System {
     }
 
     private void focus(Entity entity) {
-        PositionComponent pc =
-                (PositionComponent) entity.fetch(PositionComponent.class).get();
+        PositionComponent pc = (PositionComponent) entity.fetch(PositionComponent.class).get();
         focus(pc.position());
     }
 

--- a/game/src/core/systems/DrawSystem.java
+++ b/game/src/core/systems/DrawSystem.java
@@ -4,6 +4,7 @@ import core.Entity;
 import core.System;
 import core.components.DrawComponent;
 import core.components.PositionComponent;
+import core.utils.components.MissingComponentException;
 import core.utils.components.draw.Animation;
 import core.utils.components.draw.Painter;
 import core.utils.components.draw.PainterConfig;
@@ -28,7 +29,7 @@ import java.util.Map;
  * @see DrawComponent
  * @see Animation
  */
-public class DrawSystem extends System {
+public final class DrawSystem extends System {
 
     private final Painter painter;
     private final Map<String, PainterConfig> configs;
@@ -67,10 +68,13 @@ public class DrawSystem extends System {
     }
 
     private DSData buildDataObject(Entity e) {
-
-        DrawComponent dc = (DrawComponent) e.fetch(DrawComponent.class).get();
-        PositionComponent pc = (PositionComponent) e.fetch(PositionComponent.class).get();
-
+        DrawComponent dc =
+                e.fetch(DrawComponent.class)
+                        .orElseThrow(() -> MissingComponentException.build(e, DrawComponent.class));
+        PositionComponent pc =
+                e.fetch(PositionComponent.class)
+                        .orElseThrow(
+                                () -> MissingComponentException.build(e, PositionComponent.class));
         return new DSData(e, dc, pc);
     }
 

--- a/game/src/core/systems/DrawSystem.java
+++ b/game/src/core/systems/DrawSystem.java
@@ -68,8 +68,8 @@ public class DrawSystem extends System {
 
     private DSData buildDataObject(Entity e) {
 
-        DrawComponent dc = (DrawComponent) e.getComponent(DrawComponent.class).get();
-        PositionComponent pc = (PositionComponent) e.getComponent(PositionComponent.class).get();
+        DrawComponent dc = (DrawComponent) e.fetch(DrawComponent.class).get();
+        PositionComponent pc = (PositionComponent) e.fetch(PositionComponent.class).get();
 
         return new DSData(e, dc, pc);
     }

--- a/game/src/core/systems/HudSystem.java
+++ b/game/src/core/systems/HudSystem.java
@@ -27,7 +27,7 @@ public final class HudSystem extends System {
                 .forEach(
                         x -> {
                             Group d =
-                                    x.getComponent(UIComponent.class)
+                                    x.fetch(UIComponent.class)
                                             .map(UIComponent.class::cast)
                                             .get()
                                             .getDialog();
@@ -43,7 +43,7 @@ public final class HudSystem extends System {
         if (getEntityStream()
                 .anyMatch(
                         x ->
-                                x.getComponent(UIComponent.class)
+                                x.fetch(UIComponent.class)
                                         .map(UIComponent.class::cast)
                                         .map(y -> y.isVisible() && y.willPauseGame())
                                         .get())) {

--- a/game/src/core/systems/PlayerSystem.java
+++ b/game/src/core/systems/PlayerSystem.java
@@ -3,12 +3,13 @@ package core.systems;
 import core.Entity;
 import core.System;
 import core.components.PlayerComponent;
+import core.utils.components.MissingComponentException;
 
 /**
  * The PlayerSystem is used to control the player, it will trigger the {@link
  * PlayerComponent#execute()}-Method to execute the Functions registered to Keys.
  */
-public class PlayerSystem extends System {
+public final class PlayerSystem extends System {
 
     public PlayerSystem() {
         super(PlayerComponent.class);
@@ -20,7 +21,8 @@ public class PlayerSystem extends System {
     }
 
     private void execute(Entity entity) {
-        PlayerComponent pc = (PlayerComponent) (entity.fetch(PlayerComponent.class).get());
-        pc.execute();
+        entity.fetch(PlayerComponent.class)
+                .orElseThrow(() -> MissingComponentException.build(entity, PlayerComponent.class))
+                .execute();
     }
 }

--- a/game/src/core/systems/PlayerSystem.java
+++ b/game/src/core/systems/PlayerSystem.java
@@ -20,7 +20,7 @@ public class PlayerSystem extends System {
     }
 
     private void execute(Entity entity) {
-        PlayerComponent pc = (PlayerComponent) (entity.getComponent(PlayerComponent.class).get());
+        PlayerComponent pc = (PlayerComponent) (entity.fetch(PlayerComponent.class).get());
         pc.execute();
     }
 }

--- a/game/src/core/systems/VelocitySystem.java
+++ b/game/src/core/systems/VelocitySystem.java
@@ -63,8 +63,7 @@ public class VelocitySystem extends System {
 
         // remove projectiles that hit the wall or other non-accessible
         // tiles
-        else if (vsd.e.fetch(ProjectileComponent.class).isPresent())
-            Game.removeEntity(vsd.e);
+        else if (vsd.e.fetch(ProjectileComponent.class).isPresent()) Game.removeEntity(vsd.e);
 
         vsd.vc.setCurrentYVelocity(0);
         vsd.vc.setCurrentXVelocity(0);

--- a/game/src/core/systems/VelocitySystem.java
+++ b/game/src/core/systems/VelocitySystem.java
@@ -10,6 +10,7 @@ import core.components.DrawComponent;
 import core.components.PositionComponent;
 import core.components.VelocityComponent;
 import core.utils.Point;
+import core.utils.components.MissingComponentException;
 import core.utils.components.draw.CoreAnimations;
 
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -39,7 +40,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * @see PositionComponent
  * @see core.level.elements.ILevel
  */
-public class VelocitySystem extends System {
+public final class VelocitySystem extends System {
 
     /** Create a new VelocitySystem */
     public VelocitySystem() {
@@ -70,11 +71,19 @@ public class VelocitySystem extends System {
     }
 
     private VSData buildDataObject(Entity e) {
-        VelocityComponent vc = (VelocityComponent) e.fetch(VelocityComponent.class).get();
+        VelocityComponent vc =
+                e.fetch(VelocityComponent.class)
+                        .orElseThrow(
+                                () -> MissingComponentException.build(e, VelocityComponent.class));
 
-        PositionComponent pc = (PositionComponent) e.fetch(PositionComponent.class).get();
+        PositionComponent pc =
+                e.fetch(PositionComponent.class)
+                        .orElseThrow(
+                                () -> MissingComponentException.build(e, PositionComponent.class));
 
-        DrawComponent dc = (DrawComponent) e.fetch(DrawComponent.class).get();
+        DrawComponent dc =
+                e.fetch(DrawComponent.class)
+                        .orElseThrow(() -> MissingComponentException.build(e, DrawComponent.class));
 
         return new VSData(e, vc, pc, dc);
     }
@@ -86,8 +95,7 @@ public class VelocitySystem extends System {
                 .fetch(HealthComponent.class)
                 .ifPresent(
                         component -> {
-                            HealthComponent healthComponent = (HealthComponent) component;
-                            isDead.set(healthComponent.isDead());
+                            isDead.set(component.isDead());
                         });
 
         if (isDead.get()) {

--- a/game/src/core/systems/VelocitySystem.java
+++ b/game/src/core/systems/VelocitySystem.java
@@ -63,7 +63,7 @@ public class VelocitySystem extends System {
 
         // remove projectiles that hit the wall or other non-accessible
         // tiles
-        else if (vsd.e.getComponent(ProjectileComponent.class).isPresent())
+        else if (vsd.e.fetch(ProjectileComponent.class).isPresent())
             Game.removeEntity(vsd.e);
 
         vsd.vc.setCurrentYVelocity(0);
@@ -71,11 +71,11 @@ public class VelocitySystem extends System {
     }
 
     private VSData buildDataObject(Entity e) {
-        VelocityComponent vc = (VelocityComponent) e.getComponent(VelocityComponent.class).get();
+        VelocityComponent vc = (VelocityComponent) e.fetch(VelocityComponent.class).get();
 
-        PositionComponent pc = (PositionComponent) e.getComponent(PositionComponent.class).get();
+        PositionComponent pc = (PositionComponent) e.fetch(PositionComponent.class).get();
 
-        DrawComponent dc = (DrawComponent) e.getComponent(DrawComponent.class).get();
+        DrawComponent dc = (DrawComponent) e.fetch(DrawComponent.class).get();
 
         return new VSData(e, vc, pc, dc);
     }
@@ -84,7 +84,7 @@ public class VelocitySystem extends System {
 
         AtomicBoolean isDead = new AtomicBoolean(false);
         vsd.e
-                .getComponent(HealthComponent.class)
+                .fetch(HealthComponent.class)
                 .ifPresent(
                         component -> {
                             HealthComponent healthComponent = (HealthComponent) component;

--- a/game/src/core/utils/components/MissingComponentException.java
+++ b/game/src/core/utils/components/MissingComponentException.java
@@ -1,5 +1,6 @@
 package core.utils.components;
 
+import core.Entity;
 import core.utils.logging.CustomLogLevel;
 
 import java.util.logging.Logger;
@@ -21,5 +22,17 @@ public class MissingComponentException extends NullPointerException {
         super("Missing Component:" + message);
         Logger exceptionLogger = Logger.getLogger(this.getClass().getName());
         exceptionLogger.log(CustomLogLevel.FATAL, "Missing Component: " + message);
+    }
+
+    /**
+     * Create a new {@link MissingComponentException} that contains the default message, that the
+     * given entity is missing the given component.
+     *
+     * @param entity Entity that is missing a component
+     * @param klass Class of the Component that is missing
+     * @return the created MissingComponentException
+     */
+    public static MissingComponentException build(final Entity entity, final Class<?> klass) {
+        return new MissingComponentException(entity + "is missing " + klass.getName());
     }
 }

--- a/game/src/core/utils/components/MissingComponentException.java
+++ b/game/src/core/utils/components/MissingComponentException.java
@@ -11,14 +11,14 @@ import java.util.logging.Logger;
  * <p>This exception is thrown by (e.g. a {@link core.System System}) when a required component is
  * missing on an entity that is being processed.
  */
-public class MissingComponentException extends NullPointerException {
+public final class MissingComponentException extends NullPointerException {
 
     /**
      * Constructs a new MissingComponentException with the specified detail message.
      *
      * @param message Detail message. Should contain the name of the missing component.
      */
-    public MissingComponentException(String message) {
+    public MissingComponentException(final String message) {
         super("Missing Component:" + message);
         Logger exceptionLogger = Logger.getLogger(this.getClass().getName());
         exceptionLogger.log(CustomLogLevel.FATAL, "Missing Component: " + message);

--- a/game/test/contrib/components/CollisionComponentTest.java
+++ b/game/test/contrib/components/CollisionComponentTest.java
@@ -156,9 +156,8 @@ public class CollisionComponentTest {
                 assertThrows(MissingComponentException.class, hb::center);
         assertTrue(
                 missingComponentException.getMessage().contains(PositionComponent.class.getName()));
-        assertTrue(
-                missingComponentException.getMessage().contains(CollideComponent.class.getName()));
     }
+
     /*
        interesting Values could be
        position(0, 0), offset(0, 0),  size( 1, 1), result(.5f, .5f),
@@ -273,8 +272,6 @@ public class CollisionComponentTest {
                 assertThrows(MissingComponentException.class, hb::topRight);
         assertTrue(
                 missingComponentException.getMessage().contains(PositionComponent.class.getName()));
-        assertTrue(
-                missingComponentException.getMessage().contains(CollideComponent.class.getName()));
     }
 
     /** Position and offset stay in origin (0,0) */
@@ -382,8 +379,6 @@ public class CollisionComponentTest {
                 assertThrows(MissingComponentException.class, hb::center);
         assertTrue(
                 missingComponentException.getMessage().contains(PositionComponent.class.getName()));
-        assertTrue(
-                missingComponentException.getMessage().contains(CollideComponent.class.getName()));
     }
 
     /** Position and offset stay in origin (0,0) */

--- a/game/test/contrib/components/CollisionComponentTest.java
+++ b/game/test/contrib/components/CollisionComponentTest.java
@@ -88,7 +88,7 @@ public class CollisionComponentTest {
         CollideComponent hb1 = new CollideComponent(e1, (a, b, c) -> counterE1Enter.inc(), null);
         Entity e2 = new Entity();
         CollideComponent hb2 = new CollideComponent(e2, null, null);
-        hb1.setCollideEnter(null);
+        hb1.collideEnter(null);
         hb1.onEnter(hb2, Tile.Direction.N);
         assertEquals(
                 "Die alte Collide darf nicht mehr aufgerufen werden ",
@@ -104,7 +104,7 @@ public class CollisionComponentTest {
         CollideComponent hb1 = new CollideComponent(e1, (a, b, c) -> counterE1Enter.inc(), null);
         Entity e2 = new Entity();
         CollideComponent hb2 = new CollideComponent(e2, null, null);
-        hb1.setCollideEnter((a, b, c) -> newCounterE1Enter.inc());
+        hb1.collideEnter((a, b, c) -> newCounterE1Enter.inc());
         hb1.onEnter(hb2, Tile.Direction.N);
         assertEquals(
                 "Die alte Collide darf nicht mehr aufgerufen werden ",
@@ -120,7 +120,7 @@ public class CollisionComponentTest {
         CollideComponent hb1 = new CollideComponent(e1, null, (a, b, c) -> counterE1Enter.inc());
         Entity e2 = new Entity();
         CollideComponent hb2 = new CollideComponent(e2, null, null);
-        hb1.setCollideLeave(null);
+        hb1.collideLeave(null);
         hb1.onLeave(hb2, Tile.Direction.N);
         assertEquals(
                 "Die alte Collide darf nicht mehr aufgerufen werden ",
@@ -136,7 +136,7 @@ public class CollisionComponentTest {
         CollideComponent hb1 = new CollideComponent(e1, null, (a, b, c) -> counterE1Leave.inc());
         Entity e2 = new Entity();
         CollideComponent hb2 = new CollideComponent(e2, null, null);
-        hb1.setCollideLeave((a, b, c) -> newCounterE1Leave.inc());
+        hb1.collideLeave((a, b, c) -> newCounterE1Leave.inc());
         hb1.onLeave(hb2, Tile.Direction.N);
         assertEquals(
                 "Die alte Collide darf nicht mehr aufgerufen werden ",
@@ -153,7 +153,7 @@ public class CollisionComponentTest {
                 new CollideComponent(
                         e, new Point(0, 0), new Point(0, 0), (a, b, c) -> {}, (a, b, c) -> {});
         MissingComponentException missingComponentException =
-                assertThrows(MissingComponentException.class, hb::getCenter);
+                assertThrows(MissingComponentException.class, hb::center);
         assertTrue(
                 missingComponentException.getMessage().contains(PositionComponent.class.getName()));
         assertTrue(
@@ -179,7 +179,7 @@ public class CollisionComponentTest {
         new PositionComponent(e, position);
         CollideComponent hb = new CollideComponent(e, offset, size, iCollide, iCollide);
 
-        Point center = hb.getCenter();
+        Point center = hb.center();
         assertEquals(0.5f, center.x, DELTA);
         assertEquals(0.5f, center.y, DELTA);
     }
@@ -195,7 +195,7 @@ public class CollisionComponentTest {
         new PositionComponent(e, position);
         CollideComponent hb = new CollideComponent(e, offset, size, iCollide, iCollide);
 
-        Point center = hb.getCenter();
+        Point center = hb.center();
         assertEquals(1.5f, center.x, DELTA);
         assertEquals(1.5f, center.y, DELTA);
     }
@@ -210,7 +210,7 @@ public class CollisionComponentTest {
         TriConsumer<Entity, Entity, Tile.Direction> iCollide = (a, b, c) -> {};
         new PositionComponent(e, position);
         CollideComponent hb = new CollideComponent(e, offset, size, iCollide, iCollide);
-        Point center = hb.getCenter();
+        Point center = hb.center();
 
         assertEquals(-.5f, center.x, DELTA);
         assertEquals(-.5f, center.y, DELTA);
@@ -226,7 +226,7 @@ public class CollisionComponentTest {
         TriConsumer<Entity, Entity, Tile.Direction> iCollide = (a, b, c) -> {};
         new PositionComponent(e, position);
         CollideComponent hb = new CollideComponent(e, offset, size, iCollide, iCollide);
-        Point center = hb.getCenter();
+        Point center = hb.center();
 
         assertEquals(1, center.x, DELTA);
         assertEquals(1, center.y, DELTA);
@@ -242,7 +242,7 @@ public class CollisionComponentTest {
         TriConsumer<Entity, Entity, Tile.Direction> iCollide = (a, b, c) -> {};
         new PositionComponent(e, position);
         CollideComponent hb = new CollideComponent(e, offset, size, iCollide, iCollide);
-        Point center = hb.getCenter();
+        Point center = hb.center();
 
         assertEquals(0, center.x, DELTA);
         assertEquals(0, center.y, DELTA);
@@ -258,7 +258,7 @@ public class CollisionComponentTest {
         TriConsumer<Entity, Entity, Tile.Direction> iCollide = (a, b, c) -> {};
         new PositionComponent(e, position);
         CollideComponent hb = new CollideComponent(e, offset, size, iCollide, iCollide);
-        Point center = hb.getCenter();
+        Point center = hb.center();
 
         assertEquals(.5, center.x, DELTA);
         assertEquals(1.5, center.y, DELTA);
@@ -270,7 +270,7 @@ public class CollisionComponentTest {
         Entity e = new Entity();
         CollideComponent hb = new CollideComponent(e);
         MissingComponentException missingComponentException =
-                assertThrows(MissingComponentException.class, hb::getTopRight);
+                assertThrows(MissingComponentException.class, hb::topRight);
         assertTrue(
                 missingComponentException.getMessage().contains(PositionComponent.class.getName()));
         assertTrue(
@@ -287,7 +287,7 @@ public class CollisionComponentTest {
         TriConsumer<Entity, Entity, Tile.Direction> iCollide = (a, b, c) -> {};
         new PositionComponent(e, position);
         CollideComponent hb = new CollideComponent(e, offset, size, iCollide, iCollide);
-        Point center = hb.getTopRight();
+        Point center = hb.topRight();
 
         assertEquals(1, center.x, DELTA);
         assertEquals(1, center.y, DELTA);
@@ -303,7 +303,7 @@ public class CollisionComponentTest {
         TriConsumer<Entity, Entity, Tile.Direction> iCollide = (a, b, c) -> {};
         new PositionComponent(e, position);
         CollideComponent hb = new CollideComponent(e, offset, size, iCollide, iCollide);
-        Point center = hb.getTopRight();
+        Point center = hb.topRight();
 
         assertEquals(2, center.x, DELTA);
         assertEquals(2, center.y, DELTA);
@@ -319,7 +319,7 @@ public class CollisionComponentTest {
         TriConsumer<Entity, Entity, Tile.Direction> iCollide = (a, b, c) -> {};
         new PositionComponent(e, position);
         CollideComponent hb = new CollideComponent(e, offset, size, iCollide, iCollide);
-        Point center = hb.getTopRight();
+        Point center = hb.topRight();
 
         assertEquals(3, center.x, DELTA);
         assertEquals(2, center.y, DELTA);
@@ -335,7 +335,7 @@ public class CollisionComponentTest {
         TriConsumer<Entity, Entity, Tile.Direction> iCollide = (a, b, c) -> {};
         new PositionComponent(e, position);
         CollideComponent hb = new CollideComponent(e, offset, size, iCollide, iCollide);
-        Point center = hb.getTopRight();
+        Point center = hb.topRight();
 
         assertEquals(2, center.x, DELTA);
         assertEquals(3, center.y, DELTA);
@@ -351,7 +351,7 @@ public class CollisionComponentTest {
         TriConsumer<Entity, Entity, Tile.Direction> iCollide = (a, b, c) -> {};
         new PositionComponent(e, position);
         CollideComponent hb = new CollideComponent(e, offset, size, iCollide, iCollide);
-        Point center = hb.getTopRight();
+        Point center = hb.topRight();
 
         assertEquals(6, center.x, DELTA);
         assertEquals(6, center.y, DELTA);
@@ -367,7 +367,7 @@ public class CollisionComponentTest {
         TriConsumer<Entity, Entity, Tile.Direction> iCollide = (a, b, c) -> {};
         new PositionComponent(e, position);
         CollideComponent hb = new CollideComponent(e, offset, size, iCollide, iCollide);
-        Point center = hb.getTopRight();
+        Point center = hb.topRight();
 
         assertEquals(8, center.x, DELTA);
         assertEquals(8, center.y, DELTA);
@@ -379,7 +379,7 @@ public class CollisionComponentTest {
         Entity e = new Entity();
         CollideComponent hb = new CollideComponent(e);
         MissingComponentException missingComponentException =
-                assertThrows(MissingComponentException.class, hb::getCenter);
+                assertThrows(MissingComponentException.class, hb::center);
         assertTrue(
                 missingComponentException.getMessage().contains(PositionComponent.class.getName()));
         assertTrue(
@@ -396,7 +396,7 @@ public class CollisionComponentTest {
         TriConsumer<Entity, Entity, Tile.Direction> iCollide = (a, b, c) -> {};
         new PositionComponent(e, position);
         CollideComponent hb = new CollideComponent(e, offset, size, iCollide, iCollide);
-        Point center = hb.getBottomLeft();
+        Point center = hb.bottomLeft();
 
         assertEquals(0, center.x, DELTA);
         assertEquals(0, center.y, DELTA);
@@ -412,7 +412,7 @@ public class CollisionComponentTest {
         TriConsumer<Entity, Entity, Tile.Direction> iCollide = (a, b, c) -> {};
         new PositionComponent(e, position);
         CollideComponent hb = new CollideComponent(e, offset, size, iCollide, iCollide);
-        Point center = hb.getBottomLeft();
+        Point center = hb.bottomLeft();
 
         assertEquals(2, center.x, DELTA);
         assertEquals(1, center.y, DELTA);
@@ -428,7 +428,7 @@ public class CollisionComponentTest {
         TriConsumer<Entity, Entity, Tile.Direction> iCollide = (a, b, c) -> {};
         new PositionComponent(e, position);
         CollideComponent hb = new CollideComponent(e, offset, size, iCollide, iCollide);
-        Point center = hb.getBottomLeft();
+        Point center = hb.bottomLeft();
 
         assertEquals(1, center.x, DELTA);
         assertEquals(2, center.y, DELTA);
@@ -444,7 +444,7 @@ public class CollisionComponentTest {
         TriConsumer<Entity, Entity, Tile.Direction> iCollide = (a, b, c) -> {};
         new PositionComponent(e, position);
         CollideComponent hb = new CollideComponent(e, offset, size, iCollide, iCollide);
-        Point center = hb.getBottomLeft();
+        Point center = hb.bottomLeft();
 
         assertEquals(5, center.x, DELTA);
         assertEquals(5, center.y, DELTA);

--- a/game/test/contrib/components/InteractionComponentTest.java
+++ b/game/test/contrib/components/InteractionComponentTest.java
@@ -41,7 +41,7 @@ public class InteractionComponentTest {
         InteractionComponent component = new InteractionComponent(e, 1, true, iInteraction);
         component.triggerInteraction();
         verify(iInteraction).accept(e);
-        assertTrue(e.getComponent(InteractionComponent.class).isPresent());
+        assertTrue(e.fetch(InteractionComponent.class).isPresent());
     }
 
     /** Checks if after the interaction the component gets removed */
@@ -52,7 +52,7 @@ public class InteractionComponentTest {
         InteractionComponent component = new InteractionComponent(e, 1, false, iInteraction);
         component.triggerInteraction();
         verify(iInteraction).accept(e);
-        assertFalse(e.getComponent(InteractionComponent.class).isPresent());
+        assertFalse(e.fetch(InteractionComponent.class).isPresent());
     }
 
     /** Checks that the interaction only gets triggered for the linked iInteraction */
@@ -78,6 +78,6 @@ public class InteractionComponentTest {
         InteractionComponent component = new InteractionComponent(e, 1, false, iInteraction);
         InteractionComponent component2 = new InteractionComponent(e2, 1, false, iInteraction2);
         component.triggerInteraction();
-        assertTrue(e2.getComponent(InteractionComponent.class).isPresent());
+        assertTrue(e2.fetch(InteractionComponent.class).isPresent());
     }
 }

--- a/game/test/contrib/entities/ChestTest.java
+++ b/game/test/contrib/entities/ChestTest.java
@@ -38,14 +38,14 @@ public class ChestTest {
 
         assertTrue(
                 "Needs the AnimationComponent to be visible to the player.",
-                c.getComponent(DrawComponent.class).isPresent());
-        Optional<Component> inventoryComponent = c.getComponent(InventoryComponent.class);
+                c.fetch(DrawComponent.class).isPresent());
+        Optional<Component> inventoryComponent = c.fetch(InventoryComponent.class);
         assertTrue("Needs the InventoryComponent to be a chest", inventoryComponent.isPresent());
         assertEquals(
                 "Chest should have the given Items",
                 itemData,
                 inventoryComponent.map(InventoryComponent.class::cast).get().getItems());
-        Optional<Component> positionComponent = c.getComponent(PositionComponent.class);
+        Optional<Component> positionComponent = c.fetch(PositionComponent.class);
         assertTrue(
                 "Needs the PositionComponent to be somewhere in the Level",
                 positionComponent.isPresent());
@@ -126,8 +126,8 @@ public class ChestTest {
         // newChest));
         assertTrue(
                 "Needs the AnimationComponent to be visible to the player.",
-                newChest.getComponent(DrawComponent.class).isPresent());
-        Optional<Component> inventoryComponent = newChest.getComponent(InventoryComponent.class);
+                newChest.fetch(DrawComponent.class).isPresent());
+        Optional<Component> inventoryComponent = newChest.fetch(InventoryComponent.class);
         assertTrue("Needs the InventoryComponent to be a chest", inventoryComponent.isPresent());
         assertTrue(
                 "Chest should have atleast 1 Item",
@@ -140,7 +140,7 @@ public class ChestTest {
         assertEquals(
                 "x Position has to be 0. Only Tile is at 0,0",
                 0,
-                newChest.getComponent(PositionComponent.class)
+                newChest.fetch(PositionComponent.class)
                         .map(PositionComponent.class::cast)
                         .get()
                         .position()
@@ -149,7 +149,7 @@ public class ChestTest {
         assertEquals(
                 "y Position has to be 0. Only Tile is at 0,0",
                 0,
-                newChest.getComponent(PositionComponent.class)
+                newChest.fetch(PositionComponent.class)
                         .map(PositionComponent.class::cast)
                         .get()
                         .position()

--- a/game/test/contrib/entities/ChestTest.java
+++ b/game/test/contrib/entities/ChestTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.*;
 import contrib.components.InventoryComponent;
 import contrib.utils.components.item.ItemData;
 
-import core.Component;
 import core.Entity;
 import core.Game;
 import core.components.*;
@@ -39,13 +38,13 @@ public class ChestTest {
         assertTrue(
                 "Needs the AnimationComponent to be visible to the player.",
                 c.fetch(DrawComponent.class).isPresent());
-        Optional<Component> inventoryComponent = c.fetch(InventoryComponent.class);
+        Optional<InventoryComponent> inventoryComponent = c.fetch(InventoryComponent.class);
         assertTrue("Needs the InventoryComponent to be a chest", inventoryComponent.isPresent());
         assertEquals(
                 "Chest should have the given Items",
                 itemData,
                 inventoryComponent.map(InventoryComponent.class::cast).get().getItems());
-        Optional<Component> positionComponent = c.fetch(PositionComponent.class);
+        Optional<PositionComponent> positionComponent = c.fetch(PositionComponent.class);
         assertTrue(
                 "Needs the PositionComponent to be somewhere in the Level",
                 positionComponent.isPresent());
@@ -127,7 +126,7 @@ public class ChestTest {
         assertTrue(
                 "Needs the AnimationComponent to be visible to the player.",
                 newChest.fetch(DrawComponent.class).isPresent());
-        Optional<Component> inventoryComponent = newChest.fetch(InventoryComponent.class);
+        Optional<InventoryComponent> inventoryComponent = newChest.fetch(InventoryComponent.class);
         assertTrue("Needs the InventoryComponent to be a chest", inventoryComponent.isPresent());
         assertTrue(
                 "Chest should have atleast 1 Item",

--- a/game/test/contrib/utils/components/ai/ProtectOnAttackTest.java
+++ b/game/test/contrib/utils/components/ai/ProtectOnAttackTest.java
@@ -96,8 +96,8 @@ public class ProtectOnAttackTest {
 
         // when
         for (Entity e : entitiesToProtect) {
-            if (e.getComponent(HealthComponent.class).isPresent()) {
-                HealthComponent hCp = (HealthComponent) e.getComponent(HealthComponent.class).get();
+            if (e.fetch(HealthComponent.class).isPresent()) {
+                HealthComponent hCp = (HealthComponent) e.fetch(HealthComponent.class).get();
                 hCp.receiveHit(new Damage(1, null, attacker));
             }
         }

--- a/game/test/contrib/utils/components/ai/SelfDefendTransitionTest.java
+++ b/game/test/contrib/utils/components/ai/SelfDefendTransitionTest.java
@@ -55,6 +55,5 @@ public class SelfDefendTransitionTest {
         MissingComponentException exception =
                 assertThrows(MissingComponentException.class, () -> defend.apply(entity));
         assertTrue(exception.getMessage().contains(HealthComponent.class.getName()));
-        assertTrue(exception.getMessage().contains(SelfDefendTransition.class.getName()));
     }
 }

--- a/game/test/contrib/utils/components/health/DropLootTest.java
+++ b/game/test/contrib/utils/components/health/DropLootTest.java
@@ -26,7 +26,6 @@ public class DropLootTest {
         MissingComponentException mce =
                 assertThrows(MissingComponentException.class, () -> dropLoot.accept(new Entity()));
         assertTrue(mce.getMessage().contains(InventoryComponent.class.getName()));
-        assertTrue(mce.getMessage().contains(DropLoot.class.getName()));
     }
 
     /** Checks the handling when the PositionComponent is missing on the entity */
@@ -38,7 +37,6 @@ public class DropLootTest {
         MissingComponentException mce =
                 assertThrows(MissingComponentException.class, () -> dropLoot.accept(entity));
         assertTrue(mce.getMessage().contains(PositionComponent.class.getName()));
-        assertTrue(mce.getMessage().contains(DropLoot.class.getName()));
     }
 
     /** Checks the handling when the InventoryComponent has no Items */

--- a/game/test/contrib/utils/components/interaction/InteractionToolTest.java
+++ b/game/test/contrib/utils/components/interaction/InteractionToolTest.java
@@ -64,12 +64,6 @@ public class InteractionToolTest {
                         MissingComponentException.class,
                         () -> InteractionTool.interactWithClosestInteractable(Game.hero().get()));
         assertTrue(
-                "Errormessage should contain information where the Exception was thrown.",
-                e.getMessage().contains(InteractionTool.class.getName()));
-        assertTrue(
-                "Errormessage should contain information about which class did miss the Component.",
-                e.getMessage().contains(Entity.class.getName()));
-        assertTrue(
                 "Errormessage should contain information about which Component is missing.",
                 e.getMessage().contains(PositionComponent.class.getName()));
         cleanup();

--- a/game/test/contrib/utils/components/item/ItemDataTest.java
+++ b/game/test/contrib/utils/components/item/ItemDataTest.java
@@ -25,9 +25,9 @@ public class ItemDataTest {
     @Test
     public void testDefaultConstructor() {
         ItemData itemData = new ItemData();
-        assertEquals(ItemConfig.NAME.get(), itemData.getItemName());
-        assertEquals(ItemConfig.DESCRIPTION.get(), itemData.getDescription());
-        assertEquals(ItemConfig.TYPE.get(), itemData.getItemType());
+        assertEquals(ItemConfig.NAME.get(), itemData.itemName());
+        assertEquals(ItemConfig.DESCRIPTION.get(), itemData.description());
+        assertEquals(ItemConfig.TYPE.get(), itemData.itemType());
         // assertEquals(ItemData.DEFAULT_WORLD_ANIMATION, itemData.getWorldTexture());
         // assertEquals(ItemData.DEFAULT_INVENTORY_ANIMATION, itemData.getInventoryTexture());
     }
@@ -47,12 +47,11 @@ public class ItemDataTest {
                         item_name,
                         item_description);
 
-        assertEquals(type, itemData.getItemType());
-        assertEquals(
-                inventoryTexture, itemData.getInventoryTexture().getNextAnimationTexturePath());
-        assertEquals(worldTexture, itemData.getWorldTexture().getNextAnimationTexturePath());
-        assertEquals(item_name, itemData.getItemName());
-        assertEquals(item_description, itemData.getDescription());
+        assertEquals(type, itemData.itemType());
+        assertEquals(inventoryTexture, itemData.inventoryTexture().getNextAnimationTexturePath());
+        assertEquals(worldTexture, itemData.worldTexture().getNextAnimationTexturePath());
+        assertEquals(item_name, itemData.itemName());
+        assertEquals(item_description, itemData.description());
     }
 
     // <p> Since we cant update the {@link Game#entities} from outside the gameloop, this is

--- a/game/test/core/EntityTest.java
+++ b/game/test/core/EntityTest.java
@@ -21,19 +21,19 @@ public class EntityTest {
 
     @Test
     public void addComponent() {
-        assertEquals(testComponent, entity.getComponent(testComponent.getClass()).get());
+        assertEquals(testComponent, entity.fetch(testComponent.getClass()).get());
     }
 
     @Test
     public void addAlreadyExistingComponent() {
         Component newComponent = Mockito.mock(Component.class);
         entity.addComponent(newComponent);
-        assertEquals(newComponent, entity.getComponent(testComponent.getClass()).get());
+        assertEquals(newComponent, entity.fetch(testComponent.getClass()).get());
     }
 
     @Test
     public void removeComponent() {
         entity.removeComponent(testComponent.getClass());
-        assertTrue(entity.getComponent(testComponent.getClass()).isEmpty());
+        assertTrue(entity.fetch(testComponent.getClass()).isEmpty());
     }
 }


### PR DESCRIPTION
fixes #718

- `Entity#getComponent` in `Entity#fetch` umbenannt und umgebaut
```java
public <T extends Component> Optional<T> fetch(Class<T> klass) {
    return Optional.ofNullable(klass.cast(components.get(klass)));
}
```
- `static MissingComponentException#build` eingefügt, um eine einheitliche Methode zum Erzeugen einer MissingComponentException zu haben.
- Aufrufe von `Entity#fetch` angepasst:
    - Entfernen des Parsens, da dies durch das eingebaute Klassen-Cast nicht mehr nötig ist.
    - Es wird jetzt immer eine MissingComponentException geworfen, wenn das Component nicht optional ist.
- Etliche Klassen und Methoden-Parameter auf `final` gesetzt.
- Etliche Getter/Setter nach record-vorbild umbenannt.