### PR TITLE
[Org]  rename project "dsl-connector" to "dungeon" in Codeowner configuration

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,7 +8,7 @@
 /dsl/ @malt-r @Programmiermethoden/dungeon
 
 #dsl connector owner
-/dsl-connector/ @malt-r @AMatutat @Programmiermethoden/dungeon
+/dungeon/ @malt-r @AMatutat @Programmiermethoden/dungeon
 
 #doc folder
 /doc/ @Programmiermethoden/dungeon


### PR DESCRIPTION
In #657 haben wir das Projekt "dsl-connector" in "dungeon" umbenannt.
Diese Namensänderung wurde nicht in die Codeowner Konfiguration aufgenommen.
Dieser PR macht das.
