### PR TITLE
[Doc/Publication] add overview table of conferences  

### DIFF
--- a/doc/related_work/conferences.md
+++ b/doc/related_work/conferences.md
@@ -2,17 +2,17 @@
 title: "Übersicht Konferenzen"
 ---
 
-| Name                                                                     | Bereich                                 | Zyklus         | Link                                                  |
-| ------------------------------------------------------------------------ | --------------------------------------- | -------------- | ----------------------------------------------------- |
-| University Future Festival                                               | Digitale Lehre; Informatik in der Lehre | 2 Jährig       | [Link](https://festival.hfd.digital/de/)              |
-| TURN Conference (Workshop)                                               | Lehre; Digitale Lehre                   | Jährlich       | [Link](https://turn-conference.org/)                  |
-| DELFI-Tagung                                                             | Digitale Lehre; Informatik in der Lehre | Jährlich (?)   | [Link](https://delfi-tagung.de/)                      |
-| World Conference on Teaching and Education (World CTE)                   | Lehre; Digitale Lehre                   | halb Jährlich  | [Link](https://www.worldcte.org/)                     |
-| Workshop "Automatische Bewertung von Programmieraufgaben" (ABP Workshop) | Autograding                             | 2 Jährlich (?) | [Link](https://www.abp-workshop.de/)                  |
-| Infos2023                                                                | Informatik-Lehre (Schulen)              | 2 Jährlich (?) | [Link](https://infos2023.informatik.uni-rostock.de)   |
-| Software Engineering (SEUH)                                              | Software Engineering; Software-Technik  | Jährlich       | [Link](https://se-2023.gi.de/)                        |
-| ITiCSE                                                                   | Informatik-Lehre                        | Jährlich       | [Link](https://sigcse.org/events/iticse/index.html)   |
-| ICER                                                                     | Informatik-Lehre                        | Jährlich       | [Link](https://sigcse.org/events/icer/index.html)     |
-| Symposia                                                                 | Informatik-Lehre                        | Jährlich       | [Link](https://sigcse.org/events/symposia/index.html) |
-| Start Play                                                               | Lehre; Gamification                     | Jährlich (?)   | [Link](https://startplay-conference.com/)             |
-| SIGCSE                                                                   | Informatik-Lehren                       | ?              | [Link](https://cssplice.github.io/SIGCSE23/CFP.html)  |
+| Name                                                                     | Bereich                                 | Zyklus         | Link                                          |
+| ------------------------------------------------------------------------ | --------------------------------------- | -------------- | --------------------------------------------- |
+| University Future Festival                                               | Digitale Lehre; Informatik in der Lehre | 2 Jährig       | https://festival.hfd.digital/de/              |
+| TURN Conference (Workshop)                                               | Lehre; Digitale Lehre                   | Jährlich       | https://turn-conference.org/                  |
+| DELFI-Tagung                                                             | Digitale Lehre; Informatik in der Lehre | Jährlich (?)   | https://delfi-tagung.de/                      |
+| World Conference on Teaching and Education (World CTE)                   | Lehre; Digitale Lehre                   | halb Jährlich  | https://www.worldcte.org/                     |
+| Workshop "Automatische Bewertung von Programmieraufgaben" (ABP Workshop) | Autograding                             | 2 Jährlich (?) | https://www.abp-workshop.de/                  |
+| Infos2023                                                                | Informatik-Lehre (Schulen)              | 2 Jährlich (?) | [https://infos2023.informatik.uni-rostock.de  |
+| Software Engineering (SEUH)                                              | Software Engineering; Software-Technik  | Jährlich       | [https://se-2023.gi.de/                       |
+| ITiCSE                                                                   | Informatik-Lehre                        | Jährlich       | https://sigcse.org/events/iticse/index.html   |
+| ICER                                                                     | Informatik-Lehre                        | Jährlich       | https://sigcse.org/events/icer/index.html     |
+| Symposia                                                                 | Informatik-Lehre                        | Jährlich       | https://sigcse.org/events/symposia/index.html |
+| Start Play                                                               | Lehre; Gamification                     | Jährlich (?)   | https://startplay-conference.com/             |
+| SIGCSE                                                                   | Informatik-Lehren                       | ?              | https://cssplice.github.io/SIGCSE23/CFP.html  |

--- a/doc/related_work/conferences.md
+++ b/doc/related_work/conferences.md
@@ -13,10 +13,8 @@ title: "Übersicht Konferenzen "
 | ABP Workshop | Autograding | 2 Jährlich (?)| [Link](https://www.abp-workshop.de/) |
 | Infos2023 | Informatik-Lehre (Schulen) | 2 Jährlich (?) | [Link](https://infos2023.informatik.uni-rostock.de) |
 |Software Engineering | Software Engineering; Software-Technik | Jährlich | [Link](https://se-2023.gi.de/) |
-| ITiCSE | SIGCSE | - | [Link](https://sigcse.org/events/iticse/index.html) |
-| ICER | SIGCSE | - | [Link](https://sigcse.org/events/icer/index.html) |
-| Symposia | SIGCSE | - | [Link](https://sigcse.org/events/symposia/index.html) |
-| DELFI-Tagung | - | - | [Link](https://delfi-tagung.de/delfi-2023/call-for-papers) |
-| ABP Workshop | - | - | [Link](https://www.abp-workshop.de) |
-| Start Play | - | - | [Link](https://startplay-conference.com/) |
+| ITiCSE | Informatik-Lehre | Jährlich | [Link](https://sigcse.org/events/iticse/index.html) |
+| ICER | Informatik-Lehre |Jährlich | [Link](https://sigcse.org/events/icer/index.html) |
+| Symposia | Informatik-Lehre | Jährlich | [Link](https://sigcse.org/events/symposia/index.html) |
+| Start Play | Lehre; Gamification | Jährlich (?) | [Link](https://startplay-conference.com/) |
 

--- a/doc/related_work/conferences.md
+++ b/doc/related_work/conferences.md
@@ -17,4 +17,5 @@ title: "Übersicht Konferenzen"
 | ICER | Informatik-Lehre |Jährlich | [Link](https://sigcse.org/events/icer/index.html) |
 | Symposia | Informatik-Lehre | Jährlich | [Link](https://sigcse.org/events/symposia/index.html) |
 | Start Play | Lehre; Gamification | Jährlich (?) | [Link](https://startplay-conference.com/) |
+| SIGCSE | Informatik-Lehren | ?| [Link](https://cssplice.github.io/SIGCSE23/CFP.html) |
 

--- a/doc/related_work/conferences.md
+++ b/doc/related_work/conferences.md
@@ -6,9 +6,9 @@ title: "Übersicht Konferenzen "
 
 | Name | Bereich | Zyklus | Link |
 | --- | --- | --- | --- |
-| Festival HFD | Digital | - | [Link](https://festival.hfd.digital/de/call-2023/) |
-| TURN Conference | - | - | [Link](https://turn-conference.org/turn23/) |
-| DELFI-Tagung | - | - | [Link](https://delfi-tagung.de/delfi-2023/call-for-papers) |
+| University Future Festival | Digitale Lehre; Informatik in der Lehre | 2 Jährig | [Link](https://festival.hfd.digital/de/) |
+| TURN Conference (Workshop)| Lehre; Digitale Lehre | Jährlich | [Link]https://turn-conference.org/) |
+| DELFI-Tagung | Digitale Lehre; Informatik in der Lehre | Jährlich (?)| [Link](https://delfi-tagung.de/) |
 | World CTE | - | - | [Link](https://www.worldcte.org/) |
 | ABP Workshop | - | - | [Link](https://www.abp-workshop.de/) |
 | Infos2023 | Informatik | - | [Link](https://infos2023.informatik.uni-rostock.de) |

--- a/doc/related_work/conferences.md
+++ b/doc/related_work/conferences.md
@@ -1,0 +1,23 @@
+---
+title: "Übersicht Konferenzen "
+---
+
+
+
+| Name | Bereich | Zyklus | Link |
+| --- | --- | --- | --- |
+| Festival HFD | Digital | - | [Link](https://festival.hfd.digital/de/call-2023/) |
+| TURN Conference | - | - | [Link](https://turn-conference.org/turn23/) |
+| DELFI-Tagung | - | - | [Link](https://delfi-tagung.de/delfi-2023/call-for-papers) |
+| World CTE | - | - | [Link](https://www.worldcte.org/) |
+| ABP Workshop | - | - | [Link](https://www.abp-workshop.de/) |
+| Infos2023 | Informatik | - | [Link](https://infos2023.informatik.uni-rostock.de) |
+| SE 2023 | GI | - | [Link](https://se-2023.gi.de/) |
+| SIGCSE23 | - | - | [Link](https://cssplice.github.io/SIGCSE23/CFP.html) |
+| ITiCSE | SIGCSE | - | [Link](https://sigcse.org/events/iticse/index.html) |
+| ICER | SIGCSE | - | [Link](https://sigcse.org/events/icer/index.html) |
+| Symposia | SIGCSE | - | [Link](https://sigcse.org/events/symposia/index.html) |
+| DELFI-Tagung | - | - | [Link](https://delfi-tagung.de/delfi-2023/call-for-papers) |
+| ABP Workshop | - | - | [Link](https://www.abp-workshop.de) |
+| Start Play | - | - | [Link](https://startplay-conference.com/) |
+

--- a/doc/related_work/conferences.md
+++ b/doc/related_work/conferences.md
@@ -13,7 +13,6 @@ title: "Übersicht Konferenzen "
 | ABP Workshop | Autograding | 2 Jährlich (?)| [Link](https://www.abp-workshop.de/) |
 | Infos2023 | Informatik-Lehre (Schulen) | 2 Jährlich (?) | [Link](https://infos2023.informatik.uni-rostock.de) |
 |Software Engineering | Software Engineering; Software-Technik | Jährlich | [Link](https://se-2023.gi.de/) |
-| SIGCSE23 | - | - | [Link](https://cssplice.github.io/SIGCSE23/CFP.html) |
 | ITiCSE | SIGCSE | - | [Link](https://sigcse.org/events/iticse/index.html) |
 | ICER | SIGCSE | - | [Link](https://sigcse.org/events/icer/index.html) |
 | Symposia | SIGCSE | - | [Link](https://sigcse.org/events/symposia/index.html) |

--- a/doc/related_work/conferences.md
+++ b/doc/related_work/conferences.md
@@ -1,5 +1,5 @@
 ---
-title: "Übersicht Konferenzen "
+title: "Übersicht Konferenzen"
 ---
 
 
@@ -9,10 +9,10 @@ title: "Übersicht Konferenzen "
 | University Future Festival | Digitale Lehre; Informatik in der Lehre | 2 Jährig | [Link](https://festival.hfd.digital/de/) |
 | TURN Conference (Workshop)| Lehre; Digitale Lehre | Jährlich | [Link](https://turn-conference.org/) |
 | DELFI-Tagung | Digitale Lehre; Informatik in der Lehre | Jährlich (?)| [Link](https://delfi-tagung.de/) |
-| World CTE | Lehre; Digitale Lehre | halb Jährlich | [Link](https://www.worldcte.org/) |
-| ABP Workshop | Autograding | 2 Jährlich (?)| [Link](https://www.abp-workshop.de/) |
+| World Conference on Teaching and Education (World CTE) | Lehre; Digitale Lehre | halb Jährlich | [Link](https://www.worldcte.org/) |
+| Workshop "Automatische Bewertung von Programmieraufgaben" (ABP Workshop) | Autograding | 2 Jährlich (?)| [Link](https://www.abp-workshop.de/) |
 | Infos2023 | Informatik-Lehre (Schulen) | 2 Jährlich (?) | [Link](https://infos2023.informatik.uni-rostock.de) |
-|Software Engineering | Software Engineering; Software-Technik | Jährlich | [Link](https://se-2023.gi.de/) |
+|Software Engineering (SEUH) | Software Engineering; Software-Technik | Jährlich | [Link](https://se-2023.gi.de/) |
 | ITiCSE | Informatik-Lehre | Jährlich | [Link](https://sigcse.org/events/iticse/index.html) |
 | ICER | Informatik-Lehre |Jährlich | [Link](https://sigcse.org/events/icer/index.html) |
 | Symposia | Informatik-Lehre | Jährlich | [Link](https://sigcse.org/events/symposia/index.html) |

--- a/doc/related_work/conferences.md
+++ b/doc/related_work/conferences.md
@@ -2,20 +2,17 @@
 title: "Übersicht Konferenzen"
 ---
 
-
-
-| Name | Bereich | Zyklus | Link |
-| --- | --- | --- | --- |
-| University Future Festival | Digitale Lehre; Informatik in der Lehre | 2 Jährig | [Link](https://festival.hfd.digital/de/) |
-| TURN Conference (Workshop)| Lehre; Digitale Lehre | Jährlich | [Link](https://turn-conference.org/) |
-| DELFI-Tagung | Digitale Lehre; Informatik in der Lehre | Jährlich (?)| [Link](https://delfi-tagung.de/) |
-| World Conference on Teaching and Education (World CTE) | Lehre; Digitale Lehre | halb Jährlich | [Link](https://www.worldcte.org/) |
-| Workshop "Automatische Bewertung von Programmieraufgaben" (ABP Workshop) | Autograding | 2 Jährlich (?)| [Link](https://www.abp-workshop.de/) |
-| Infos2023 | Informatik-Lehre (Schulen) | 2 Jährlich (?) | [Link](https://infos2023.informatik.uni-rostock.de) |
-|Software Engineering (SEUH) | Software Engineering; Software-Technik | Jährlich | [Link](https://se-2023.gi.de/) |
-| ITiCSE | Informatik-Lehre | Jährlich | [Link](https://sigcse.org/events/iticse/index.html) |
-| ICER | Informatik-Lehre |Jährlich | [Link](https://sigcse.org/events/icer/index.html) |
-| Symposia | Informatik-Lehre | Jährlich | [Link](https://sigcse.org/events/symposia/index.html) |
-| Start Play | Lehre; Gamification | Jährlich (?) | [Link](https://startplay-conference.com/) |
-| SIGCSE | Informatik-Lehren | ?| [Link](https://cssplice.github.io/SIGCSE23/CFP.html) |
-
+| Name                                                                     | Bereich                                 | Zyklus         | Link                                                  |
+| ------------------------------------------------------------------------ | --------------------------------------- | -------------- | ----------------------------------------------------- |
+| University Future Festival                                               | Digitale Lehre; Informatik in der Lehre | 2 Jährig       | [Link](https://festival.hfd.digital/de/)              |
+| TURN Conference (Workshop)                                               | Lehre; Digitale Lehre                   | Jährlich       | [Link](https://turn-conference.org/)                  |
+| DELFI-Tagung                                                             | Digitale Lehre; Informatik in der Lehre | Jährlich (?)   | [Link](https://delfi-tagung.de/)                      |
+| World Conference on Teaching and Education (World CTE)                   | Lehre; Digitale Lehre                   | halb Jährlich  | [Link](https://www.worldcte.org/)                     |
+| Workshop "Automatische Bewertung von Programmieraufgaben" (ABP Workshop) | Autograding                             | 2 Jährlich (?) | [Link](https://www.abp-workshop.de/)                  |
+| Infos2023                                                                | Informatik-Lehre (Schulen)              | 2 Jährlich (?) | [Link](https://infos2023.informatik.uni-rostock.de)   |
+| Software Engineering (SEUH)                                              | Software Engineering; Software-Technik  | Jährlich       | [Link](https://se-2023.gi.de/)                        |
+| ITiCSE                                                                   | Informatik-Lehre                        | Jährlich       | [Link](https://sigcse.org/events/iticse/index.html)   |
+| ICER                                                                     | Informatik-Lehre                        | Jährlich       | [Link](https://sigcse.org/events/icer/index.html)     |
+| Symposia                                                                 | Informatik-Lehre                        | Jährlich       | [Link](https://sigcse.org/events/symposia/index.html) |
+| Start Play                                                               | Lehre; Gamification                     | Jährlich (?)   | [Link](https://startplay-conference.com/)             |
+| SIGCSE                                                                   | Informatik-Lehren                       | ?              | [Link](https://cssplice.github.io/SIGCSE23/CFP.html)  |

--- a/doc/related_work/conferences.md
+++ b/doc/related_work/conferences.md
@@ -7,7 +7,7 @@ title: "Übersicht Konferenzen "
 | Name | Bereich | Zyklus | Link |
 | --- | --- | --- | --- |
 | University Future Festival | Digitale Lehre; Informatik in der Lehre | 2 Jährig | [Link](https://festival.hfd.digital/de/) |
-| TURN Conference (Workshop)| Lehre; Digitale Lehre | Jährlich | [Link]https://turn-conference.org/) |
+| TURN Conference (Workshop)| Lehre; Digitale Lehre | Jährlich | [Link](https://turn-conference.org/) |
 | DELFI-Tagung | Digitale Lehre; Informatik in der Lehre | Jährlich (?)| [Link](https://delfi-tagung.de/) |
 | World CTE | Lehre; Digitale Lehre | halb Jährlich | [Link](https://www.worldcte.org/) |
 | ABP Workshop | Autograding | 2 Jährlich (?)| [Link](https://www.abp-workshop.de/) |

--- a/doc/related_work/conferences.md
+++ b/doc/related_work/conferences.md
@@ -9,10 +9,10 @@ title: "Übersicht Konferenzen "
 | University Future Festival | Digitale Lehre; Informatik in der Lehre | 2 Jährig | [Link](https://festival.hfd.digital/de/) |
 | TURN Conference (Workshop)| Lehre; Digitale Lehre | Jährlich | [Link]https://turn-conference.org/) |
 | DELFI-Tagung | Digitale Lehre; Informatik in der Lehre | Jährlich (?)| [Link](https://delfi-tagung.de/) |
-| World CTE | - | - | [Link](https://www.worldcte.org/) |
-| ABP Workshop | - | - | [Link](https://www.abp-workshop.de/) |
-| Infos2023 | Informatik | - | [Link](https://infos2023.informatik.uni-rostock.de) |
-| SE 2023 | GI | - | [Link](https://se-2023.gi.de/) |
+| World CTE | Lehre; Digitale Lehre | halb Jährlich | [Link](https://www.worldcte.org/) |
+| ABP Workshop | Autograding | 2 Jährlich (?)| [Link](https://www.abp-workshop.de/) |
+| Infos2023 | Informatik-Lehre (Schulen) | 2 Jährlich (?) | [Link](https://infos2023.informatik.uni-rostock.de) |
+|Software Engineering | Software Engineering; Software-Technik | Jährlich | [Link](https://se-2023.gi.de/) |
 | SIGCSE23 | - | - | [Link](https://cssplice.github.io/SIGCSE23/CFP.html) |
 | ITiCSE | SIGCSE | - | [Link](https://sigcse.org/events/iticse/index.html) |
 | ICER | SIGCSE | - | [Link](https://sigcse.org/events/icer/index.html) |

--- a/doc/related_work/readme.md
+++ b/doc/related_work/readme.md
@@ -1,5 +1,5 @@
 ---
-title: "Übersicht Konferenzen "
+title: "Startseite related work "
 ---
 
 In diesem Verzeichnis werden Zusammenfassungen/Erkenntnisse anderer Veröffentlichungen gesammelt. 

--- a/doc/related_work/readme.md
+++ b/doc/related_work/readme.md
@@ -1,5 +1,5 @@
 ---
-title: "Startseite related work "
+title: "Startseite related work"
 ---
 
 In diesem Verzeichnis werden Zusammenfassungen/Erkenntnisse anderer Veröffentlichungen gesammelt. 

--- a/doc/related_work/readme.md
+++ b/doc/related_work/readme.md
@@ -3,4 +3,4 @@ title: "Übersicht Konferenzen "
 ---
 
 In diesem Verzeichnis werden Zusammenfassungen/Erkenntnisse anderer Veröffentlichungen gesammelt. 
-Auch eine Übersicht mit verschiedenen [Konferenzen](./conferences.md) wird gepflegt.
+Auch eine Übersicht mit verschiedenen [Konferenzen](conferences.md) wird gepflegt.

--- a/doc/related_work/readme.md
+++ b/doc/related_work/readme.md
@@ -1,0 +1,24 @@
+---
+title: "Übersicht Konferenzen "
+---
+
+
+Hier erste Konferenzen (vom StIL):
+- University:Future Festival 2023 (Einreichung bis 31.01.23; Tagung Ende April in Berlin) https://festival.hfd.digital/de/call-2023/
+- TURN Conference (Einreichung bis 31.01.23; Tagung Mitte September) https://turn-conference.org/turn23/
+- **DeLFI 2023** (Einreichung bis 19.03.2023; Tagung Mitte September) https://delfi-tagung.de/delfi-2023/call-for-papers
+- World Conference on Teaching and Education: https://www.worldcte.org/
+- Workshop "Automatische Bewertung von Programmieraufgaben": https://www.abp-workshop.de/
+- **Infos 2023** (Einreichung bis 19.02.23; Tagung 20-29.09.23) https://infos2023.informatik.uni-rostock.de
+- [SEUH](https://se-2023.gi.de/)
+
+https://cssplice.github.io/SIGCSE23/CFP.html
+https://sigcse.org/events/iticse/index.html
+https://sigcse.org/events/icer/index.html
+https://sigcse.org/events/symposia/index.html
+
+Auf der DeLFI hatten wir auch schon mal so Lehr-/Lern-Kram: DeLFI 2023 (Einreichung bis 05.02.23; Tagung Mitte September) https://delfi-tagung.de/delfi-2023/call-for-papers
+
+https://www.abp-workshop.de
+
+https://www.google.com/search?client=safari&rls=en&q=Start+Play&ie=UTF-8&oe=UTF-8

--- a/doc/related_work/readme.md
+++ b/doc/related_work/readme.md
@@ -2,23 +2,5 @@
 title: "Übersicht Konferenzen "
 ---
 
-
-Hier erste Konferenzen (vom StIL):
-- University:Future Festival 2023 (Einreichung bis 31.01.23; Tagung Ende April in Berlin) https://festival.hfd.digital/de/call-2023/
-- TURN Conference (Einreichung bis 31.01.23; Tagung Mitte September) https://turn-conference.org/turn23/
-- **DeLFI 2023** (Einreichung bis 19.03.2023; Tagung Mitte September) https://delfi-tagung.de/delfi-2023/call-for-papers
-- World Conference on Teaching and Education: https://www.worldcte.org/
-- Workshop "Automatische Bewertung von Programmieraufgaben": https://www.abp-workshop.de/
-- **Infos 2023** (Einreichung bis 19.02.23; Tagung 20-29.09.23) https://infos2023.informatik.uni-rostock.de
-- [SEUH](https://se-2023.gi.de/)
-
-https://cssplice.github.io/SIGCSE23/CFP.html
-https://sigcse.org/events/iticse/index.html
-https://sigcse.org/events/icer/index.html
-https://sigcse.org/events/symposia/index.html
-
-Auf der DeLFI hatten wir auch schon mal so Lehr-/Lern-Kram: DeLFI 2023 (Einreichung bis 05.02.23; Tagung Mitte September) https://delfi-tagung.de/delfi-2023/call-for-papers
-
-https://www.abp-workshop.de
-
-https://www.google.com/search?client=safari&rls=en&q=Start+Play&ie=UTF-8&oe=UTF-8
+In diesem Verzeichnis werden Zusammenfassungen/Erkenntnisse anderer Veröffentlichungen gesammelt. 
+Auch eine Übersicht mit verschiedenen [Konferenzen](./conferences.md) wird gepflegt.


### PR DESCRIPTION
fixes #431

Dieser PR fügt eine Übersichtstabelle der in #431 genannten Konferenzen hinzu.
Unter dem "Bereich"-Abschnitt habe ich versucht, eine grobe Übersicht über die Themen zu geben, die auf der Konferenz behandelt werden. Diese können von Jahr zu Jahr variieren und sollten daher als grobe Kategorisierung verstanden werden.
Um den Zyklus zu bestimmen, habe ich mich auf die Informationen auf der Webseite verlassen und kurz recherchiert, ob es in den vergangenen Jahren ebenfalls Konferenzen gab, um den Zyklus festzulegen.