### PR TITLE
[GAME] add `onEntityShow`, `onEntityAdd` and `onEntityRemove` Consumer in `System`

### DIFF
--- a/game/src/core/System.java
+++ b/game/src/core/System.java
@@ -38,33 +38,33 @@ public abstract class System {
     /**
      * Will be called after an entity was added to the internal set of the system.
      *
-     * <p>Use this in your own System to implement logic that should be executed after an entity was
+     * <p>Use this in your own system to implement logic that should be executed after an entity was
      * added.
      *
-     * <p>The default implementation does nothing.
+     * <p>The default implementation is just empty.
      */
     protected Consumer<Entity> onEntityAdd = (e) -> {};
     /**
      * Will be called after an entity was removed from the internal set of the system.
      *
-     * <p>Use this in your own System to implement logic that should be executed after an entity was
+     * <p>Use this in your own system to implement logic that should be executed after an entity was
      * removed.
      *
-     * <p>The default implementation does nothing.
+     * <p>The default implementation is just empty.
      */
     protected Consumer<Entity> onEntityRemove = (e) -> {};
 
     /**
      * Will be called if an entity is shown to the system.
      *
-     * <p>Use this in your own System to implement logic that should be executed after an entity is
+     * <p>Use this in your own system to implement logic that should be executed after an entity is
      * shown to the system.
      *
-     * <p>This function will be called after the entity is added/removed from the set. It is the
+     * <p>This function will be called after the entity is added/removed to/from the set. It is the
      * final call in {@link #showEntity(Entity)}. So {@link #onEntityAdd} or {@link #onEntityRemove}
      * could have been executed already.
      *
-     * <p>The default implementation does nothing.
+     * <p>The default implementation is just empty.
      */
     protected Consumer<Entity> onEntityShow = (e) -> {};
 

--- a/game/test/core/SystemTest.java
+++ b/game/test/core/SystemTest.java
@@ -7,6 +7,8 @@ import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
+import java.util.function.Consumer;
+
 public class SystemTest {
 
     @Test
@@ -16,9 +18,29 @@ public class SystemTest {
                     @Override
                     public void execute() {}
                 };
+
+        final boolean[] onShow = {false};
+        final boolean[] onAdd = {false};
+        ts.onEntityShow =
+                new Consumer<Entity>() {
+                    @Override
+                    public void accept(Entity entity) {
+                        onShow[0] = true;
+                    }
+                };
+        ts.onEntityAdd =
+                new Consumer<Entity>() {
+                    @Override
+                    public void accept(Entity entity) {
+                        onAdd[0] = true;
+                    }
+                };
+
         Entity e = new Entity();
         e.addComponent(new DummyComponent(e));
         ts.showEntity(e);
+        assertTrue(onShow[0]);
+        assertTrue(onAdd[0]);
         ts.execute();
         assertTrue(ts.getEntityStream().anyMatch(en -> e == en));
         Game.removeAllEntities();
@@ -32,7 +54,25 @@ public class SystemTest {
                     @Override
                     public void execute() {}
                 };
+        final boolean[] onShow = {false};
+        final boolean[] onAdd = {false};
+        ts.onEntityShow =
+                new Consumer<Entity>() {
+                    @Override
+                    public void accept(Entity entity) {
+                        onShow[0] = true;
+                    }
+                };
+        ts.onEntityAdd =
+                new Consumer<Entity>() {
+                    @Override
+                    public void accept(Entity entity) {
+                        onAdd[0] = true;
+                    }
+                };
         ts.showEntity(e);
+        assertTrue(onShow[0]);
+        assertFalse(onAdd[0]);
         ts.execute();
         assertFalse(ts.getEntityStream().anyMatch(en -> e == en));
         Game.removeAllEntities();
@@ -45,11 +85,63 @@ public class SystemTest {
                     @Override
                     public void execute() {}
                 };
+        final boolean[] onShow = {false};
+        final boolean[] onRemove = {false};
+        ts.onEntityShow =
+                new Consumer<Entity>() {
+                    @Override
+                    public void accept(Entity entity) {
+                        onShow[0] = true;
+                    }
+                };
+        ts.onEntityRemove =
+                new Consumer<Entity>() {
+                    @Override
+                    public void accept(Entity entity) {
+                        onRemove[0] = true;
+                    }
+                };
         Entity e = new Entity();
         e.addComponent(new DummyComponent(e));
         ts.showEntity(e);
+        assertTrue(onShow[0]);
         ts.execute();
         ts.removeEntity(e);
+        assertTrue(onRemove[0]);
+        ts.execute();
+        assertFalse(ts.getEntityStream().anyMatch(en -> e == en));
+        Game.removeAllEntities();
+    }
+
+    @Test
+    public void remove_notExisting() {
+        System ts =
+                new System(DummyComponent.class) {
+                    @Override
+                    public void execute() {}
+                };
+        final boolean[] onShow = {false};
+        final boolean[] onRemove = {false};
+        ts.onEntityShow =
+                new Consumer<Entity>() {
+                    @Override
+                    public void accept(Entity entity) {
+                        onShow[0] = true;
+                    }
+                };
+        ts.onEntityRemove =
+                new Consumer<Entity>() {
+                    @Override
+                    public void accept(Entity entity) {
+                        onRemove[0] = true;
+                    }
+                };
+        Entity e = new Entity();
+        ts.showEntity(e);
+        assertTrue(onShow[0]);
+        ts.execute();
+        ts.removeEntity(e);
+        assertFalse(onRemove[0]);
         ts.execute();
         assertFalse(ts.getEntityStream().anyMatch(en -> e == en));
         Game.removeAllEntities();


### PR DESCRIPTION
bzgl #727
- fügt in `System` die `protected Consumer <Entity>`
    - `onEntityRemove` -> letzter Aufruf in `System#removeEntity`
   - `onEntityAdd` -> letzter Aufruf in `System#addEntity`
   - `onEntityShow` -> letzter Aufruf in `System#showEntity` (`onAddEntity`/ `onRemoveEntity` wird daher (wenn das Event passiert, vor `onEntityShow` aufgerufen) 
- passe Tests an


@cagix Ich habe mich aus dem Bauchgefühl heraus für `protected` Consumer entscheiden und keine getter/setter verwendet. 
Für mich sind die Consumer etwas, was in den abgeleiteten Systemen im Konstruktor gesetzt wird, nach außen sind die irrelevant. 
Getter/Setter haben für mich immer einen leichten API-Geschmack, also Konfiguration von/nach "außen". 
Hast du eine andere Präferenz?

@AHeinisch kannst du damit #727 umsetzten? 