### PR TITLE
[GAME] fix bug where LevelManger was initialized two times

### DIFF
--- a/game/src/core/Game.java
+++ b/game/src/core/Game.java
@@ -625,7 +625,6 @@ public final class Game extends ScreenAdapter implements IOnLevelLoader {
         batch = new SpriteBatch();
         painter = new Painter(batch);
         IGenerator generator = new RandomWalkGenerator();
-        levelManager = new LevelManager(batch, painter, generator, this);
         initBaseLogger();
         levelManager =
                 new LevelManager(


### PR DESCRIPTION
fix #680 

sollte eigentlich in #688 behoben worden sein, scheint aber beim rebasen verloren gegangen zu sein.