### PR TITLE
[GAME] remove DrawComponent from the entity if animations can't be loaded and refactor the DrawComponent (JavaDoc, Clean Code)

### DIFF
--- a/game/src/core/components/DrawComponent.java
+++ b/game/src/core/components/DrawComponent.java
@@ -73,17 +73,19 @@ public final class DrawComponent extends Component {
         File directory;
         try {
             directory = new File(classLoader.getResource(path).getFile());
+            animationMap =
+                    Arrays.stream(directory.listFiles())
+                            .filter(File::isDirectory)
+                            .collect(Collectors.toMap(File::getName, Animation::of));
+            currentAnimation(CoreAnimations.IDLE_LEFT);
         } catch (NullPointerException np) {
-            throw new FileNotFoundException("Path " + path + " not found.");
+            entity.removeComponent(DrawComponent.class);
+            throw new FileNotFoundException(
+                    "Path "
+                            + path
+                            + " not found. DrawComponent was removed from Entity: "
+                            + entity);
         }
-        if (!directory.exists() || !directory.isDirectory()) {
-            throw new FileNotFoundException("Path " + path + " not found.");
-        }
-        animationMap =
-                Arrays.stream(directory.listFiles())
-                        .filter(File::isDirectory)
-                        .collect(Collectors.toMap(File::getName, Animation::of));
-        currentAnimation(CoreAnimations.IDLE_LEFT);
     }
 
     /**

--- a/game/src/core/components/DrawComponent.java
+++ b/game/src/core/components/DrawComponent.java
@@ -82,9 +82,8 @@ public final class DrawComponent extends Component {
             // This means that if the files can't be loaded, the component is considered "defective" and will likely throw exceptions.
             // For that reason, we remove the defective component from the entity.
             entity.removeComponent(DrawComponent.class);
-            /* We convert the "NullPointerException" to a "FileNotFoundException" because the only
-               reason for a NullPointerException is if the directory does not exist.
-            */
+            // We convert the "NullPointerException" to a "FileNotFoundException" because the only
+            // reason for a NullPointerException is if the directory does not exist.
             throw new FileNotFoundException(
                     "Path "
                             + path

--- a/game/src/core/components/DrawComponent.java
+++ b/game/src/core/components/DrawComponent.java
@@ -79,7 +79,8 @@ public final class DrawComponent extends Component {
             currentAnimation(CoreAnimations.IDLE_LEFT);
         } catch (NullPointerException np) {
             // The component gets registered at the entity in super().
-            // This means that if the files can't be loaded, the component is considered "defective" and will likely throw exceptions.
+            // This means that if the files can't be loaded, the component is considered "defective"
+            // and will likely throw exceptions.
             // For that reason, we remove the defective component from the entity.
             entity.removeComponent(DrawComponent.class);
             // We convert the "NullPointerException" to a "FileNotFoundException" because the only

--- a/game/src/core/components/DrawComponent.java
+++ b/game/src/core/components/DrawComponent.java
@@ -78,10 +78,9 @@ public final class DrawComponent extends Component {
                             .collect(Collectors.toMap(File::getName, Animation::of));
             currentAnimation(CoreAnimations.IDLE_LEFT);
         } catch (NullPointerException np) {
-            /* The component gets registered at the entity in super().
-               This means that if the files can't be loaded, the component is considered "defective" and will likely throw exceptions.
-               For that reason, we remove the defective component from the entity.
-            */
+            // The component gets registered at the entity in super().
+            // This means that if the files can't be loaded, the component is considered "defective" and will likely throw exceptions.
+            // For that reason, we remove the defective component from the entity.
             entity.removeComponent(DrawComponent.class);
             /* We convert the "NullPointerException" to a "FileNotFoundException" because the only
                reason for a NullPointerException is if the directory does not exist.

--- a/game/src/core/components/DrawComponent.java
+++ b/game/src/core/components/DrawComponent.java
@@ -61,7 +61,7 @@ public final class DrawComponent extends Component {
      * <p>Will set the current animation to idle left
      *
      * @param entity associated entity
-     * @param path Path (as a string) to the directory in the assets' folder where the
+     * @param path Path (as a string) to the directory in the assets folder where the
      *     subdirectories containing the animation files are stored. Example: "character/knight".
      * @throws IOException if the given path does not exist
      * @see Animation

--- a/game/src/core/components/DrawComponent.java
+++ b/game/src/core/components/DrawComponent.java
@@ -78,7 +78,14 @@ public final class DrawComponent extends Component {
                             .collect(Collectors.toMap(File::getName, Animation::of));
             currentAnimation(CoreAnimations.IDLE_LEFT);
         } catch (NullPointerException np) {
+            /* The component gets registered at the entity in super().
+               This means that if the files can't be loaded, the component is considered "defective" and will likely throw exceptions.
+               For that reason, we remove the defective component from the entity.
+            */
             entity.removeComponent(DrawComponent.class);
+            /* We convert the "NullPointerException" to a "FileNotFoundException" because the only
+               reason for a NullPointerException is if the directory does not exist.
+            */
             throw new FileNotFoundException(
                     "Path "
                             + path

--- a/game/src/core/components/DrawComponent.java
+++ b/game/src/core/components/DrawComponent.java
@@ -61,8 +61,8 @@ public final class DrawComponent extends Component {
      * <p>Will set the current animation to idle left
      *
      * @param entity associated entity
-     * @param path Path (as a string) to the directory in the assets folder where the subdirectories
-     *     containing the animation files are stored. Example: "character/knight".
+     * @param path Path (as a string) to the directory in the assets' folder where the
+     *     subdirectories containing the animation files are stored. Example: "character/knight".
      * @throws IOException if the given path does not exist
      * @see Animation
      */
@@ -70,12 +70,12 @@ public final class DrawComponent extends Component {
         super(entity);
         // fetch available animations
         ClassLoader classLoader = getClass().getClassLoader();
-        File directory = new File(classLoader.getResource(path).getFile());
+        File directory = new File(Objects.requireNonNull(classLoader.getResource(path)).getFile());
         if (!directory.exists() || !directory.isDirectory()) {
             throw new FileNotFoundException("Path " + path + " not found.");
         }
         animationMap =
-                Arrays.stream(directory.listFiles())
+                Arrays.stream(Objects.requireNonNull(directory.listFiles()))
                         .filter(File::isDirectory)
                         .collect(Collectors.toMap(File::getName, Animation::of));
         currentAnimation(CoreAnimations.IDLE_LEFT);

--- a/game/src/core/components/DrawComponent.java
+++ b/game/src/core/components/DrawComponent.java
@@ -53,7 +53,7 @@ public final class DrawComponent extends Component {
     private Animation currentAnimation;
 
     /**
-     * Create a new DrawComponent.
+     * Create a new DrawComponent and add it to the associated entity..
      *
      * <p>Will read in all subdirectories of the given path and use each file in the subdirectory to
      * create an animation. So each subdirectory should contain only the files for one animation.

--- a/game/src/core/components/DrawComponent.java
+++ b/game/src/core/components/DrawComponent.java
@@ -17,7 +17,7 @@ import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 /**
- * The DrawComponent stores all {@link Animation}s for an entity.
+ * Store all {@link Animation}s for an entity.
  *
  * <p>At creation, the component will read in each subdirectory in the given path and create an
  * animation for each subdirectory.
@@ -25,7 +25,7 @@ import java.util.stream.Collectors;
  * <p>Each Animation will be created with default settings. If you want to change these settings,
  * use the methods from {@link Animation}.
  *
- * <p>Use {@link #currentAnimation} to set the current Animation.
+ * <p>Use {@link #currentAnimation} to set the current animation.
  *
  * <p>Use {@link #currentAnimation} to get the current active animation or use {@link #getAnimation}
  * to get a specific animation.
@@ -159,12 +159,12 @@ public final class DrawComponent extends Component {
     }
 
     /**
-     * Check if the animation at the given path is the current-animation
+     * Check if the animation at the given path is the current animation
      *
      * <p>Will log a warning if no animation is stored for the given path.
      *
      * @param path Path to the animation to check
-     * @return true if the current-animation equals the animation at the given path, false if not or
+     * @return true if the current animation equals the animation at the given path, false if not or
      *     no animation for the given oath is stored in this component.
      */
     public boolean isCurrentAnimation(final IPath path) {

--- a/game/src/core/components/DrawComponent.java
+++ b/game/src/core/components/DrawComponent.java
@@ -47,7 +47,7 @@ import java.util.stream.Collectors;
  * @see Animation
  * @see IPath
  */
-public class DrawComponent extends Component {
+public final class DrawComponent extends Component {
     private final Map<String, Animation> animationMap;
     private final Logger LOGGER = Logger.getLogger(this.getClass().getName());
     private Animation currentAnimation;
@@ -66,7 +66,7 @@ public class DrawComponent extends Component {
      * @throws IOException if the given path does not exist
      * @see Animation
      */
-    public DrawComponent(Entity entity, String path) throws IOException {
+    public DrawComponent(final Entity entity, final String path) throws IOException {
         super(entity);
         // fetch available animations
         ClassLoader classLoader = getClass().getClassLoader();
@@ -92,7 +92,7 @@ public class DrawComponent extends Component {
      * @param entity associated entity
      * @param idle Animation to use as idle-left and idle-right animation.
      */
-    public DrawComponent(Entity entity, Animation idle) {
+    public DrawComponent(final Entity entity, final Animation idle) {
         super(entity);
         animationMap = new HashMap<>();
         animationMap.put(CoreAnimations.IDLE_LEFT.pathString(), idle);
@@ -120,7 +120,7 @@ public class DrawComponent extends Component {
      * @param animationName Path of the new current animation (this is the name of the directory).
      * @see IPath
      */
-    public void currentAnimation(IPath animationName) {
+    public void currentAnimation(final IPath animationName) {
         Animation animation = animationMap.get(animationName.pathString());
         if (animation != null) this.currentAnimation = animation;
         else
@@ -139,7 +139,7 @@ public class DrawComponent extends Component {
      * @param path Path of the Animation
      * @return The animation or null
      */
-    public Optional<Animation> getAnimation(IPath path) {
+    public Optional<Animation> getAnimation(final IPath path) {
         return Optional.ofNullable(animationMap.get(path.pathString()));
     }
 
@@ -149,7 +149,7 @@ public class DrawComponent extends Component {
      * @param path Path of the animation to look for
      * @return true if the animation exists in this component, false if not
      */
-    public boolean hasAnimation(IPath path) {
+    public boolean hasAnimation(final IPath path) {
         return animationMap.containsKey(path.pathString());
     }
 
@@ -162,7 +162,7 @@ public class DrawComponent extends Component {
      * @return true if the current-animation equals the animation at the given path, false if not or
      *     no animation for the given oath is stored in this component.
      */
-    public boolean isCurrentAnimation(IPath path) {
+    public boolean isCurrentAnimation(final IPath path) {
         Optional<Animation> animation = getAnimation(path);
         if (animation.isPresent()) return animation.get() == currentAnimation;
         LOGGER.warning("Animation " + path + " is not stored inside " + entity.toString());

--- a/game/src/core/components/DrawComponent.java
+++ b/game/src/core/components/DrawComponent.java
@@ -69,10 +69,9 @@ public final class DrawComponent extends Component {
     public DrawComponent(final Entity entity, final String path) throws IOException {
         super(entity);
         // fetch available animations
-        ClassLoader classLoader = getClass().getClassLoader();
-        File directory;
         try {
-            directory = new File(classLoader.getResource(path).getFile());
+            ClassLoader classLoader = getClass().getClassLoader();
+            File directory = new File(classLoader.getResource(path).getFile());
             animationMap =
                     Arrays.stream(directory.listFiles())
                             .filter(File::isDirectory)

--- a/game/src/core/components/DrawComponent.java
+++ b/game/src/core/components/DrawComponent.java
@@ -61,8 +61,8 @@ public final class DrawComponent extends Component {
      * <p>Will set the current animation to idle left
      *
      * @param entity associated entity
-     * @param path Path (as a string) to the directory in the assets folder where the
-     *     subdirectories containing the animation files are stored. Example: "character/knight".
+     * @param path Path (as a string) to the directory in the assets folder where the subdirectories
+     *     containing the animation files are stored. Example: "character/knight".
      * @throws IOException if the given path does not exist
      * @see Animation
      */
@@ -70,12 +70,12 @@ public final class DrawComponent extends Component {
         super(entity);
         // fetch available animations
         ClassLoader classLoader = getClass().getClassLoader();
-        File directory = new File(Objects.requireNonNull(classLoader.getResource(path)).getFile());
+        File directory = new File(classLoader.getResource(path).getFile());
         if (!directory.exists() || !directory.isDirectory()) {
             throw new FileNotFoundException("Path " + path + " not found.");
         }
         animationMap =
-                Arrays.stream(Objects.requireNonNull(directory.listFiles()))
+                Arrays.stream(directory.listFiles())
                         .filter(File::isDirectory)
                         .collect(Collectors.toMap(File::getName, Animation::of));
         currentAnimation(CoreAnimations.IDLE_LEFT);

--- a/game/src/core/components/DrawComponent.java
+++ b/game/src/core/components/DrawComponent.java
@@ -53,7 +53,7 @@ public final class DrawComponent extends Component {
     private Animation currentAnimation;
 
     /**
-     * Create a new DrawComponent and add it to the associated entity..
+     * Create a new DrawComponent and add it to the associated entity.
      *
      * <p>Will read in all subdirectories of the given path and use each file in the subdirectory to
      * create an animation. So each subdirectory should contain only the files for one animation.
@@ -70,7 +70,12 @@ public final class DrawComponent extends Component {
         super(entity);
         // fetch available animations
         ClassLoader classLoader = getClass().getClassLoader();
-        File directory = new File(classLoader.getResource(path).getFile());
+        File directory;
+        try {
+            directory = new File(classLoader.getResource(path).getFile());
+        } catch (NullPointerException np) {
+            throw new FileNotFoundException("Path " + path + " not found.");
+        }
         if (!directory.exists() || !directory.isDirectory()) {
             throw new FileNotFoundException("Path " + path + " not found.");
         }


### PR DESCRIPTION
In diesem Pull-Request wurde das `DrawComponent` refactored.

Dieser Pull-Request zielt darauf ab, sicherzustellen, dass die Qualität der JavaDoc zu verbessern und Clean Code sowie Java Konventionen umzusetzen. 

- DrawComponent wird aus Entität entfernt, wenn beim laden der Animationen eine FileNotFound-Exception auftritt
- try-catch im Konstruktor verbessert

Dieser Pull-Request nimmt keine Änderungen am Logging (#683) oder an der Testabdeckung vor. 