### PR TITLE
[Game] Hero ohne PositionComponent führt nicht mehr zu MissingComponentException

### DIFF
--- a/game/src/core/Game.java
+++ b/game/src/core/Game.java
@@ -640,7 +640,11 @@ public final class Game extends ScreenAdapter implements IOnLevelLoader {
      * <p>This is the place to add basic logic that isn't part of any system.
      */
     private void onFrame() {
-        hero().ifPresent(this::loadNextLevelIfEntityIsOnEndTile);
+        try {
+            hero().ifPresent(this::loadNextLevelIfEntityIsOnEndTile);
+        } catch (MissingComponentException e) {
+            LOGGER.warning(e.getMessage());
+        }
         debugKeys();
         userOnFrame.execute();
     }
@@ -686,7 +690,11 @@ public final class Game extends ScreenAdapter implements IOnLevelLoader {
     public void onLevelLoad() {
         currentLevel = levelManager.currentLevel();
         removeAllEntities();
-        hero().ifPresent(this::placeOnLevelStart);
+        try {
+            hero().ifPresent(this::placeOnLevelStart);
+        } catch (MissingComponentException e) {
+            LOGGER.warning(e.getMessage());
+        }
         hero().ifPresent(Game::addEntity);
         userOnLevelLoad.execute();
     }

--- a/game/src/core/utils/components/MissingComponentException.java
+++ b/game/src/core/utils/components/MissingComponentException.java
@@ -33,6 +33,6 @@ public final class MissingComponentException extends NullPointerException {
      * @return the created MissingComponentException
      */
     public static MissingComponentException build(final Entity entity, final Class<?> klass) {
-        return new MissingComponentException(entity + "is missing " + klass.getName());
+        return new MissingComponentException(entity + " is missing " + klass.getName());
     }
 }


### PR DESCRIPTION
fixes #556

- die Methode `Game.onLevelLoad` wirft durch Aufruf von `Game.placeOnLevelStart` eine MissingComponentException wenn der Held keine PositionComponent hat
    - Try-Catch-Block innerhalb von `Game.onLevelLoad`, der `Game.placeOnLevelStart` aufruft und bei Auftreten einer MissingComponentException dies loggt
- gleiches Verhalten bei `Game.onFrame`, welches durch den Aufruf von `Game.loadNextLevelIfEntityIsOnEndTile` bei fehlendem PositionComponent des Helden zu einer MissingComponentException führt

