### PR TITLE
[GAME] refactor `LevelManger` into `LevelSystem`, use `LinkedHashMap` to store Systems in `Game`, use `static Painter` and `static batch` in `DrawSystem`

### DIFF
--- a/game/src/core/Game.java
+++ b/game/src/core/Game.java
@@ -613,7 +613,6 @@ public final class Game extends ScreenAdapter {
         ds.batch().setProjectionMatrix(CameraSystem.camera().combined);
         onFrame();
         clearScreen();
-        levelSystem.update();
         updateSystems();
         systems.values().stream().filter(System::isRunning).forEach(System::execute);
         CameraSystem.camera().update();
@@ -634,10 +633,7 @@ public final class Game extends ScreenAdapter {
         DrawSystem ds = (DrawSystem) systems.get(DrawSystem.class);
         levelSystem =
                 new LevelSystem(
-                        ds.batch(),
-                        ds.painter(),
-                        new WallGenerator(new RandomWalkGenerator()),
-                        onLevelLoad);
+                        ds.painter(), new WallGenerator(new RandomWalkGenerator()), onLevelLoad);
         levelSystem.loadLevel(LevelSystem.levelSize());
 
         setupStage();
@@ -650,11 +646,6 @@ public final class Game extends ScreenAdapter {
      * <p>This is the place to add basic logic that isn't part of any system.
      */
     private void onFrame() {
-        try {
-            hero().ifPresent(levelSystem::loadNextLevelIfEntityIsOnEndTile);
-        } catch (MissingComponentException e) {
-            LOGGER.warning(e.getMessage());
-        }
         debugKeys();
         fullscreenKey();
         userOnFrame.execute();
@@ -751,10 +742,7 @@ public final class Game extends ScreenAdapter {
         addSystem(ds);
         addSystem(
                 new LevelSystem(
-                        ds.batch(),
-                        ds.painter(),
-                        new WallGenerator(new RandomWalkGenerator()),
-                        onLevelLoad));
+                        ds.painter(), new WallGenerator(new RandomWalkGenerator()), onLevelLoad));
         addSystem(new VelocitySystem());
         addSystem(new PlayerSystem());
         addSystem(new HudSystem());

--- a/game/src/core/Game.java
+++ b/game/src/core/Game.java
@@ -601,7 +601,7 @@ public final class Game extends ScreenAdapter {
      */
     public static void currentLevel(ILevel level) {
         LevelSystem levelSystem = (LevelSystem) systems.get(LevelSystem.class);
-        if (levelSystem != null) levelSystem.level(level);
+        if (levelSystem != null) levelSystem.loadLevel(level);
         else LOGGER.warning("Can not set Level because levelSystem is null.");
     }
 

--- a/game/src/core/Game.java
+++ b/game/src/core/Game.java
@@ -34,7 +34,7 @@ import core.utils.Point;
 import core.utils.components.MissingComponentException;
 
 import java.io.IOException;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.logging.Logger;
@@ -48,7 +48,7 @@ public final class Game extends ScreenAdapter {
      *
      * <p>The Key-Value is the Class of the system
      */
-    private static final Map<Class<? extends System>, System> systems = new HashMap<>();
+    private static final Map<Class<? extends System>, System> systems = new LinkedHashMap<>();
     /** All entities that are currently active in the dungeon */
     private static final DelayedSet<Entity> entities = new DelayedSet<>();
 
@@ -139,7 +139,7 @@ public final class Game extends ScreenAdapter {
      * @return a copy of the map that stores all registered {@link System} in the game.
      */
     public static Map<Class<? extends System>, System> systems() {
-        return new HashMap<>(systems);
+        return new LinkedHashMap<>(systems);
     }
 
     /** Remove all registered systems from the game. */
@@ -630,11 +630,6 @@ public final class Game extends ScreenAdapter {
         CameraSystem.camera().zoom = Constants.DEFAULT_ZOOM_FACTOR;
         initBaseLogger();
         createSystems();
-        DrawSystem ds = (DrawSystem) systems.get(DrawSystem.class);
-        levelSystem =
-                new LevelSystem(
-                        ds.painter(), new WallGenerator(new RandomWalkGenerator()), onLevelLoad);
-        levelSystem.loadLevel(LevelSystem.levelSize());
 
         setupStage();
     }

--- a/game/src/core/Game.java
+++ b/game/src/core/Game.java
@@ -120,8 +120,6 @@ public final class Game extends ScreenAdapter {
 
     private static Stage stage;
 
-    private static LevelSystem levelSystem;
-
     private boolean doSetup = true;
     private boolean uiDebugFlag = false;
 
@@ -132,7 +130,7 @@ public final class Game extends ScreenAdapter {
      * @return the currently loaded level
      */
     public static ILevel currentLevel() {
-        return LevelSystem.currentLevel();
+        return LevelSystem.level();
     }
 
     /**
@@ -586,8 +584,8 @@ public final class Game extends ScreenAdapter {
      * @param level New level
      */
     public static void currentLevel(ILevel level) {
+        LevelSystem levelSystem = (LevelSystem) systems.get(LevelSystem.class);
         if (levelSystem != null) levelSystem.level(level);
-        LevelSystem.currentLevel(level);
     }
 
     private static void setupStage() {
@@ -630,7 +628,6 @@ public final class Game extends ScreenAdapter {
         CameraSystem.camera().zoom = Constants.DEFAULT_ZOOM_FACTOR;
         initBaseLogger();
         createSystems();
-
         setupStage();
     }
 
@@ -733,11 +730,12 @@ public final class Game extends ScreenAdapter {
     /** Create the systems. */
     private void createSystems() {
         addSystem(new CameraSystem());
-        DrawSystem ds = new DrawSystem();
-        addSystem(ds);
         addSystem(
                 new LevelSystem(
-                        ds.painter(), new WallGenerator(new RandomWalkGenerator()), onLevelLoad));
+                        DrawSystem.painter(),
+                        new WallGenerator(new RandomWalkGenerator()),
+                        onLevelLoad));
+        addSystem(new DrawSystem());
         addSystem(new VelocitySystem());
         addSystem(new PlayerSystem());
         addSystem(new HudSystem());

--- a/game/src/core/Game.java
+++ b/game/src/core/Game.java
@@ -59,7 +59,7 @@ public final class Game extends ScreenAdapter implements IOnLevelLoader {
      * The currently loaded level of the game.
      *
      * @see ILevel
-     * @see LevelManager
+     * @see LevelSystem
      */
     private static ILevel currentLevel;
     /**
@@ -131,7 +131,7 @@ public final class Game extends ScreenAdapter implements IOnLevelLoader {
 
     private static Stage stage;
 
-    private static LevelManager levelManager;
+    private static LevelSystem levelSystem;
 
     private boolean doSetup = true;
     private boolean uiDebugFlag = false;
@@ -594,12 +594,12 @@ public final class Game extends ScreenAdapter implements IOnLevelLoader {
      *
      * <p>This method is for testing and debugging purposes.
      *
-     * <p>Will trigger {@link #onLevelLoad() if a {@link LevelManager} is active.}
+     * <p>Will trigger {@link #onLevelLoad() if a {@link LevelSystem } is active.}
      *
      * @param level New level
      */
     public static void currentLevel(ILevel level) {
-        if (levelManager != null) levelManager.level(level);
+        if (levelSystem != null) levelSystem.level(level);
         currentLevel = level;
     }
 
@@ -626,7 +626,7 @@ public final class Game extends ScreenAdapter implements IOnLevelLoader {
         ds.batch().setProjectionMatrix(CameraSystem.camera().combined);
         onFrame();
         clearScreen();
-        levelManager.update();
+        levelSystem.update();
         updateSystems();
         systems.values().stream().filter(System::isRunning).forEach(System::execute);
         CameraSystem.camera().update();
@@ -646,13 +646,13 @@ public final class Game extends ScreenAdapter implements IOnLevelLoader {
         initBaseLogger();
         createSystems();
         DrawSystem ds = (DrawSystem) systems.get(DrawSystem.class);
-        levelManager =
-                new LevelManager(
+        levelSystem =
+                new LevelSystem(
                         ds.batch(),
                         ds.painter(),
                         new WallGenerator(new RandomWalkGenerator()),
                         this);
-        levelManager.loadLevel(LEVELSIZE);
+        levelSystem.loadLevel(LEVELSIZE);
 
         setupStage();
     }
@@ -720,7 +720,7 @@ public final class Game extends ScreenAdapter implements IOnLevelLoader {
      */
     @Override
     public void onLevelLoad() {
-        currentLevel = levelManager.currentLevel();
+        currentLevel = levelSystem.currentLevel();
         removeAllEntities();
         try {
             hero().ifPresent(this::placeOnLevelStart);
@@ -739,7 +739,7 @@ public final class Game extends ScreenAdapter implements IOnLevelLoader {
      */
     private void loadNextLevelIfEntityIsOnEndTile(Entity hero) {
         if (isOnEndTile(hero)) {
-            levelManager.loadLevel(LEVELSIZE);
+            levelSystem.loadLevel(LEVELSIZE);
         }
     }
 

--- a/game/src/core/level/IOnLevelLoader.java
+++ b/game/src/core/level/IOnLevelLoader.java
@@ -1,7 +1,0 @@
-package core.level;
-
-/** Interface to use a custom `onLevelLoad` method. */
-public interface IOnLevelLoader {
-    /** Called after a new level has been loaded. */
-    void onLevelLoad();
-}

--- a/game/src/core/systems/DrawSystem.java
+++ b/game/src/core/systems/DrawSystem.java
@@ -64,6 +64,7 @@ public final class DrawSystem extends System {
      */
     @Override
     public void execute() {
+        java.lang.System.out.println("DrawSystem!!!!!!!!!!!!!!!!!");
         entityStream().map(this::buildDataObject).forEach(this::draw);
     }
 

--- a/game/src/core/systems/DrawSystem.java
+++ b/game/src/core/systems/DrawSystem.java
@@ -33,14 +33,14 @@ import java.util.Map;
  */
 public final class DrawSystem extends System {
 
-    /** Draws objects */
-    private final Painter painter;
-
     /**
      * The batch is necessary to draw ALL the stuff. Every object that uses draw need to know the
      * batch.
      */
-    private final SpriteBatch batch;
+    private static final SpriteBatch batch = new SpriteBatch();
+
+    /** Draws objects */
+    private static final Painter painter = new Painter(batch);
 
     private final Map<String, PainterConfig> configs;
 
@@ -51,8 +51,6 @@ public final class DrawSystem extends System {
      */
     public DrawSystem() {
         super(DrawComponent.class, PositionComponent.class);
-        batch = new SpriteBatch();
-        painter = new Painter(batch);
         configs = new HashMap<>();
     }
 
@@ -100,14 +98,14 @@ public final class DrawSystem extends System {
     /**
      * @return the {@link #painter} of the Drawsystem
      */
-    public Painter painter() {
+    public static Painter painter() {
         return painter;
     }
 
     /**
      * @return the {@link #batch} of the Drawsystem
      */
-    public SpriteBatch batch() {
+    public static SpriteBatch batch() {
         return batch;
     }
 }

--- a/game/src/core/systems/DrawSystem.java
+++ b/game/src/core/systems/DrawSystem.java
@@ -64,7 +64,6 @@ public final class DrawSystem extends System {
      */
     @Override
     public void execute() {
-        java.lang.System.out.println("DrawSystem!!!!!!!!!!!!!!!!!");
         entityStream().map(this::buildDataObject).forEach(this::draw);
     }
 

--- a/game/src/core/systems/LevelSystem.java
+++ b/game/src/core/systems/LevelSystem.java
@@ -1,7 +1,5 @@
 package core.systems;
 
-import com.badlogic.gdx.graphics.g2d.SpriteBatch;
-
 import core.Entity;
 import core.Game;
 import core.System;
@@ -24,7 +22,6 @@ import java.util.logging.Logger;
 
 /** Manages the level. */
 public class LevelSystem extends System {
-    private final SpriteBatch batch;
     private final Painter painter;
     private final IVoidFunction onLevelLoader;
     private IGenerator gen;
@@ -40,16 +37,13 @@ public class LevelSystem extends System {
     private final Logger levelAPI_logger = Logger.getLogger(this.getClass().getName());
 
     /**
-     * @param batch Batch on which to draw.
      * @param painter Who draws?
      * @param generator Level generator
      * @param onLevelLoader Object that implements the onLevelLoad method.
      */
-    public LevelSystem(
-            SpriteBatch batch, Painter painter, IGenerator generator, IVoidFunction onLevelLoader) {
+    public LevelSystem(Painter painter, IGenerator generator, IVoidFunction onLevelLoader) {
         super(PlayerComponent.class, PositionComponent.class);
         this.gen = generator;
-        this.batch = batch;
         this.painter = painter;
         this.onLevelLoader = onLevelLoader;
     }
@@ -87,11 +81,6 @@ public class LevelSystem extends System {
     /** Load a new level with random size and random design. */
     public void loadLevel() {
         loadLevel(LevelSize.randomSize(), DesignLabel.randomDesign());
-    }
-
-    /** Draw level */
-    public void update() {
-        drawLevel();
     }
 
     /**
@@ -150,17 +139,6 @@ public class LevelSystem extends System {
     }
 
     /**
-     * If the given entity is on the end-tile, load the new level
-     *
-     * @param hero entity to check for, normally this is the hero
-     */
-    public void loadNextLevelIfEntityIsOnEndTile(Entity hero) {
-        if (isOnEndTile(hero)) {
-            loadLevel(LEVELSIZE);
-        }
-    }
-
-    /**
      * Check if the given en entity is on the end-tile
      *
      * @param entity entity to check for
@@ -187,7 +165,8 @@ public class LevelSystem extends System {
 
     @Override
     public void execute() {
+        java.lang.System.out.println("LEVEL!!!!!!!!!");
         drawLevel();
-        entityStream().forEach(this::loadNextLevelIfEntityIsOnEndTile);
+        if (entityStream().anyMatch(this::isOnEndTile)) loadLevel(levelSize());
     }
 }

--- a/game/src/core/systems/LevelSystem.java
+++ b/game/src/core/systems/LevelSystem.java
@@ -45,9 +45,7 @@ import java.util.logging.Logger;
  * onLevelLoad callback.
  */
 public final class LevelSystem extends System {
-    /**
-     * Currently used level-size configuration for generating new level.
-     */
+    /** Currently used level-size configuration for generating new level. */
     private static LevelSize levelSize = LevelSize.MEDIUM;
     /**
      * The currently loaded level of the game.
@@ -68,8 +66,8 @@ public final class LevelSystem extends System {
      * DesignLabel)} if you want to trigger the load of a level manually, otherwise the first level
      * will be loaded if this system {@link #execute()} is executed.
      *
-     * @param painter     The {@link Painter} to use to draw the level.
-     * @param generator   Level generator to use to generate level.
+     * @param painter The {@link Painter} to use to draw the level.
+     * @param generator Level generator to use to generate level.
      * @param onLevelLoad Callback-function that is called if a new level was loaded.
      */
     public LevelSystem(Painter painter, IGenerator generator, IVoidFunction onLevelLoad) {
@@ -107,11 +105,23 @@ public final class LevelSystem extends System {
     }
 
     /**
+     * Set the current level to the given level.
+     *
+     * <p>Will trigger the onLevelLoad callback.
+     *
+     * @param level The level to be set.
+     */
+    public void loadLevel(ILevel level) {
+        currentLevel = level;
+        onLevelLoad.execute();
+    }
+
+    /**
      * Load a new level.
      *
      * <p>Will trigger the onLevelLoad callback.
      *
-     * @param size  The wanted size of the new level.
+     * @param size The wanted size of the new level.
      * @param label The wanted design of the new level.
      */
     public void loadLevel(LevelSize size, DesignLabel label) {
@@ -185,18 +195,6 @@ public final class LevelSystem extends System {
      */
     public void generator(IGenerator generator) {
         gen = generator;
-    }
-
-    /**
-     * Set the current level to the given level.
-     *
-     * <p>Will trigger the onLevelLoad callback.
-     *
-     * @param level The level to be set.
-     */
-    public void loadLevel(ILevel level) {
-        currentLevel = level;
-        onLevelLoad.execute();
     }
 
     /**

--- a/game/src/core/systems/LevelSystem.java
+++ b/game/src/core/systems/LevelSystem.java
@@ -67,7 +67,7 @@ public class LevelSystem extends System {
     }
 
     /**
-     * Load a new level with random size and the given desing
+     * Load a new level with random size and the given design
      *
      * @param designLabel The design that the level should have
      */
@@ -76,7 +76,7 @@ public class LevelSystem extends System {
     }
 
     /**
-     * Load a new level with the given size and a random desing
+     * Load a new level with the given size and a random design
      *
      * @param size wanted size of the level
      */
@@ -109,9 +109,9 @@ public class LevelSystem extends System {
         Map<String, PainterConfig> mapping = new HashMap<>();
 
         Tile[][] layout = currentLevel.layout();
-        for (int y = 0; y < layout.length; y++) {
+        for (Tile[] tiles : layout) {
             for (int x = 0; x < layout[0].length; x++) {
-                Tile t = layout[y][x];
+                Tile t = tiles[x];
                 if (t.levelElement() != LevelElement.SKIP) {
                     String texturePath = t.texturePath();
                     if (!mapping.containsKey(texturePath)) {

--- a/game/src/core/systems/LevelSystem.java
+++ b/game/src/core/systems/LevelSystem.java
@@ -46,6 +46,7 @@ public class LevelSystem extends System {
         this.gen = generator;
         this.painter = painter;
         this.onLevelLoader = onLevelLoader;
+        loadLevel(LEVELSIZE);
     }
 
     /**
@@ -165,8 +166,7 @@ public class LevelSystem extends System {
 
     @Override
     public void execute() {
-        java.lang.System.out.println("LEVEL!!!!!!!!!");
         drawLevel();
-        if (entityStream().anyMatch(this::isOnEndTile)) loadLevel(levelSize());
+        if (entityStream().anyMatch(this::isOnEndTile)) loadLevel(LEVELSIZE);
     }
 }

--- a/game/src/core/systems/LevelSystem.java
+++ b/game/src/core/systems/LevelSystem.java
@@ -23,7 +23,7 @@ import java.util.logging.Logger;
 /** Manages the level. */
 public final class LevelSystem extends System {
     /** Currently used level-size configuration for generating new level */
-    private static LevelSize LEVELSIZE = LevelSize.SMALL;
+    private static LevelSize levelSize = LevelSize.SMALL;
     /**
      * The currently loaded level of the game.
      *
@@ -31,19 +31,19 @@ public final class LevelSystem extends System {
      */
     private static ILevel currentLevel;
 
-    private final IVoidFunction onLevelLoader;
+    private final IVoidFunction onLevelLoad;
     private final Painter painter;
     private final Logger levelAPI_logger = Logger.getLogger(this.getClass().getName());
     private IGenerator gen;
 
     /**
      * @param generator Level generator
-     * @param onLevelLoader Object that implements the onLevelLoad method.
+     * @param onLevelLoad Object that implements the onLevelLoad method.
      */
-    public LevelSystem(Painter painter, IGenerator generator, IVoidFunction onLevelLoader) {
+    public LevelSystem(Painter painter, IGenerator generator, IVoidFunction onLevelLoad) {
         super(PlayerComponent.class, PositionComponent.class);
         this.gen = generator;
-        this.onLevelLoader = onLevelLoader;
+        this.onLevelLoad = onLevelLoad;
         this.painter = painter;
     }
 
@@ -55,11 +55,11 @@ public final class LevelSystem extends System {
     }
 
     public static LevelSize levelSize() {
-        return LEVELSIZE;
+        return levelSize;
     }
 
     public static void levelSize(LevelSize levelSize) {
-        LEVELSIZE = levelSize;
+        LevelSystem.levelSize = levelSize;
     }
 
     /**
@@ -70,7 +70,7 @@ public final class LevelSystem extends System {
      */
     public void loadLevel(LevelSize size, DesignLabel label) {
         currentLevel = gen.level(label, size);
-        onLevelLoader.execute();
+        onLevelLoad.execute();
         levelAPI_logger.info("A new level was loaded.");
     }
 
@@ -138,7 +138,7 @@ public final class LevelSystem extends System {
      */
     public void level(ILevel level) {
         currentLevel = level;
-        onLevelLoader.execute();
+        onLevelLoad.execute();
     }
 
     /**
@@ -160,8 +160,8 @@ public final class LevelSystem extends System {
 
     @Override
     public void execute() {
-        if (currentLevel == null) loadLevel(LEVELSIZE);
-        else if (entityStream().anyMatch(this::isOnEndTile)) loadLevel(LEVELSIZE);
+        if (currentLevel == null) loadLevel(levelSize);
+        else if (entityStream().anyMatch(this::isOnEndTile)) loadLevel(levelSize);
         drawLevel();
     }
 }

--- a/game/src/core/systems/LevelSystem.java
+++ b/game/src/core/systems/LevelSystem.java
@@ -1,4 +1,4 @@
-package core;
+package core.systems;
 
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 
@@ -17,7 +17,7 @@ import java.util.Map;
 import java.util.logging.Logger;
 
 /** Manages the level. */
-public class LevelManager {
+public class LevelSystem {
     private final SpriteBatch batch;
     private final Painter painter;
     private final IOnLevelLoader onLevelLoader;
@@ -31,7 +31,7 @@ public class LevelManager {
      * @param generator Level generator
      * @param onLevelLoader Object that implements the onLevelLoad method.
      */
-    public LevelManager(
+    public LevelSystem(
             SpriteBatch batch,
             Painter painter,
             IGenerator generator,

--- a/game/src/starter/Main.java
+++ b/game/src/starter/Main.java
@@ -6,6 +6,7 @@ import contrib.systems.*;
 import contrib.utils.components.Debugger;
 
 import core.Game;
+import core.level.utils.LevelSize;
 
 import java.io.IOException;
 import java.util.logging.Logger;
@@ -34,6 +35,7 @@ public class Main {
                         LOGGER.warning("Could not create new Chest: " + e.getMessage());
                         throw new RuntimeException();
                     }
+                    Game.levelSize(LevelSize.randomSize());
                 });
         Game.userOnFrame(debugger::execute);
         Game.windowTitle("My Dungeon");

--- a/game/test/contrib/entities/ChestTest.java
+++ b/game/test/contrib/entities/ChestTest.java
@@ -1,18 +1,22 @@
 package contrib.entities;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import contrib.components.InventoryComponent;
 import contrib.utils.components.item.ItemData;
 
 import core.Entity;
 import core.Game;
-import core.components.*;
+import core.components.DrawComponent;
+import core.components.PositionComponent;
 import core.level.TileLevel;
 import core.level.utils.DesignLabel;
 import core.level.utils.LevelElement;
+import core.systems.LevelSystem;
 import core.utils.Point;
 
+import org.junit.After;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -21,15 +25,16 @@ import java.util.Set;
 
 public class ChestTest {
 
-    /** Helper cleans up class attributes used by Chest Initializes the Item#ITEM_REGISTER */
-    private static void cleanup() {
+    @After
+    public void cleanup() {
         Game.removeAllEntities();
+        Game.currentLevel(null);
+        Game.removeAllSystems();
     }
 
     /** checks the correct creation of the Chest */
     @Test
     public void checkCreation() throws IOException {
-        cleanup();
         Set<ItemData> itemData = Set.of();
         Point position = new Point(0, 0);
         Entity c = null;
@@ -52,7 +57,6 @@ public class ChestTest {
                 "Position should be equal to the given Position",
                 position,
                 positionComponent.map(PositionComponent.class::cast).get().position());
-        cleanup();
     }
 
     /**
@@ -63,7 +67,6 @@ public class ChestTest {
      */
     /* @Test
     public void checkInteractionDroppingItems() {
-        cleanup();
         List<ItemData> itemData = List.of(new ItemDataGenerator().generateItemData());
         Point position = new Point(0, 0);
         Entity c = EntityFactory.getChest(itemData, position);
@@ -74,8 +77,6 @@ public class ChestTest {
                 .get()
                 .triggerInteraction();
        // assertEquals(2, Game.getEntitiesStream().count());
-
-        cleanup();
     }*/
 
     /**
@@ -86,7 +87,6 @@ public class ChestTest {
      */
     /* @Test
     public void checkInteractionOnDroppedItems() {
-        cleanup();
         List<ItemData> itemData = List.of(new ItemDataGenerator().generateItemData());
         Point position = new Point(0, 0);
         Entity c = EntityFactory.getChest(itemData, position);
@@ -103,13 +103,11 @@ public class ChestTest {
                         .getComponent(CollideComponent.class)
                         .map(CollideComponent.class::cast)
                         .isPresent());
-
-        cleanup();
     }*/
-
     @Test
     public void checkGeneratorMethod() throws IOException {
-        cleanup();
+        new LevelSystem(null, null, () -> {});
+
         Game.currentLevel(
                 new TileLevel(
                         new LevelElement[][] {
@@ -118,7 +116,6 @@ public class ChestTest {
                             }
                         },
                         DesignLabel.DEFAULT));
-
         Entity newChest = EntityFactory.newChest();
 
         // assertTrue("Chest is added to Game", Game.getEntitiesStream().anyMatch(e -> e ==
@@ -149,6 +146,5 @@ public class ChestTest {
                         .position()
                         .y,
                 0.00001f);
-        cleanup();
     }
 }

--- a/game/test/contrib/entities/MonsterTest.java
+++ b/game/test/contrib/entities/MonsterTest.java
@@ -1,6 +1,6 @@
 package contrib.entities;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertTrue;
 
 import contrib.components.AIComponent;
 import contrib.components.CollideComponent;
@@ -13,18 +13,26 @@ import core.components.PositionComponent;
 import core.level.TileLevel;
 import core.level.utils.DesignLabel;
 import core.level.utils.LevelElement;
+import core.systems.LevelSystem;
 
 import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.util.Optional;
 
 public class MonsterTest {
+    @Before
+    public void setup() {
+        new LevelSystem(null, null, () -> {});
+    }
 
     @After
     public void cleanup() {
         Game.removeAllEntities();
+        Game.currentLevel(null);
+        Game.removeAllSystems();
     }
 
     @Test

--- a/game/test/core/level/TileLevelAPITest.java
+++ b/game/test/core/level/TileLevelAPITest.java
@@ -19,6 +19,7 @@ import core.level.utils.DesignLabel;
 import core.level.utils.LevelElement;
 import core.level.utils.LevelSize;
 import core.systems.LevelSystem;
+import core.utils.IVoidFunction;
 import core.utils.Point;
 import core.utils.components.draw.Painter;
 import core.utils.components.draw.PainterConfig;
@@ -42,7 +43,7 @@ public class TileLevelAPITest {
     private TextureMap textureMap;
     private Painter painter;
     private SpriteBatch batch;
-    private IOnLevelLoader onLevelLoader;
+    private IVoidFunction onLevelLoader;
     private ILevel level;
 
     @Before
@@ -57,7 +58,7 @@ public class TileLevelAPITest {
 
         painter = Mockito.mock(Painter.class);
         generator = Mockito.mock(IGenerator.class);
-        onLevelLoader = Mockito.mock(IOnLevelLoader.class);
+        onLevelLoader = Mockito.mock(IVoidFunction.class);
         level = Mockito.mock(TileLevel.class);
         api = new LevelSystem(batch, painter, generator, onLevelLoader);
     }
@@ -68,7 +69,7 @@ public class TileLevelAPITest {
         api.loadLevel(LevelSize.SMALL, DesignLabel.DEFAULT);
         verify(generator).level(DesignLabel.DEFAULT, LevelSize.SMALL);
         Mockito.verifyNoMoreInteractions(generator);
-        verify(onLevelLoader).onLevelLoad();
+        verify(onLevelLoader).execute();
         Mockito.verifyNoMoreInteractions(onLevelLoader);
         assertEquals(level, api.currentLevel());
     }
@@ -79,7 +80,7 @@ public class TileLevelAPITest {
         api.loadLevel();
         verify(generator).level(Mockito.any(), Mockito.any());
         Mockito.verifyNoMoreInteractions(generator);
-        verify(onLevelLoader).onLevelLoad();
+        verify(onLevelLoader).execute();
         Mockito.verifyNoMoreInteractions(onLevelLoader);
         assertEquals(level, api.currentLevel());
     }
@@ -90,7 +91,7 @@ public class TileLevelAPITest {
         api.loadLevel(DesignLabel.DEFAULT);
         verify(generator).level(eq(DesignLabel.DEFAULT), any());
         Mockito.verifyNoMoreInteractions(generator);
-        verify(onLevelLoader).onLevelLoad();
+        verify(onLevelLoader).execute();
         Mockito.verifyNoMoreInteractions(onLevelLoader);
         assertEquals(level, api.currentLevel());
     }
@@ -101,7 +102,7 @@ public class TileLevelAPITest {
         api.loadLevel(LevelSize.SMALL);
         verify(generator).level(any(), eq(LevelSize.SMALL));
         Mockito.verifyNoMoreInteractions(generator);
-        verify(onLevelLoader).onLevelLoad();
+        verify(onLevelLoader).execute();
         Mockito.verifyNoMoreInteractions(onLevelLoader);
         assertEquals(level, api.currentLevel());
     }
@@ -179,7 +180,7 @@ public class TileLevelAPITest {
     public void test_setLevel() {
         api.level(level);
         Mockito.verifyNoInteractions(generator);
-        verify(onLevelLoader).onLevelLoad();
+        verify(onLevelLoader).execute();
         Mockito.verifyNoMoreInteractions(onLevelLoader);
         assertEquals(level, api.currentLevel());
     }

--- a/game/test/core/level/TileLevelAPITest.java
+++ b/game/test/core/level/TileLevelAPITest.java
@@ -39,19 +39,16 @@ public class TileLevelAPITest {
 
     private LevelSystem api;
     private IGenerator generator;
-    private Texture texture;
-    private TextureMap textureMap;
     private Painter painter;
-    private SpriteBatch batch;
     private IVoidFunction onLevelLoader;
     private ILevel level;
 
     @Before
     public void setup() {
-        batch = Mockito.mock(SpriteBatch.class);
+        SpriteBatch batch = Mockito.mock(SpriteBatch.class);
 
-        texture = Mockito.mock(Texture.class);
-        textureMap = Mockito.mock(TextureMap.class);
+        Texture texture = Mockito.mock(Texture.class);
+        TextureMap textureMap = Mockito.mock(TextureMap.class);
         PowerMockito.mockStatic(TextureMap.class);
         when(TextureMap.instance()).thenReturn(textureMap);
         when(textureMap.textureAt(anyString())).thenReturn(texture);
@@ -71,7 +68,7 @@ public class TileLevelAPITest {
         Mockito.verifyNoMoreInteractions(generator);
         verify(onLevelLoader).execute();
         Mockito.verifyNoMoreInteractions(onLevelLoader);
-        assertEquals(level, api.currentLevel());
+        assertEquals(level, LevelSystem.currentLevel());
     }
 
     @Test
@@ -82,7 +79,7 @@ public class TileLevelAPITest {
         Mockito.verifyNoMoreInteractions(generator);
         verify(onLevelLoader).execute();
         Mockito.verifyNoMoreInteractions(onLevelLoader);
-        assertEquals(level, api.currentLevel());
+        assertEquals(level, LevelSystem.currentLevel());
     }
 
     @Test
@@ -93,7 +90,7 @@ public class TileLevelAPITest {
         Mockito.verifyNoMoreInteractions(generator);
         verify(onLevelLoader).execute();
         Mockito.verifyNoMoreInteractions(onLevelLoader);
-        assertEquals(level, api.currentLevel());
+        assertEquals(level, LevelSystem.currentLevel());
     }
 
     @Test
@@ -104,7 +101,7 @@ public class TileLevelAPITest {
         Mockito.verifyNoMoreInteractions(generator);
         verify(onLevelLoader).execute();
         Mockito.verifyNoMoreInteractions(onLevelLoader);
-        assertEquals(level, api.currentLevel());
+        assertEquals(level, LevelSystem.currentLevel());
     }
 
     @Test
@@ -150,7 +147,7 @@ public class TileLevelAPITest {
         verify(layout[0][0]).levelElement();
         verify(layout[0][0]).texturePath();
         verify(layout[0][0]).position();
-        // for some reason mocktio.verify can't compare the points of the tile correctly
+        // for some reason mockito.verify can't compare the points of the tile correctly
         verify(painter, times(3))
                 .draw(any(Point.class), any(String.class), any(PainterConfig.class));
         verifyNoMoreInteractions(layout[0][0]);
@@ -158,14 +155,14 @@ public class TileLevelAPITest {
         verify(layout[0][1]).levelElement();
         verify(layout[0][1]).texturePath();
         verify(layout[0][1]).position();
-        // for some reason mocktio.verify can't compare the points of the tile correctly
+        // for some reason mockito.verify can't compare the points of the tile correctly
         verify(painter, times(3))
                 .draw(any(Point.class), any(String.class), any(PainterConfig.class));
         verifyNoMoreInteractions(layout[0][1]);
         verify(layout[1][0]).levelElement();
         verify(layout[1][0]).texturePath();
         verify(layout[1][0]).position();
-        // for some reason mocktio.verify can't compare the points of the tile correctly
+        // for some reason mockito.verify can't compare the points of the tile correctly
         verify(painter, times(3))
                 .draw(any(Point.class), any(String.class), any(PainterConfig.class));
         verifyNoMoreInteractions(layout[1][0]);
@@ -182,6 +179,6 @@ public class TileLevelAPITest {
         Mockito.verifyNoInteractions(generator);
         verify(onLevelLoader).execute();
         Mockito.verifyNoMoreInteractions(onLevelLoader);
-        assertEquals(level, api.currentLevel());
+        assertEquals(level, LevelSystem.currentLevel());
     }
 }

--- a/game/test/core/level/TileLevelAPITest.java
+++ b/game/test/core/level/TileLevelAPITest.java
@@ -57,7 +57,7 @@ public class TileLevelAPITest {
         generator = Mockito.mock(IGenerator.class);
         onLevelLoader = Mockito.mock(IVoidFunction.class);
         level = Mockito.mock(TileLevel.class);
-        api = new LevelSystem(batch, painter, generator, onLevelLoader);
+        api = new LevelSystem(painter, generator, onLevelLoader);
     }
 
     @Test
@@ -139,7 +139,7 @@ public class TileLevelAPITest {
         when(level.layout()).thenReturn(layout);
 
         api.level(level);
-        api.update();
+        api.execute();
 
         verify(level).layout();
         verifyNoMoreInteractions(level);

--- a/game/test/core/level/TileLevelAPITest.java
+++ b/game/test/core/level/TileLevelAPITest.java
@@ -149,7 +149,7 @@ public class TileLevelAPITest {
 
         when(level.layout()).thenReturn(layout);
 
-        api.level(level);
+        api.loadLevel(level);
         api.execute();
 
         verify(level).layout();
@@ -219,7 +219,7 @@ public class TileLevelAPITest {
 
     @Test
     public void test_setLevel() {
-        api.level(level);
+        api.loadLevel(level);
         Mockito.verifyNoInteractions(generator);
         verify(onLevelLoader).execute();
         Mockito.verifyNoMoreInteractions(onLevelLoader);

--- a/game/test/core/level/TileLevelAPITest.java
+++ b/game/test/core/level/TileLevelAPITest.java
@@ -45,7 +45,6 @@ public class TileLevelAPITest {
 
     @Before
     public void setup() {
-        SpriteBatch batch = Mockito.mock(SpriteBatch.class);
 
         Texture texture = Mockito.mock(Texture.class);
         TextureMap textureMap = Mockito.mock(TextureMap.class);

--- a/game/test/core/level/TileLevelAPITest.java
+++ b/game/test/core/level/TileLevelAPITest.java
@@ -12,13 +12,13 @@ import static org.mockito.Mockito.when;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 
-import core.LevelManager;
 import core.level.elements.ILevel;
 import core.level.generator.IGenerator;
 import core.level.utils.Coordinate;
 import core.level.utils.DesignLabel;
 import core.level.utils.LevelElement;
 import core.level.utils.LevelSize;
+import core.systems.LevelSystem;
 import core.utils.Point;
 import core.utils.components.draw.Painter;
 import core.utils.components.draw.PainterConfig;
@@ -36,7 +36,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
 @PrepareForTest({TextureMap.class})
 public class TileLevelAPITest {
 
-    private LevelManager api;
+    private LevelSystem api;
     private IGenerator generator;
     private Texture texture;
     private TextureMap textureMap;
@@ -59,7 +59,7 @@ public class TileLevelAPITest {
         generator = Mockito.mock(IGenerator.class);
         onLevelLoader = Mockito.mock(IOnLevelLoader.class);
         level = Mockito.mock(TileLevel.class);
-        api = new LevelManager(batch, painter, generator, onLevelLoader);
+        api = new LevelSystem(batch, painter, generator, onLevelLoader);
     }
 
     @Test

--- a/game/test/core/systems/CameraSystemTest.java
+++ b/game/test/core/systems/CameraSystemTest.java
@@ -12,6 +12,7 @@ import core.level.Tile;
 import core.level.elements.ILevel;
 import core.utils.Point;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -19,12 +20,11 @@ import org.mockito.Mockito;
 
 public class CameraSystemTest {
 
-    private CameraSystem cameraSystem;
+    private static final Point testPoint = new Point(3, 3);
     private final ILevel level = Mockito.mock(ILevel.class);
     private final Tile startTile = Mockito.mock(Tile.class);
-
+    private CameraSystem cameraSystem;
     private Point expectedFocusPoint;
-    private static final Point testPoint = new Point(3, 3);
 
     @BeforeClass
     public static void initGDX() {
@@ -37,6 +37,13 @@ public class CameraSystemTest {
         Mockito.when(startTile.position()).thenReturn(testPoint);
         Mockito.when(level.randomTilePoint(Mockito.any())).thenReturn(testPoint);
         Mockito.when(level.startTile()).thenReturn(startTile);
+        new LevelSystem(null, null, () -> {});
+    }
+
+    @After
+    public void cleanup() {
+        Game.removeAllEntities();
+        Game.removeAllSystems();
     }
 
     @Test
@@ -49,21 +56,20 @@ public class CameraSystemTest {
         expectedFocusPoint = positionComponent.position();
 
         cameraSystem.execute();
-        assertEquals(expectedFocusPoint.x, cameraSystem.camera().position.x, 0.001);
-        assertEquals(expectedFocusPoint.y, cameraSystem.camera().position.y, 0.001);
+        assertEquals(expectedFocusPoint.x, CameraSystem.camera().position.x, 0.001);
+        assertEquals(expectedFocusPoint.y, CameraSystem.camera().position.y, 0.001);
     }
 
     @Test
     public void executeWithoutEntity() {
-        Game.removeAllEntities();
         Game.currentLevel(level);
 
         expectedFocusPoint = level.startTile().position();
 
         cameraSystem.execute();
 
-        assertEquals(expectedFocusPoint.x, cameraSystem.camera().position.x, 0.001);
-        assertEquals(expectedFocusPoint.y, cameraSystem.camera().position.y, 0.001);
+        assertEquals(expectedFocusPoint.x, CameraSystem.camera().position.x, 0.001);
+        assertEquals(expectedFocusPoint.y, CameraSystem.camera().position.y, 0.001);
     }
 
     @Test
@@ -71,21 +77,21 @@ public class CameraSystemTest {
         Game.currentLevel(null);
         Point expectedFocusPoint = new Point(0, 0);
         cameraSystem.execute();
-        assertEquals(expectedFocusPoint.x, cameraSystem.camera().position.x, 0.001);
-        assertEquals(expectedFocusPoint.y, cameraSystem.camera().position.y, 0.001);
+        assertEquals(expectedFocusPoint.x, CameraSystem.camera().position.x, 0.001);
+        assertEquals(expectedFocusPoint.y, CameraSystem.camera().position.y, 0.001);
     }
 
     @Test
     public void isPointInFrustumWithVisiblePoint() {
         float x = 1.0f;
         float y = 1.0f;
-        assertTrue(cameraSystem.isPointInFrustum(x, y));
+        assertTrue(CameraSystem.isPointInFrustum(x, y));
     }
 
     @Test
     public void isPointInFrustumWithInvisiblePoint() {
         float x = 100.0f;
         float y = 100.0f;
-        assertFalse(cameraSystem.isPointInFrustum(x, y));
+        assertFalse(CameraSystem.isPointInFrustum(x, y));
     }
 }

--- a/game/test/core/systems/VelocitySystemTest.java
+++ b/game/test/core/systems/VelocitySystemTest.java
@@ -14,6 +14,7 @@ import core.level.elements.ILevel;
 import core.utils.Point;
 import core.utils.components.draw.CoreAnimations;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -22,14 +23,13 @@ import java.io.IOException;
 
 public class VelocitySystemTest {
 
-    private VelocitySystem velocitySystem;
     private final ILevel level = Mockito.mock(ILevel.class);
     private final Tile tile = Mockito.mock(Tile.class);
-
     private final float xVelocity = 1f;
     private final float yVelocity = 2f;
     private final float startXPosition = 2f;
     private final float startYPosition = 4f;
+    private VelocitySystem velocitySystem;
     private PositionComponent positionComponent;
     private VelocityComponent velocityComponent;
 
@@ -38,9 +38,9 @@ public class VelocitySystemTest {
 
     @Before
     public void setup() throws IOException {
+        new LevelSystem(null, null, () -> {});
         Game.currentLevel(level);
         Mockito.when(level.tileAt((Point) Mockito.any())).thenReturn(tile);
-        Game.removeEntity(entity);
         entity = new Entity();
         velocitySystem = new VelocitySystem();
         velocityComponent = new VelocityComponent(entity, xVelocity, yVelocity);
@@ -48,6 +48,12 @@ public class VelocitySystemTest {
                 new PositionComponent(entity, new Point(startXPosition, startYPosition));
         animationComponent = new DrawComponent(entity, "character/blue_knight");
         velocitySystem.showEntity(entity);
+    }
+
+    @After
+    public void cleanup() {
+        Game.removeAllEntities();
+        Game.removeAllSystems();
     }
 
     @Test


### PR DESCRIPTION
fixes #762 

Der `LevelManager` wurde durch das `LevelSystem` ersetzt. Die Methoden wurden übernommen und angepasst. Weitere Methoden aus `Game`, die im Zusammenhang mit dem Laden der Level standen, wurden in LevelSystem verschoben.

Außerdem:
- `Game#systems` ist nun eine LinkedHashMap um das Laden der Systeme in einer gewissen Reihenfolge zu garantieren.
    - Als HashMap kam es vor, dass das LevelSystem nach dem DrawSystem geladen wurde und das Level über die Entities gezeichnet wurde.
- 
- Tests innerhlab von `TileLevelAPITest` gefixt und weitere ergänzt
- `setup()` und `cleanup()` zu den Testklassen `ChestTest`, `MonsterTest`, `ControlPointReachableTest`, `CamerSystemTest` und `VelocitySystemTest` hinzugefügt oder ergänzt, da manche Tests sonst fehlschlugen
- Javadoc in der Klasse `LevelSystem` ergänzt