### PR TITLE
[GAME] Entity#toString will return $name_$id if the entity has a name

### DIFF
--- a/game/src/core/Entity.java
+++ b/game/src/core/Entity.java
@@ -47,7 +47,7 @@ public final class Entity {
     public Entity(final String name) {
         id = nextId++;
         components = new HashMap<>();
-        this.name = name;
+        this.name = name + "_" + id;
         Game.addEntity(this);
         LOGGER.info("The entity '" + name + "' was created.");
     }

--- a/game/src/core/Entity.java
+++ b/game/src/core/Entity.java
@@ -47,7 +47,7 @@ public final class Entity {
     public Entity(final String name) {
         id = nextId++;
         components = new HashMap<>();
-        this.name = name + "_" + id;
+        this.name = name;
         Game.addEntity(this);
         LOGGER.info("The entity '" + name + "' was created.");
     }
@@ -127,6 +127,7 @@ public final class Entity {
 
     @Override
     public String toString() {
-        return name;
+        if (name.contains("_" + id)) return name;
+        else return name + "_" + id;
     }
 }


### PR DESCRIPTION
In #652 aufgekommen
- Wenn eine Entität einen expliziten Namen hat, wird in `toString` noch "_${id}" angehangen. 
- Wenn die Entität keinen expliziten  Name hat, dann wird nur `"_${id}`angehangen

Warum wird der explizite Name nicht im Konstruktor um die id ergänzt?
Also `this.name=name+"_"+id`. 
Ich könnte mir vorstellen, dass die `toString` Methoden genutzt wird, um in irgendwelchen Texten den Namen auszugeben.
z.B
`"Hallo "+hero+" meine Name ist "+cagix";` 