### PR TITLE
[DSL] Refactoring von DSLInterpreter tests

### DIFF
--- a/dsl/test/helpers/Helpers.java
+++ b/dsl/test/helpers/Helpers.java
@@ -19,13 +19,11 @@ import semanticanalysis.Scope;
 import semanticanalysis.ScopedSymbol;
 import semanticanalysis.SemanticAnalyzer;
 import semanticanalysis.Symbol;
-import semanticanalysis.types.IType;
 
 import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.util.List;
 
 public class Helpers {
 
@@ -99,23 +97,6 @@ public class Helpers {
         SemanticAnalyzer symbolTableParser = new SemanticAnalyzer();
         symbolTableParser.setup(new GameEnvironment());
         return symbolTableParser.walk(ast);
-    }
-
-    /**
-     * Performs semantic analysis for given AST with loaded types and returns the {@link
-     * SemanticAnalyzer.Result} output from the SymbolTableParser
-     *
-     * @param ast the AST to create the symbol table for
-     * @param types the types to load into the environment before doing semantic analysis
-     * @return the {@link SemanticAnalyzer.Result} of the semantic analysis
-     */
-    public static SemanticAnalyzer.Result getSymtableForASTWithLoadedTypes(
-            parser.ast.Node ast, IType[] types) {
-        var symTableParser = new SemanticAnalyzer();
-        var env = new GameEnvironment();
-        env.loadTypes(List.of(types));
-        symTableParser.setup(env);
-        return symTableParser.walk(ast);
     }
 
     public static void bindDefaultValueInMemorySpace(Symbol symbol, MemorySpace ms) {

--- a/dsl/test/interpreter/TestDSLInterpreter.java
+++ b/dsl/test/interpreter/TestDSLInterpreter.java
@@ -157,22 +157,16 @@ public class TestDSLInterpreter {
             test: print(ret_string())
         }
             """;
-        TestEnvironment env = new TestEnvironment();
-        env.loadFunctions(TestFunctionReturnHelloWorld.func);
-
-        SemanticAnalyzer symbolTableParser = new SemanticAnalyzer();
-        symbolTableParser.setup(env);
-        var ast = Helpers.getASTFromString(program);
-        symbolTableParser.walk(ast);
-
-        DSLInterpreter interpreter = new DSLInterpreter();
-        interpreter.initializeRuntime(env);
 
         // print currently just prints to system.out, so we need to
         // check the contents for the printed string
         var outputStream = new ByteArrayOutputStream();
         System.setOut(new PrintStream(outputStream));
-        interpreter.generateQuestConfig(ast);
+
+        TestEnvironment env = new TestEnvironment();
+        DSLInterpreter interpreter = new DSLInterpreter();
+        Helpers.generateQuestConfigWithCustomFunctions(
+                program, env, interpreter, TestFunctionReturnHelloWorld.func);
 
         assertTrue(outputStream.toString().contains("Hello, World!"));
     }
@@ -188,23 +182,16 @@ public class TestDSLInterpreter {
             quest_config c {
                 test: print(ret_string())
             }
-        """;
-        TestEnvironment env = new TestEnvironment();
-        env.loadFunctions(TestFunctionReturnHelloWorld.func);
-
-        SemanticAnalyzer symbolTableParser = new SemanticAnalyzer();
-        symbolTableParser.setup(env);
-        var ast = Helpers.getASTFromString(program);
-        symbolTableParser.walk(ast);
-
-        DSLInterpreter interpreter = new DSLInterpreter();
-        interpreter.initializeRuntime(env);
-
+            """;
         // print currently just prints to system.out, so we need to
         // check the contents for the printed string
         var outputStream = new ByteArrayOutputStream();
         System.setOut(new PrintStream(outputStream));
-        interpreter.generateQuestConfig(ast);
+
+        TestEnvironment env = new TestEnvironment();
+        DSLInterpreter interpreter = new DSLInterpreter();
+        Helpers.generateQuestConfigWithCustomFunctions(
+                program, env, interpreter, TestFunctionReturnHelloWorld.func);
 
         assertFalse(outputStream.toString().contains("Hello, World!"));
     }
@@ -327,22 +314,11 @@ public class TestDSLInterpreter {
                 }
                 """;
 
-        TypeBuilder tb = new TypeBuilder();
-        var testCompType = tb.createTypeFromClass(new Scope(), TestComponent.class);
-        var otherCompType = tb.createTypeFromClass(new Scope(), OtherComponent.class);
-
         var env = new GameEnvironment();
-        env.loadTypes(testCompType, otherCompType);
+        var interpreter = new DSLInterpreter();
+        Helpers.generateQuestConfigWithCustomTypes(
+                program, env, interpreter, TestComponent.class, OtherComponent.class);
 
-        SemanticAnalyzer symbolTableParser = new SemanticAnalyzer();
-        symbolTableParser.setup(env);
-        var ast = Helpers.getASTFromString(program);
-        symbolTableParser.walk(ast);
-
-        DSLInterpreter interpreter = new DSLInterpreter();
-        interpreter.initializeRuntime(env);
-
-        var questConfig = interpreter.generateQuestConfig(ast);
         var rtEnv = interpreter.getRuntimeEnvironment();
 
         var typeWithDefaults = rtEnv.lookupPrototype("c");
@@ -388,23 +364,18 @@ public class TestDSLInterpreter {
                 }
                 """;
 
-        TypeBuilder tb = new TypeBuilder();
-        var entityType = tb.createTypeFromClass(new Scope(), Entity.class);
-        var testCompType = tb.createTypeFromClass(new Scope(), TestComponent1.class);
-        var otherCompType = tb.createTypeFromClass(new Scope(), TestComponent2.class);
-
         var env = new TestEnvironment();
-        env.loadTypes(entityType, testCompType, otherCompType);
+        var interpreter = new DSLInterpreter();
+        var questConfig =
+                Helpers.generateQuestConfigWithCustomTypes(
+                        program,
+                        env,
+                        interpreter,
+                        Entity.class,
+                        TestComponent1.class,
+                        TestComponent2.class);
 
-        SemanticAnalyzer symbolTableParser = new SemanticAnalyzer();
-        symbolTableParser.setup(env);
-        var ast = Helpers.getASTFromString(program);
-        symbolTableParser.walk(ast);
-
-        DSLInterpreter interpreter = new DSLInterpreter();
-        interpreter.initializeRuntime(env);
-
-        var entity = ((CustomQuestConfig) interpreter.generateQuestConfig(ast)).entity();
+        var entity = ((CustomQuestConfig) questConfig).entity();
         var rtEnv = interpreter.getRuntimeEnvironment();
         var globalMs = interpreter.getGlobalMemorySpace();
 
@@ -462,22 +433,11 @@ public class TestDSLInterpreter {
             }
             """;
 
-        TypeBuilder tb = new TypeBuilder();
-        var entityType = tb.createTypeFromClass(new Scope(), Entity.class);
-        var compType = tb.createTypeFromClass(new Scope(), ComponentWithExternalTypeMember.class);
-
         var env = new TestEnvironment();
-        env.loadTypes(entityType, compType);
-
-        SemanticAnalyzer symbolTableParser = new SemanticAnalyzer();
-        symbolTableParser.setup(env);
-        var ast = Helpers.getASTFromString(program);
-        symbolTableParser.walk(ast);
-
         DSLInterpreter interpreter = new DSLInterpreter();
-        interpreter.initializeRuntime(env);
+        Helpers.generateQuestConfigWithCustomTypes(
+                program, env, interpreter, Entity.class, ComponentWithExternalTypeMember.class);
 
-        interpreter.generateQuestConfig(ast);
         var globalMs = interpreter.getGlobalMemorySpace();
 
         // check, if the component was instantiated and the
@@ -518,26 +478,16 @@ public class TestDSLInterpreter {
 
         // setup test type system
         var env = new TestEnvironment();
-        var entityType = env.getTypeBuilder().createTypeFromClass(new Scope(), Entity.class);
-        var testCompType =
-                env.getTypeBuilder().createTypeFromClass(new Scope(), TestComponent1.class);
-
         env.getTypeBuilder().registerTypeAdapter(ExternalTypeBuilder.class, Scope.NULL);
-        var externalComponentType =
-                env.getTypeBuilder()
-                        .createTypeFromClass(Scope.NULL, TestComponentWithExternalType.class);
-        var externalType = env.getTypeBuilder().createTypeFromClass(Scope.NULL, ExternalType.class);
-        env.loadTypes(entityType, testCompType, externalComponentType, externalType);
-
-        SemanticAnalyzer symbolTableParser = new SemanticAnalyzer();
-        symbolTableParser.setup(env);
-        var ast = Helpers.getASTFromString(program);
-        symbolTableParser.walk(ast);
-
         DSLInterpreter interpreter = new DSLInterpreter();
-        interpreter.initializeRuntime(env);
-
-        interpreter.generateQuestConfig(ast);
+        Helpers.generateQuestConfigWithCustomTypes(
+                program,
+                env,
+                interpreter,
+                Entity.class,
+                TestComponent1.class,
+                TestComponentWithExternalType.class,
+                ExternalType.class);
 
         var globalMs = interpreter.getGlobalMemorySpace();
         AggregateValue config = (AggregateValue) (globalMs.resolve("config"));
@@ -571,26 +521,16 @@ public class TestDSLInterpreter {
 
         // setup test type system
         var env = new TestEnvironment();
-        var entityType = env.getTypeBuilder().createTypeFromClass(new Scope(), Entity.class);
-        var testCompType =
-                env.getTypeBuilder().createTypeFromClass(new Scope(), TestComponent1.class);
-
         env.getTypeBuilder().registerTypeAdapter(ExternalTypeBuilderMultiParam.class, Scope.NULL);
-        var externalComponentType =
-                env.getTypeBuilder()
-                        .createTypeFromClass(Scope.NULL, TestComponentWithExternalType.class);
-        var adapterType = env.getTypeBuilder().createTypeFromClass(Scope.NULL, ExternalType.class);
-        env.loadTypes(entityType, testCompType, externalComponentType, adapterType);
-
-        SemanticAnalyzer symbolTableParser = new SemanticAnalyzer();
-        symbolTableParser.setup(env);
-        var ast = Helpers.getASTFromString(program);
-        symbolTableParser.walk(ast);
-
         DSLInterpreter interpreter = new DSLInterpreter();
-        interpreter.initializeRuntime(env);
-
-        interpreter.generateQuestConfig(ast);
+        Helpers.generateQuestConfigWithCustomTypes(
+                program,
+                env,
+                interpreter,
+                Entity.class,
+                TestComponent1.class,
+                TestComponentWithExternalType.class,
+                ExternalType.class);
 
         var globalMs = interpreter.getGlobalMemorySpace();
         AggregateValue config = (AggregateValue) (globalMs.resolve("config"));


### PR DESCRIPTION
Das folgende Codesnippet taucht häufig in den Tests für den `DSLInterpreter` auf:
``` java 
// Laden von Datentypen
TypeBuilder tb = new TypeBuilder();
var testCompType = tb.createTypeFromClass(new Scope(), TestComponent.class);
var otherCompType = tb.createTypeFromClass(new Scope(), OtherComponent.class);
var env = new GameEnvironment();
env.loadTypes(testCompType, otherCompType);

// Durchführen von Parsing und  semantischer Analyse 
SemanticAnalyzer symbolTableParser = new SemanticAnalyzer();
symbolTableParser.setup(env);
var ast = Helpers.getASTFromString(program);
symbolTableParser.walk(ast);

// Erzeugung der QuestConfig
DSLInterpreter interpreter = new DSLInterpreter();
interpreter.initializeRuntime(env);
var questConfig = interpreter.generateQuestConfig(ast);
```

Ein vergleichbares Snippet findet sich auch für das Laden von Funktionen.

Dieser PR fügt zwei Methoden in `Helpers` hinzu, welche diese Logik kapseln und passt die Testimplementierungen an.