### PR TITLE
[GAME] Fix für AITools.getRandomAccessibleTileCoordinateInRange: IllegalArgumentException: bound must be positive

### DIFF
--- a/game/src/contrib/entities/EntityFactory.java
+++ b/game/src/contrib/entities/EntityFactory.java
@@ -1,7 +1,12 @@
 package contrib.entities;
 
+import static core.level.elements.ITileable.RANDOM;
+
 import contrib.components.*;
 import contrib.configuration.KeyboardConfig;
+import contrib.utils.components.ai.fight.CollideAI;
+import contrib.utils.components.ai.idle.RadiusWalk;
+import contrib.utils.components.ai.transition.RangeTransition;
 import contrib.utils.components.interaction.DropItemsInteraction;
 import contrib.utils.components.interaction.InteractionTool;
 import contrib.utils.components.item.ItemData;
@@ -21,6 +26,8 @@ import core.utils.components.draw.CoreAnimations;
 import java.io.IOException;
 import java.util.List;
 import java.util.Random;
+import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.logging.Logger;
 import java.util.stream.IntStream;
 
@@ -160,5 +167,20 @@ public class EntityFactory {
         dc.getAnimation(CoreAnimations.IDLE_RIGHT).ifPresent(a -> a.setLoop(false));
 
         return chest;
+    }
+
+    public static Entity newMonster() throws IOException {
+        Entity monster = new Entity("monster");
+
+        new PositionComponent(monster);
+        new VelocityComponent(monster, 0.3f, 0.3f);
+        new DrawComponent(monster, "character/monster/imp");
+
+        Consumer<Entity> fightAI = new CollideAI(RANDOM.nextFloat(1.5f));
+        Function<Entity, Boolean> transition = new RangeTransition(RANDOM.nextFloat(2f, 4f));
+        Consumer<Entity> idle = new RadiusWalk(RANDOM.nextFloat(10f), RANDOM.nextInt(2, 4));
+        new AIComponent(monster, fightAI, idle, transition);
+
+        return monster;
     }
 }

--- a/game/src/contrib/utils/components/ai/AITools.java
+++ b/game/src/contrib/utils/components/ai/AITools.java
@@ -72,7 +72,7 @@ public class AITools {
     /**
      * @param center center point
      * @param radius Search radius
-     * @return List of tiles in the given radius arround the center point
+     * @return List of tiles in the given radius around the center point
      */
     public static List<Tile> tilesInRange(final Point center, final float radius) {
         List<Tile> tiles = new ArrayList<>();
@@ -88,7 +88,7 @@ public class AITools {
     /**
      * @param center center point
      * @param radius Search radius
-     * @return List of accessible tiles in the given radius arround the center point
+     * @return List of accessible tiles in the given radius around the center point
      */
     public static List<Tile> accessibleTilesInRange(final Point center, final float radius) {
         List<Tile> tiles = tilesInRange(center, radius);
@@ -101,11 +101,13 @@ public class AITools {
      * @param radius search radius
      * @return random tile in given range
      */
-    public static Coordinate randomAccessibleTileCoordinateInRange(
+    public static Optional<Coordinate> randomAccessibleTileCoordinateInRange(
             final Point center, final float radius) {
-        List<Tile> tiles = accessibleTilesInRange(center, radius);
+        List<Tile> tiles = Collections.emptyList();
+        // List<Tile> tiles = accessibleTilesInRange(center, radius);
+        if (tiles.isEmpty()) return Optional.empty();
         Coordinate newPosition = tiles.get(random.nextInt(tiles.size())).coordinate();
-        return newPosition;
+        return Optional.of(newPosition);
     }
 
     /**
@@ -136,7 +138,8 @@ public class AITools {
      */
     public static GraphPath<Tile> calculatePathToRandomTileInRange(
             final Point point, final float radius) {
-        Coordinate newPosition = randomAccessibleTileCoordinateInRange(point, radius);
+        Coordinate newPosition =
+                randomAccessibleTileCoordinateInRange(point, radius).orElse(point.toCoordinate());
         return calculatePath(point.toCoordinate(), newPosition);
     }
 
@@ -239,8 +242,7 @@ public class AITools {
     public static boolean playerInRange(final Entity entity, final float range) {
 
         Optional<Entity> hero = Game.hero();
-        if (hero.isPresent()) return entityInRange(entity, hero.get(), range);
-        else return false;
+        return hero.filter(value -> entityInRange(entity, value, range)).isPresent();
     }
 
     /**

--- a/game/src/contrib/utils/components/ai/idle/StaticRadiusWalk.java
+++ b/game/src/contrib/utils/components/ai/idle/StaticRadiusWalk.java
@@ -8,6 +8,7 @@ import core.Entity;
 import core.Game;
 import core.components.PositionComponent;
 import core.level.Tile;
+import core.level.utils.Coordinate;
 import core.utils.Point;
 import core.utils.components.MissingComponentException;
 
@@ -57,7 +58,9 @@ public class StaticRadiusWalk implements Consumer<Entity> {
                                                         entity, PositionComponent.class));
                 currentPosition = pc2.position();
                 newEndTile =
-                        AITools.randomAccessibleTileCoordinateInRange(center, radius).toPoint();
+                        AITools.randomAccessibleTileCoordinateInRange(center, radius)
+                                .map(Coordinate::toPoint)
+                                .orElse(center);
                 path = AITools.calculatePath(currentPosition, newEndTile);
                 accept(entity);
             }

--- a/game/src/starter/Main.java
+++ b/game/src/starter/Main.java
@@ -21,6 +21,7 @@ public class Main {
                 () -> {
                     try {
                         EntityFactory.newChest();
+                        EntityFactory.newMonster();
                     } catch (IOException e) {
                         LOGGER.warning("Could not create new Chest: " + e.getMessage());
                         throw new RuntimeException();


### PR DESCRIPTION
fixes #626

- die Methode `AITools#getRandomAccessibleTileCoordinateInRange` hat nun als Rückgabetyp `Optional<Coordinate>`
    - falls die Liste `tiles` leer ist, wird `Optional.empty` zurückgegeben, sonst die Koordinate eines Tiles innerhalb der Range
    - falls `Optional.empty` bei Aufruf der Methode zuückgegeben wird, mit `orElse` sinnvolle Werte gesetzt


TODO
- [ ] `tiles` in `AITools.getRandomAccessibleTileCoordinateInRange` wieder zu keiner leeren Liste machen
- [ ] Monster wieder entfernen