### PR TITLE
[Game] Entity Comparable<Entity> implemented

### DIFF
--- a/game/src/contrib/systems/CollisionSystem.java
+++ b/game/src/contrib/systems/CollisionSystem.java
@@ -51,11 +51,11 @@ public final class CollisionSystem extends System {
      * @return the stream which contains every valid pair of Entities
      */
     private Stream<CollisionData> createDataPairs(Entity a) {
-        return entityStream().filter(b -> isIDSmallerThen(a, b)).map(b -> newDataPair(a, b));
+        return entityStream().filter(b -> isSmallerThen(a, b)).map(b -> newDataPair(a, b));
     }
 
     /**
-     * Compare the id of the given entities.
+     * Compare the entities.
      *
      * <p>This comparison is applied in the {@link #createDataPairs(Entity a) createDataPairs}
      * method to create only tuples with entities with higher ID. This avoids performing a collision
@@ -63,10 +63,10 @@ public final class CollisionSystem extends System {
      *
      * @param a first Entity
      * @param b second Entity
-     * @return true when the id of a is smaller than the one from b, otherwise false
+     * @return true when the comparison between a and b is less than zero, otherwise false
      */
-    private boolean isIDSmallerThen(Entity a, Entity b) {
-        return a.id() < b.id();
+    private boolean isSmallerThen(Entity a, Entity b) {
+        return a.compareTo(b) < 0;
     }
 
     /**

--- a/game/src/core/Entity.java
+++ b/game/src/core/Entity.java
@@ -32,7 +32,7 @@ import java.util.logging.Logger;
  */
 @DSLType(name = "game_object")
 @DSLContextPush(name = "entity")
-public final class Entity {
+public final class Entity implements Comparable<Entity> {
     private static final Logger LOGGER = Logger.getLogger(Entity.class.getName());
     private static int nextId = 0;
     private final int id;
@@ -129,5 +129,10 @@ public final class Entity {
     public String toString() {
         if (name.contains("_" + id)) return name;
         else return name + "_" + id;
+    }
+
+    @Override
+    public int compareTo(Entity o) {
+        return id - o.id;
     }
 }

--- a/game/test/core/EntityTest.java
+++ b/game/test/core/EntityTest.java
@@ -37,19 +37,39 @@ public class EntityTest {
     }
 
     @Test
-    public void compareTo() {
+    public void compareToSameID() {
+        assertEquals(entity.id(), entity.id());
+        assertEquals("Entity with the same id should return a 0. ", 0, entity.compareTo(entity));
+    }
+
+    @Test
+    public void compareToLowerID() {
+        Entity entity1 = new Entity();
+        Entity entity2 = new Entity();
+        assertTrue(
+                "Entity which gets created earlier should have a lower id.",
+                entity1.id() < entity2.id());
+        assertTrue(
+                "Entity which gets created earlier should return negative number.",
+                entity1.compareTo(entity2) < 0);
+    }
+
+    @Test
+    public void compareToHigherID() {
         Entity entity1 = new Entity();
         Entity entity2 = new Entity();
 
-        assertEquals(entity1.id(), entity1.id());
-        assertEquals(0, entity1.compareTo(entity1));
-        assertTrue(entity1.compareTo(entity2) < 0);
-        assertTrue(entity2.compareTo(entity1) > 0);
+        assertTrue(
+                "Entity which gets created later should have a higher id.",
+                entity2.id() > entity1.id());
+        assertTrue(
+                "Entity which gets created later should return a number higher then 0.",
+                entity2.compareTo(entity1) > 0);
     }
 
+    /** Gets called after each @Test and cleans up any Entity left in game. */
     @After
     public void tearDown() {
         Game.removeAllEntities();
-
     }
 }

--- a/game/test/core/EntityTest.java
+++ b/game/test/core/EntityTest.java
@@ -13,8 +13,6 @@ public class EntityTest {
 
     @Before
     public void setup() {
-        // Cleanup
-        Game.removeEntity(entity);
         entity = new Entity();
         entity.addComponent(testComponent);
     }

--- a/game/test/core/EntityTest.java
+++ b/game/test/core/EntityTest.java
@@ -2,6 +2,7 @@ package core;
 
 import static org.junit.Assert.*;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -33,5 +34,22 @@ public class EntityTest {
     public void removeComponent() {
         entity.removeComponent(testComponent.getClass());
         assertTrue(entity.fetch(testComponent.getClass()).isEmpty());
+    }
+
+    @Test
+    public void compareTo() {
+        Entity entity1 = new Entity();
+        Entity entity2 = new Entity();
+
+        assertEquals(entity1.id(), entity1.id());
+        assertEquals(0, entity1.compareTo(entity1));
+        assertTrue(entity1.compareTo(entity2) < 0);
+        assertTrue(entity2.compareTo(entity1) > 0);
+    }
+
+    @After
+    public void tearDown() {
+        Game.removeAllEntities();
+
     }
 }


### PR DESCRIPTION
fixes #754 

- Einfache implementation des Comparable interfaces
- Drei Tests für Kontrolle der Funktionalität
- EntityTest nebeneffekt entfernt (setup räumt auf, aber nicht richtig, dass Delayedset wurde nicht geupdated)
- CollisionSystem isIDsmaller umgebaut, nutzt nun compareTo