### PR TITLE
[GAME] add  component stream getter to `Entity`

### DIFF
--- a/game/src/core/Entity.java
+++ b/game/src/core/Entity.java
@@ -6,6 +6,7 @@ import semanticanalysis.types.DSLType;
 import java.util.HashMap;
 import java.util.Optional;
 import java.util.logging.Logger;
+import java.util.stream.Stream;
 
 /**
  * An Entity is a container for {@link Component}s.
@@ -134,5 +135,23 @@ public final class Entity implements Comparable<Entity> {
     @Override
     public int compareTo(Entity o) {
         return id - o.id;
+    }
+
+    /**
+     * Get a stream of components associated with this entity.
+     *
+     * @return Stream of components.
+     */
+    public Stream<Component> componentValueStream() {
+        return components.values().stream();
+    }
+    /**
+     * Get a stream of component classes where instances of the class are associated with this
+     * entity.
+     *
+     * @return Stream of classes.
+     */
+    public Stream<Class<? extends Component>> componentKeyStream() {
+        return components.keySet().stream();
     }
 }

--- a/game/src/core/Entity.java
+++ b/game/src/core/Entity.java
@@ -76,11 +76,7 @@ public final class Entity implements Comparable<Entity> {
     public void addComponent(final Component component) {
         components.put(component.getClass(), component);
         Game.informAboutChanges(this);
-        LOGGER.info(
-                component.getClass().getName()
-                        + " Components from "
-                        + this.toString()
-                        + " was added.");
+        LOGGER.info(component.getClass().getName() + " Components from " + this + " was added.");
     }
 
     /**
@@ -145,6 +141,7 @@ public final class Entity implements Comparable<Entity> {
     public Stream<Component> componentValueStream() {
         return components.values().stream();
     }
+
     /**
      * Get a stream of component classes where instances of the class are associated with this
      * entity.

--- a/game/src/core/Entity.java
+++ b/game/src/core/Entity.java
@@ -138,17 +138,7 @@ public final class Entity implements Comparable<Entity> {
      *
      * @return Stream of components.
      */
-    public Stream<Component> componentValueStream() {
+    public Stream<Component> componentStream() {
         return components.values().stream();
-    }
-
-    /**
-     * Get a stream of component classes where instances of the class are associated with this
-     * entity.
-     *
-     * @return Stream of classes.
-     */
-    public Stream<Class<? extends Component>> componentKeyStream() {
-        return components.keySet().stream();
     }
 }


### PR DESCRIPTION
fixes #778
 
 - Fügt `Entity#componentValueStream` hinzu, um einen Stream aller Komponenteninstanzen abzurufen, die in der Entität gespeichert sind.
- Fügt `Entity#componentKeyStream` hinzu, um einen Stream von `Class<? extends Component>` abzurufen, wobei jede Klasse Teil des Streams ist, wenn eine Instanz in der Entität gespeichert ist.

