### PR TITLE
[GAME] refactor XPComponent use Consumer<Entity> for level-up callback ( and JavaDoc, Clean Code)

### DIFF
--- a/game/src/contrib/components/XPComponent.java
+++ b/game/src/contrib/components/XPComponent.java
@@ -42,12 +42,12 @@ public final class XPComponent extends Component {
      * {@code LEVEL_1_XP}.
      */
     private static final Function<Long, Long> DEFAULT_LEVEL_UP_FORMULA =
-        level -> Math.round(FORMULA_SLOPE * Math.pow(level, 2) + NEEDED_XP_FOR_LEVEL_ONE);
+            level -> Math.round(FORMULA_SLOPE * Math.pow(level, 2) + NEEDED_XP_FOR_LEVEL_ONE);
 
-    private static final Consumer<Entity> DEFAULT_LEVEL_UP = entity1 -> {
-    };
+    private static final Consumer<Entity> DEFAULT_LEVEL_UP = entity1 -> {};
 
-    private static final Function<XPComponent, Long> DEFAULT_LOOT_XP_FUNCTION = xpComponent -> (long) (xpComponent.currentXP * 0.5f);
+    private static final Function<XPComponent, Long> DEFAULT_LOOT_XP_FUNCTION =
+            xpComponent -> (long) (xpComponent.currentXP * 0.5f);
 
     private Function<XPComponent, Long> lootXPFunction;
     private Function<Long, Long> levelUPFormula;
@@ -55,16 +55,15 @@ public final class XPComponent extends Component {
     private long characterLevel;
     private long currentXP;
 
-
     /**
      * Create a new XPComponent and add it to the associated entity.
      *
      * <p>Useful for entities that should collect XP to level up, such as the player character.
      *
-     * <p>The {@link #lootXPFunction} will always be half of {@link #currentXP}, dynamically adjusting as
+     * <p>The {@link #lootXP()} will always be half of {@link #currentXP}, dynamically adjusting as
      * this component collects more XP.
      *
-     * @param entity  the associated entity
+     * @param entity the associated entity
      * @param levelUp the callback for when the entity levels up
      */
     public XPComponent(final Entity entity, final Consumer<Entity> levelUp) {
@@ -81,7 +80,7 @@ public final class XPComponent extends Component {
      *
      * @param entity the associated entity
      * @param lootXP the amount of XP this entity drops if it dies (requires a {@link
-     *               HealthComponent}). If the value is negativ, XP are taken from the entity that is looting.</p>
+     *     HealthComponent}). If the value is negativ, XP are taken from the entity that is looting.
      */
     public XPComponent(final Entity entity, long lootXP) {
         super(entity);
@@ -179,21 +178,23 @@ public final class XPComponent extends Component {
     }
 
     /**
-     * Set the function to calculate the amount of XP that will be dropped when the associated entity dies.
+     * Set the function to calculate the amount of XP that will be dropped when the associated
+     * entity dies.
      *
-     * @param lootXPFunction Function that gets the {@link XPComponent} of the associated entity and returns the amount of XP to drop as {@link Long}. If the return value is negative, XP is taken from the entity that is looting.
+     * @param lootXPFunction Function that gets the {@link XPComponent} of the associated entity and
+     *     returns the amount of XP to drop as {@link Long}. If the return value is negative, XP is
+     *     taken from the entity that is looting.
      */
     public void lootXP(Function<XPComponent, Long> lootXPFunction) {
         this.lootXPFunction = lootXPFunction;
     }
-
 
     /**
      * Set the function to calculate the amount of XP that is missing to reach the next character
      * level.
      *
      * @param formula The new formula used to calculate the missing XP. (Function<Long, Long> where
-     *                the input is the character level and the output is the XP needed for the next level)
+     *     the input is the character level and the output is the XP needed for the next level)
      */
     public void levelUPFormula(Function<Long, Long> formula) {
         this.levelUPFormula = formula;

--- a/game/src/contrib/components/XPComponent.java
+++ b/game/src/contrib/components/XPComponent.java
@@ -3,126 +3,177 @@ package contrib.components;
 import core.Component;
 import core.Entity;
 
-import java.util.function.LongConsumer;
+import java.util.function.Consumer;
 
-public class XPComponent extends Component {
-
-    private static final double LEVEL_1_XP = 100;
+/**
+ * Allow associated entity to collect Experience Points (XP) and level up if enough XP is collected.
+ *
+ * <p>The component stores the current character level, the amount of XP this entity has collected,
+ * and the amount of XP this entity will drop if it dies. To drop XP, a {@link HealthComponent} is
+ * needed.
+ *
+ * <p>The callback {@link #callbackLevelUp} can be used to trigger specific behavior when the
+ * associated entity reaches a new character level.
+ *
+ * <p>Use {@link #addXP(long)} to gain XP for the component. The {@link
+ * contrib.systems.HealthSystem} will use this to increase the amount of XP in this component if the
+ * associated entity has killed another entity with an {@link XPComponent} by the amount of {@link
+ * #lootXP()} from the killed entity.
+ *
+ * <p>The {@link contrib.systems.XPSystem} will check if the component has collected enough XP to
+ * reach the next level using {@link #xpToNextCharacterLevel()} and will then update the character
+ * level and trigger the {@link #levelUp()} callback function.
+ *
+ * <p>The amount of XP needed for a level up is calculated based on the following formula: {@code
+ * FORMULA_SLOPE * (currentLevel + 1)^2 + LEVEL_1_XP}. It's a quadratic function with a slope of
+ * {@code FORMULA_SLOPE} and a y-intercept of {@code LEVEL_1_XP}.
+ */
+public final class XPComponent extends Component {
+    private static final double NEEDED_XP_FOR_LEVEL_ONE = 100;
     private static final double FORMULA_SLOPE = 0.5;
-    private long currentLevel;
+    private static final Consumer<Entity> DEFAULT_LEVEL_UP = entity1 -> {};
+    private final Consumer<Entity> callbackLevelUp;
+    private long characterLevel;
     private long currentXP;
-    private long lootXP = -1;
-    private LongConsumer callbackLevelUp;
+    private final long lootXP;
 
     /**
-     * Create a new XP-Component and add it to the associated entity
+     * Create a new XPComponent and add it to the associated entity.
      *
-     * @param entity associated entity
+     * @param entity the associated entity
+     * @param levelUp the callback for when the entity levels up
+     * @param lootXP the amount of XP this entity drops if it dies (requires a {@link
+     *     HealthComponent})
      */
-    public XPComponent(Entity entity) {
-        super(entity);
-    }
-
-    /**
-     * Create a new XP-Component and add it to the associated entity
-     *
-     * @param entity associated entity
-     * @param levelUp callback for when the entity levels up
-     */
-    public XPComponent(Entity entity, LongConsumer levelUp, int lootXP) {
+    public XPComponent(final Entity entity, final Consumer<Entity> levelUp, int lootXP) {
         super(entity);
         this.callbackLevelUp = levelUp;
         this.lootXP = lootXP;
     }
 
-    public XPComponent(Entity entity, LongConsumer levelUp) {
-        super(entity);
-        this.callbackLevelUp = levelUp;
-    }
-
     /**
-     * Get the current level of the entity
+     * Create a new XPComponent and add it to the associated entity.
      *
-     * @return current level
+     * <p>Useful for entities that should collect XP to level up, such as the player character.
+     *
+     * <p>The {@link #lootXP} will always be half of {@link #currentXP}, dynamically adjusting as
+     * this component collects more XP.
+     *
+     * @param entity the associated entity
+     * @param levelUp the callback for when the entity levels up
      */
-    public long currentLevel() {
-        return currentLevel;
+    public XPComponent(final Entity entity, final Consumer<Entity> levelUp) {
+        this(entity, levelUp, -1);
     }
 
     /**
-     * Set the current level of the entity
+     * Create a new XPComponent with an empty level-up callback and add it to the associated entity.
      *
-     * @param currentLevel current level
+     * <p>Useful for entities that should only give XP and not gain XP themselves, such as monsters.
+     *
+     * @param entity the associated entity
+     * @param lootXP the amount of XP this entity drops if it dies (requires a {@link
+     *     HealthComponent})
      */
-    public void currentLevel(long currentLevel) {
-        this.currentLevel = currentLevel;
+    public XPComponent(final Entity entity, int lootXP) {
+        this(entity, DEFAULT_LEVEL_UP, lootXP);
     }
 
     /**
-     * Add xp to the entity. Adding negative xp will decrease the current xp. The minimum xp of an
-     * entity is 0.
+     * Create a new XPComponent with an empty level-up callback and add it to the associated entity.
      *
-     * @param xp xp to add
+     * <p>The {@link #lootXP} will always be half of {@link #currentXP}, dynamically adjusting as
+     * this entity collects more XP.
+     *
+     * @param entity the associated entity
+     */
+    public XPComponent(final Entity entity) {
+        this(entity, DEFAULT_LEVEL_UP);
+    }
+
+    /**
+     * Get the current character level of the associated entity.
+     *
+     * @return the current character level
+     */
+    public long characterLevel() {
+        return characterLevel;
+    }
+
+    /**
+     * Set the current character level of the associated entity.
+     *
+     * @param currentLevel the character level to set
+     */
+    public void characterLevel(long currentLevel) {
+        this.characterLevel = currentLevel;
+    }
+
+    /**
+     * Add XP to the associated entity.
+     *
+     * <p>Adding negative XP will decrease the current XP. The minimum XP of an entity is 0.
+     *
+     * <p>This method will only update the XP value and will not check if a new character level is
+     * reached.
+     *
+     * @param xp the amount of XP to add to this entity
      */
     public void addXP(long xp) {
         this.currentXP = Math.max(0, currentXP + xp);
     }
 
     /**
-     * Get the current xp of the entity
+     * Get the current XP of the associated entity.
      *
-     * @return current xp
+     * @return the current XP of the associated entity
      */
     public long currentXP() {
         return currentXP;
     }
 
     /**
-     * Set the current xp of the entity
+     * Set the current XP of the associated entity.
      *
-     * @param currentXP current xp
+     * <p>This method will only update the XP value and will not check if a new character level is
+     * reached.
+     *
+     * @param currentXP the value to set the current XP to
      */
     public void currentXP(long currentXP) {
         this.currentXP = currentXP;
     }
 
-    /**
-     * Trigger the level up callback
-     *
-     * @param level new level
-     */
-    public void levelUp(long level) {
-        if (this.callbackLevelUp != null) this.callbackLevelUp.accept(level);
+    /** Trigger the level-up callback function. */
+    public void levelUp() {
+        callbackLevelUp.accept(entity);
     }
 
     /**
-     * Get the amount of xp that will be dropped when the entity dies. If no value is set, the xp
-     * will be set to half of the current xp
+     * Get the amount of XP that will be dropped when the associated entity dies.
      *
-     * @return xp that will be dropped
+     * <p>If no value is set, the dropped XP will be set to half of the current XP.
+     *
+     * <p>XP can only be dropped on death if the associated entity has a {@link HealthComponent}.
+     *
+     * @return the XP that will be dropped
      */
     public long lootXP() {
         return lootXP == -1 ? currentXP / 2 : lootXP;
     }
 
     /**
-     * Set the amount of xp that will be dropped when the entity dies. Set to -1 to use the default.
+     * Calculate the amount of XP needed to reach the next character level.
      *
-     * @param lootXP xp that will be dropped
-     */
-    public void lootXP(long lootXP) {
-        this.lootXP = lootXP;
-    }
-
-    /**
-     * Calculate xp left to next level. XP are calculated based on the following formula: {@code
-     * FORMULA_SLOPE * (currentLevel + 1)^2 + LEVEL_1_XP} It's a quadratic function with a slope of
-     * {@code FORMULAR_SLOPE} and a y-intercept of {@code LEVEL_1_XP}
+     * <p>XP is calculated based on the following formula: {@code FORMULA_SLOPE * (currentLevel +
+     * 1)^2 + LEVEL_1_XP}. It's a quadratic function with a slope of {@code FORMULA_SLOPE} and a
+     * y-intercept of {@code LEVEL_1_XP}.
      *
-     * @return xp left to next level
+     * @return the amount of XP left to reach the next character level
      */
-    public long xpToNextLevel() {
-        // level 0 in Formula is level 1 in game.
-        return Math.round(FORMULA_SLOPE * Math.pow(currentLevel, 2) + LEVEL_1_XP) - currentXP;
+    public long xpToNextCharacterLevel() {
+        // character level 0 in Formula is character level 1 in game.
+        return Math.round(FORMULA_SLOPE * Math.pow(characterLevel, 2) + NEEDED_XP_FOR_LEVEL_ONE)
+                - currentXP;
     }
 }

--- a/game/src/contrib/components/XPComponent.java
+++ b/game/src/contrib/components/XPComponent.java
@@ -4,13 +4,15 @@ import core.Component;
 import core.Entity;
 
 import java.util.function.Consumer;
+import java.util.function.Function;
 
 /**
- * Allow associated entity to collect Experience Points (XP) and level up if enough XP is collected.
+ * Allow the associated entity to collect experience points (XP) and level up if enough XP is
+ * collected
  *
  * <p>The component stores the current character level, the amount of XP this entity has collected,
  * and the amount of XP this entity will drop if it dies. To drop XP, a {@link HealthComponent} is
- * needed.
+ * needed. The collected XP will not be set to zero after a level up was performed.
  *
  * <p>The callback {@link #callbackLevelUp} can be used to trigger specific behavior when the
  * associated entity reaches a new character level.
@@ -22,20 +24,39 @@ import java.util.function.Consumer;
  *
  * <p>The {@link contrib.systems.XPSystem} will check if the component has collected enough XP to
  * reach the next level using {@link #xpToNextCharacterLevel()} and will then update the character
- * level and trigger the {@link #levelUp()} callback function.
+ * level and trigger the {@link #triggerLevelUpCallback()} callback function.
  *
- * <p>The amount of XP needed for a level up is calculated based on the following formula: {@code
- * FORMULA_SLOPE * (currentLevel + 1)^2 + LEVEL_1_XP}. It's a quadratic function with a slope of
- * {@code FORMULA_SLOPE} and a y-intercept of {@code LEVEL_1_XP}.
+ * <p>The XP needed for the next level is calculated using a formula. You can set your own formula
+ * with {@link #levelUPFormula(Function)}. The default formula uses a quadratic function, resulting
+ * in each level requiring more XP than the previous one.
  */
 public final class XPComponent extends Component {
+
     private static final double NEEDED_XP_FOR_LEVEL_ONE = 100;
     private static final double FORMULA_SLOPE = 0.5;
+    /**
+     * XP is calculated based on the following formula: {@code FORMULA_SLOPE * (currentLevel + 1)^2
+     * + LEVEL_1_XP}.
+     *
+     * <p>It's a quadratic function with a slope of {@code FORMULA_SLOPE} and a y-intercept of
+     * {@code LEVEL_1_XP}.
+     */
+    private static final Function<Long, Long> DEFAULT_LEVEL_UP_FORMULA =
+            new Function<Long, Long>() {
+                @Override
+                public Long apply(Long level) {
+                    return Math.round(FORMULA_SLOPE * Math.pow(level, 2) + NEEDED_XP_FOR_LEVEL_ONE);
+                }
+            };
+
+    private static final float DEFAULT_LOOT_FACTOR = 0.5f;
     private static final Consumer<Entity> DEFAULT_LEVEL_UP = entity1 -> {};
     private final Consumer<Entity> callbackLevelUp;
+    private final long lootXP;
+    private final float lootFactor;
     private long characterLevel;
     private long currentXP;
-    private final long lootXP;
+    private Function<Long, Long> levelUPFormula;
 
     /**
      * Create a new XPComponent and add it to the associated entity.
@@ -49,6 +70,24 @@ public final class XPComponent extends Component {
         super(entity);
         this.callbackLevelUp = levelUp;
         this.lootXP = lootXP;
+        lootFactor = DEFAULT_LOOT_FACTOR;
+        levelUPFormula = DEFAULT_LEVEL_UP_FORMULA;
+    }
+
+    /**
+     * Create a new XPComponent and add it to the associated entity.
+     *
+     * @param entity the associated entity
+     * @param levelUp the callback for when the entity levels up
+     * @param lootFactor The {@link #lootXP} will always be {@link #currentXP} multiplied with the
+     *     given factor, dynamically adjusting as this component collects more XP.
+     */
+    public XPComponent(final Entity entity, final Consumer<Entity> levelUp, float lootFactor) {
+        super(entity);
+        this.callbackLevelUp = levelUp;
+        this.lootXP = -1;
+        this.lootFactor = lootFactor;
+        levelUPFormula = DEFAULT_LEVEL_UP_FORMULA;
     }
 
     /**
@@ -77,6 +116,19 @@ public final class XPComponent extends Component {
      */
     public XPComponent(final Entity entity, int lootXP) {
         this(entity, DEFAULT_LEVEL_UP, lootXP);
+    }
+
+    /**
+     * Create a new XPComponent with an empty level-up callback and add it to the associated entity.
+     *
+     * <p>Useful for entities that should only give XP and not gain XP themselves, such as monsters.
+     *
+     * @param entity the associated entity
+     * @param lootFactor The {@link #lootXP} will always be {@link #currentXP} multiplied with the
+     *     given factor, dynamically adjusting as this component collects more XP.
+     */
+    public XPComponent(final Entity entity, float lootFactor) {
+        this(entity, DEFAULT_LEVEL_UP, lootFactor);
     }
 
     /**
@@ -145,35 +197,42 @@ public final class XPComponent extends Component {
     }
 
     /** Trigger the level-up callback function. */
-    public void levelUp() {
+    public void triggerLevelUpCallback() {
         callbackLevelUp.accept(entity);
     }
 
     /**
      * Get the amount of XP that will be dropped when the associated entity dies.
      *
-     * <p>If no value is set, the dropped XP will be set to half of the current XP.
+     * <p>If no value is set, the dropped XP will be the current XP multiplied with the loot-factor.
+     *
+     * <p>If no factor is set, the dropped XP will be set to half of the current XP.
      *
      * <p>XP can only be dropped on death if the associated entity has a {@link HealthComponent}.
      *
      * @return the XP that will be dropped
      */
     public long lootXP() {
-        return lootXP == -1 ? currentXP / 2 : lootXP;
+        return lootXP == -1 ? (long) (currentXP * lootFactor) : lootXP;
+    }
+
+    /**
+     * Set the function to calculate the amount of XP that is missing to reach the next character
+     * level.
+     *
+     * @param formula The new formula used to calculate the missing XP. (Function<Long, Long> where
+     *     the input is the character level and the output is the XP needed for the next level)
+     */
+    public void levelUPFormula(Function<Long, Long> formula) {
+        this.levelUPFormula = formula;
     }
 
     /**
      * Calculate the amount of XP needed to reach the next character level.
      *
-     * <p>XP is calculated based on the following formula: {@code FORMULA_SLOPE * (currentLevel +
-     * 1)^2 + LEVEL_1_XP}. It's a quadratic function with a slope of {@code FORMULA_SLOPE} and a
-     * y-intercept of {@code LEVEL_1_XP}.
-     *
      * @return the amount of XP left to reach the next character level
      */
     public long xpToNextCharacterLevel() {
-        // character level 0 in Formula is character level 1 in game.
-        return Math.round(FORMULA_SLOPE * Math.pow(characterLevel, 2) + NEEDED_XP_FOR_LEVEL_ONE)
-                - currentXP;
+        return levelUPFormula.apply(characterLevel) - currentXP;
     }
 }

--- a/game/src/contrib/components/XPComponent.java
+++ b/game/src/contrib/components/XPComponent.java
@@ -42,12 +42,7 @@ public final class XPComponent extends Component {
      * {@code LEVEL_1_XP}.
      */
     private static final Function<Long, Long> DEFAULT_LEVEL_UP_FORMULA =
-            new Function<Long, Long>() {
-                @Override
-                public Long apply(Long level) {
-                    return Math.round(FORMULA_SLOPE * Math.pow(level, 2) + NEEDED_XP_FOR_LEVEL_ONE);
-                }
-            };
+            level -> Math.round(FORMULA_SLOPE * Math.pow(level, 2) + NEEDED_XP_FOR_LEVEL_ONE);
 
     private static final float DEFAULT_LOOT_FACTOR = 0.5f;
     private static final Consumer<Entity> DEFAULT_LEVEL_UP = entity1 -> {};

--- a/game/src/contrib/systems/XPSystem.java
+++ b/game/src/contrib/systems/XPSystem.java
@@ -38,6 +38,6 @@ public final class XPSystem extends System {
     private void performLevelUp(XPComponent comp, int xpLeft) {
         comp.characterLevel(comp.characterLevel() + 1);
         comp.currentXP(xpLeft * -1);
-        comp.triggerLevelUpCallback();
+        comp.levelUp().accept(comp.entity());
     }
 }

--- a/game/src/contrib/systems/XPSystem.java
+++ b/game/src/contrib/systems/XPSystem.java
@@ -38,6 +38,6 @@ public final class XPSystem extends System {
     private void performLevelUp(XPComponent comp, int xpLeft) {
         comp.characterLevel(comp.characterLevel() + 1);
         comp.currentXP(xpLeft * -1);
-        comp.levelUp();
+        comp.triggerLevelUpCallback();
     }
 }

--- a/game/src/contrib/systems/XPSystem.java
+++ b/game/src/contrib/systems/XPSystem.java
@@ -22,7 +22,7 @@ public final class XPSystem extends System {
                 entity.fetch(XPComponent.class)
                         .orElseThrow(() -> MissingComponentException.build(entity, XPSystem.class));
         long xpLeft;
-        while ((xpLeft = comp.xpToNextLevel()) <= 0) {
+        while ((xpLeft = comp.xpToNextCharacterLevel()) <= 0) {
             this.performLevelUp(comp, (int) xpLeft);
         }
     }
@@ -36,8 +36,8 @@ public final class XPSystem extends System {
      * @param xpLeft XP left to level up (can be negative if greater the needed amount)
      */
     private void performLevelUp(XPComponent comp, int xpLeft) {
-        comp.currentLevel(comp.currentLevel() + 1);
+        comp.characterLevel(comp.characterLevel() + 1);
         comp.currentXP(xpLeft * -1);
-        comp.levelUp(comp.currentLevel());
+        comp.levelUp();
     }
 }

--- a/game/test/contrib/components/XPComponentTest.java
+++ b/game/test/contrib/components/XPComponentTest.java
@@ -19,7 +19,7 @@ public class XPComponentTest {
 
         /* Test */
         assertEquals(0, xpComponent.currentXP());
-        assertEquals(0, xpComponent.currentLevel());
+        assertEquals(0, xpComponent.characterLevel());
     }
 
     /** Test if xp is added correctly. */
@@ -59,7 +59,7 @@ public class XPComponentTest {
 
         /* Test */
         xpComponent.addXP(10);
-        assertEquals(90, xpComponent.xpToNextLevel());
+        assertEquals(90, xpComponent.xpToNextCharacterLevel());
     }
 
     /** Tests if getXPToNextLevel() returns correct value if enough xp is added. */
@@ -72,7 +72,7 @@ public class XPComponentTest {
 
         /* Test */
         xpComponent.addXP(100);
-        assertEquals(0, xpComponent.xpToNextLevel());
+        assertEquals(0, xpComponent.xpToNextCharacterLevel());
     }
 
     /** Tests if getXPToNextLevel() returns correct value. If more xp is added than needed. */
@@ -85,6 +85,6 @@ public class XPComponentTest {
 
         /* Test */
         xpComponent.addXP(120);
-        assertEquals(-20, xpComponent.xpToNextLevel());
+        assertEquals(-20, xpComponent.xpToNextCharacterLevel());
     }
 }

--- a/game/test/contrib/systems/XPSystemTest.java
+++ b/game/test/contrib/systems/XPSystemTest.java
@@ -10,7 +10,7 @@ import core.Game;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-import java.util.function.LongConsumer;
+import java.util.function.Consumer;
 
 public class XPSystemTest {
 
@@ -21,15 +21,15 @@ public class XPSystemTest {
         Game.removeAllEntities();
 
         Entity entity = new Entity();
-        LongConsumer levelUp = Mockito.mock(LongConsumer.class);
+        Consumer<Entity> levelUp = Mockito.mock(Consumer.class);
         XPComponent xpComponent = new XPComponent(entity, levelUp);
         XPSystem xpSystem = new XPSystem();
         xpSystem.showEntity(entity);
         assertEquals(0, xpComponent.currentXP());
-        assertEquals(0, xpComponent.currentLevel());
+        assertEquals(0, xpComponent.characterLevel());
         xpSystem.execute();
         assertEquals(0, xpComponent.currentXP());
-        assertEquals(0, xpComponent.currentLevel());
+        assertEquals(0, xpComponent.characterLevel());
     }
 
     /** Test if level up is not triggered if the xp is not enough. */
@@ -39,14 +39,14 @@ public class XPSystemTest {
         Game.removeAllEntities();
         Entity entity = new Entity();
 
-        LongConsumer levelUp = Mockito.mock(LongConsumer.class);
+        Consumer<Entity> levelUp = Mockito.mock(Consumer.class);
         XPComponent xpComponent = new XPComponent(entity, levelUp);
         XPSystem xpSystem = new XPSystem();
         xpSystem.showEntity(entity);
         /* Test */
         xpComponent.addXP(99); // First level is reached with 100 XP
         xpSystem.execute();
-        assertEquals(0, xpComponent.currentLevel());
+        assertEquals(0, xpComponent.characterLevel());
     }
 
     /** Test if level up is triggered if the xp is exact the needed amount. */
@@ -56,7 +56,7 @@ public class XPSystemTest {
         Game.removeAllEntities();
         Entity entity = new Entity();
 
-        LongConsumer levelUp = Mockito.mock(LongConsumer.class);
+        Consumer<Entity> levelUp = Mockito.mock(Consumer.class);
         XPComponent xpComponent = new XPComponent(entity, levelUp);
         XPSystem xpSystem = new XPSystem();
         xpSystem.showEntity(entity);
@@ -64,7 +64,7 @@ public class XPSystemTest {
         xpComponent.addXP(100); // First level is reached with 100 XP
 
         xpSystem.execute();
-        assertEquals(1, xpComponent.currentLevel());
+        assertEquals(1, xpComponent.characterLevel());
         assertEquals(0, xpComponent.currentXP());
     }
 
@@ -75,14 +75,14 @@ public class XPSystemTest {
         Game.removeAllEntities();
         Entity entity = new Entity();
 
-        LongConsumer levelUp = Mockito.mock(LongConsumer.class);
+        Consumer<Entity> levelUp = Mockito.mock(Consumer.class);
         XPComponent xpComponent = new XPComponent(entity, levelUp);
         XPSystem xpSystem = new XPSystem();
         xpSystem.showEntity(entity);
         /* Test */
         xpComponent.addXP(120); // First level is reached with 100 XP
         xpSystem.execute();
-        assertEquals(1, xpComponent.currentLevel());
+        assertEquals(1, xpComponent.characterLevel());
         assertEquals(20, xpComponent.currentXP());
     }
 
@@ -96,7 +96,7 @@ public class XPSystemTest {
         Game.removeAllEntities();
         Entity entity = new Entity();
 
-        LongConsumer levelUp = Mockito.mock(LongConsumer.class);
+        Consumer<Entity> levelUp = Mockito.mock(Consumer.class);
         XPComponent xpComponent = new XPComponent(entity, levelUp);
         XPSystem xpSystem = new XPSystem();
         xpSystem.showEntity(entity);
@@ -105,7 +105,7 @@ public class XPSystemTest {
         xpSystem.showEntity(entity);
 
         xpSystem.execute();
-        assertEquals(2, xpComponent.currentLevel());
+        assertEquals(2, xpComponent.characterLevel());
         assertEquals(0, xpComponent.currentXP());
     }
 
@@ -119,7 +119,7 @@ public class XPSystemTest {
         Game.removeAllEntities();
         Entity entity = new Entity();
 
-        LongConsumer levelUp = Mockito.mock(LongConsumer.class);
+        Consumer<Entity> levelUp = Mockito.mock(Consumer.class);
         XPComponent xpComponent = new XPComponent(entity, levelUp);
         XPSystem xpSystem = new XPSystem();
         xpSystem.showEntity(entity);
@@ -127,7 +127,7 @@ public class XPSystemTest {
 
         xpComponent.addXP(221);
         xpSystem.execute();
-        assertEquals(2, xpComponent.currentLevel());
+        assertEquals(2, xpComponent.characterLevel());
         assertEquals(20, xpComponent.currentXP());
     }
 
@@ -138,7 +138,7 @@ public class XPSystemTest {
         Game.removeAllEntities();
         Entity entity = new Entity();
 
-        LongConsumer levelUp = Mockito.mock(LongConsumer.class);
+        Consumer<Entity> levelUp = Mockito.mock(Consumer.class);
         XPComponent xpComponent = new XPComponent(entity, levelUp);
         XPSystem xpSystem = new XPSystem();
         xpSystem.showEntity(entity);


### PR DESCRIPTION
In diesem Pull-Request wurde das `XPComponent` refactored.

Dieser Pull-Request zielt darauf ab, sicherzustellen, dass die Qualität der JavaDoc zu verbessern und Clean Code sowie Java Konventionen umzusetzen. 

Außerdem:
Es gab einen konzeptionellen Fehler im Callback für ein Level-Up. Früher war es ein `LongConsumer`, was einfach ein `Consumer<Long>` ist. Beim Aufruf wurde dann das aktuelle Character-Level übergeben.
Die Callback-Funktion wusste dann zwar, welches Level die Entität erreicht hatte, kannte aber nicht die Entität selbst. Das Problem wurde behoben, indem jetzt (analog zu allen anderen Callbacks) ein `Consumer<Entity>` verwendet wird.
Dann kann die Callback-Methode über die Entität die gewünschten Komponenten (z. B. das XPComponent) und gewünschte Werte (z. B. das aktuelle Level) heraussuchen.

Die Tests wurden entsprechend angepasst.


Dieser Pull-Request nimmt keine Änderungen am Logging (#683) oder an der Testabdeckung vor. 