### PR TITLE
[GAME] refactor StatsComponent better api ( and JavaDoc, Clean Code)

### DIFF
--- a/game/src/contrib/components/StatsComponent.java
+++ b/game/src/contrib/components/StatsComponent.java
@@ -11,10 +11,10 @@ import core.Entity;
  * the associated entity.
  *
  * <p>To set resistances and vulnerabilities for a damage type, use {@link #multiplier(DamageType,
- * float)}. For resistances, use a float less than 1, for vulnerabilities use a float greater than
- * 1.
+ * float)}. For resistances, use values less than 1.0, for vulnerabilities use values greater than
+ * 1.0.
  *
- * <p>The modifier values are taken into account by the {@link contrib.systems.HealthSystem} when
+ * <p>The modifier values are taken into account as multiplier by the {@link contrib.systems.HealthSystem} when
  * calculating damage, allowing for defining resistances and vulnerabilities for different damage
  * types.
  *
@@ -37,7 +37,7 @@ public final class StatsComponent extends Component {
      * Get multiplier for a given damage type
      *
      * @param type damage type
-     * @return multiplier (1 is default, values greater than 1 increase damage, values less than 1
+     * @return multiplier (1.0 is default, values greater than 1.0 increase damage, values less than 1.0
      *     decrease damage)
      */
     public float multiplierFor(final DamageType type) {

--- a/game/src/contrib/components/StatsComponent.java
+++ b/game/src/contrib/components/StatsComponent.java
@@ -1,38 +1,56 @@
 package contrib.components;
 
+import contrib.utils.components.health.DamageType;
 import contrib.utils.components.stats.DamageModifier;
-
 import core.Component;
 import core.Entity;
 
-public class StatsComponent extends Component {
+/**
+ * Add resistances and vulnerabilities for {@link contrib.utils.components.health.DamageType}s to
+ * the associated entity.
+ *
+ * <p>To set resistances and vulnerabilities for a damage type, use {@link #multiplier(DamageType,
+ * float)}. For resistances, use a float less than 1, for vulnerabilities use a float greater than
+ * 1.
+ *
+ * <p>The modifier values are taken into account by the {@link contrib.systems.HealthSystem} when
+ * calculating damage, allowing for defining resistances and vulnerabilities for different damage
+ * types.
+ *
+ * @see contrib.utils.components.stats.DamageModifier
+ */
+public final class StatsComponent extends Component {
 
-    private DamageModifier damageModifier = new DamageModifier();
+    private final DamageModifier damageModifier = new DamageModifier();
 
     /**
-     * Create a new component and add it to the associated entity
+     * Create a new component and add it to the associated entity.
      *
      * @param entity associated entity
      */
-    public StatsComponent(Entity entity) {
+    public StatsComponent(final Entity entity) {
         super(entity);
     }
 
     /**
-     * Get the DamageModifier object of the entity
+     * Get multiplier for a given damage type
      *
-     * @return {@link DamageModifier} object
+     * @param type damage type
+     * @return multiplier (1 is default, values greater than 1 increase damage, values less than 1
+     * decrease damage)
      */
-    public DamageModifier damageModifiers() {
-        return this.damageModifier;
+    public float multiplierFor(DamageType type) {
+        return damageModifier.multiplierFor(type);
     }
 
     /**
-     * Overwrite the DamageModifier object of the entity
+     * Set multiplier for a given damage type
      *
-     * @param damageModifier new {@link DamageModifier} object
+     * @param type       damage type
+     * @param multiplier multiplier (1 is default, values greater than 1 increase damage, values
+     *                   less than 1 decrease damage)
      */
-    public void damageModifier(DamageModifier damageModifier) {
-        this.damageModifier = damageModifier;
+    public void multiplier(DamageType type, float multiplier) {
+        damageModifier.setMultiplier(type, multiplier);
     }
 }

--- a/game/src/contrib/components/StatsComponent.java
+++ b/game/src/contrib/components/StatsComponent.java
@@ -11,14 +11,13 @@ import core.Entity;
  * the associated entity.
  *
  * <p>Resistances refer to the ability of an entity to mitigate or reduce the damage taken from
- * specific {@link DamageType}.
- *
- * <p>Vulnerabilities indicate specific weaknesses of an entity, making them more susceptible to
- * increased damage or negative effects from certain {@link DamageType}.
+ * specific {@link DamageType}. Vulnerabilities indicate specific weaknesses of an entity, making
+ * them more susceptible to increased damage or negative effects from certain {@link DamageType}.
  *
  * <p>To set resistances and vulnerabilities for a damage type, use {@link #multiplier(DamageType,
  * float)}. For resistances, use values less than 1.0, for vulnerabilities use values greater than
- * 1.0.
+ * 1.0. If you use a value less than 0.0f, the damage will become negative, resulting in healing the
+ * entity.
  *
  * <p>The modifier values are taken into account as multiplier by the {@link
  * contrib.systems.HealthSystem} when calculating damage, allowing for defining resistances and
@@ -46,7 +45,7 @@ public final class StatsComponent extends Component {
      *
      * @param type damage type
      * @return multiplier (1.0 is default, values greater than 1.0 increase damage, values less than
-     *     1.0 decrease damage)
+     *     1.0 decrease damage, value less than 0.0 will make the damage to a heal)
      */
     public float multiplierFor(final DamageType type) {
         return damageModifier.multiplierFor(type);
@@ -57,7 +56,7 @@ public final class StatsComponent extends Component {
      *
      * @param type damage type
      * @param multiplier multiplier (1 is default, values greater than 1 increase damage, values
-     *     less than 1 decrease damage)
+     *     less than 1 decrease damage, value less than 0.0 will make the damage to a heal)
      */
     public void multiplier(final DamageType type, float multiplier) {
         damageModifier.setMultiplier(type, multiplier);

--- a/game/src/contrib/components/StatsComponent.java
+++ b/game/src/contrib/components/StatsComponent.java
@@ -2,6 +2,7 @@ package contrib.components;
 
 import contrib.utils.components.health.DamageType;
 import contrib.utils.components.stats.DamageModifier;
+
 import core.Component;
 import core.Entity;
 
@@ -37,20 +38,20 @@ public final class StatsComponent extends Component {
      *
      * @param type damage type
      * @return multiplier (1 is default, values greater than 1 increase damage, values less than 1
-     * decrease damage)
+     *     decrease damage)
      */
-    public float multiplierFor(DamageType type) {
+    public float multiplierFor(final DamageType type) {
         return damageModifier.multiplierFor(type);
     }
 
     /**
      * Set multiplier for a given damage type
      *
-     * @param type       damage type
+     * @param type damage type
      * @param multiplier multiplier (1 is default, values greater than 1 increase damage, values
-     *                   less than 1 decrease damage)
+     *     less than 1 decrease damage)
      */
-    public void multiplier(DamageType type, float multiplier) {
+    public void multiplier(final DamageType type, float multiplier) {
         damageModifier.setMultiplier(type, multiplier);
     }
 }

--- a/game/src/contrib/components/StatsComponent.java
+++ b/game/src/contrib/components/StatsComponent.java
@@ -10,13 +10,19 @@ import core.Entity;
  * Add resistances and vulnerabilities for {@link contrib.utils.components.health.DamageType}s to
  * the associated entity.
  *
+ * <p>Resistances refer to the ability of an entity to mitigate or reduce the damage taken from
+ * specific {@link DamageType}.
+ *
+ * <p>Vulnerabilities indicate specific weaknesses of an entity, making them more susceptible to
+ * increased damage or negative effects from certain {@link DamageType}.
+ *
  * <p>To set resistances and vulnerabilities for a damage type, use {@link #multiplier(DamageType,
  * float)}. For resistances, use values less than 1.0, for vulnerabilities use values greater than
  * 1.0.
  *
- * <p>The modifier values are taken into account as multiplier by the {@link contrib.systems.HealthSystem} when
- * calculating damage, allowing for defining resistances and vulnerabilities for different damage
- * types.
+ * <p>The modifier values are taken into account as multiplier by the {@link
+ * contrib.systems.HealthSystem} when calculating damage, allowing for defining resistances and
+ * vulnerabilities for different damage types.
  *
  * @see contrib.utils.components.stats.DamageModifier
  */
@@ -36,9 +42,11 @@ public final class StatsComponent extends Component {
     /**
      * Get multiplier for a given damage type
      *
+     * <p>If no modifier is set for the given type, the return value will be 1.0.
+     *
      * @param type damage type
-     * @return multiplier (1.0 is default, values greater than 1.0 increase damage, values less than 1.0
-     *     decrease damage)
+     * @return multiplier (1.0 is default, values greater than 1.0 increase damage, values less than
+     *     1.0 decrease damage)
      */
     public float multiplierFor(final DamageType type) {
         return damageModifier.multiplierFor(type);

--- a/game/src/contrib/systems/HealthSystem.java
+++ b/game/src/contrib/systems/HealthSystem.java
@@ -116,7 +116,7 @@ public final class HealthSystem extends System {
                 .mapToInt(
                         dt ->
                                 Math.round(
-                                        statsComponent.damageModifiers().multiplierFor(dt)
+                                        statsComponent.multiplierFor(dt)
                                                 * hsd.hc.calculateDamageOf(dt)))
                 .sum();
     }

--- a/game/test/contrib/systems/HealthSystemTest.java
+++ b/game/test/contrib/systems/HealthSystemTest.java
@@ -98,7 +98,7 @@ public class HealthSystemTest {
         Entity entity = new Entity();
         new DrawComponent(entity, ANIMATION_PATH);
         StatsComponent statsComponent = new StatsComponent(entity);
-        statsComponent.damageModifiers().setMultiplier(DamageType.PHYSICAL, 2);
+        statsComponent.multiplier(DamageType.PHYSICAL, 2);
 
         HealthComponent healthComponent = new HealthComponent(entity);
         healthComponent.maximalHealthpoints(100);
@@ -119,7 +119,7 @@ public class HealthSystemTest {
         Entity entity = new Entity();
         new DrawComponent(entity, ANIMATION_PATH);
         StatsComponent statsComponent = new StatsComponent(entity);
-        statsComponent.damageModifiers().setMultiplier(DamageType.PHYSICAL, -2);
+        statsComponent.multiplier(DamageType.PHYSICAL, -2);
 
         HealthComponent healthComponent = new HealthComponent(entity);
         healthComponent.maximalHealthpoints(200);
@@ -140,7 +140,7 @@ public class HealthSystemTest {
         Entity entity = new Entity();
         new DrawComponent(entity, ANIMATION_PATH);
         StatsComponent statsComponent = new StatsComponent(entity);
-        statsComponent.damageModifiers().setMultiplier(DamageType.PHYSICAL, 0);
+        statsComponent.multiplier(DamageType.PHYSICAL, 0);
 
         HealthComponent healthComponent = new HealthComponent(entity);
         healthComponent.maximalHealthpoints(200);
@@ -161,7 +161,7 @@ public class HealthSystemTest {
         Entity entity = new Entity();
         new DrawComponent(entity, ANIMATION_PATH);
         StatsComponent statsComponent = new StatsComponent(entity);
-        statsComponent.damageModifiers().setMultiplier(DamageType.PHYSICAL, 100);
+        statsComponent.multiplier(DamageType.PHYSICAL, 100);
 
         HealthComponent healthComponent = new HealthComponent(entity);
         healthComponent.maximalHealthpoints(200);


### PR DESCRIPTION
In diesem Pull-Request wurde das `StatsComponent` refactored.

Dieser Pull-Request zielt darauf ab, sicherzustellen, dass die Qualität der JavaDoc zu verbessern und Clean Code sowie Java Konventionen umzusetzen. 

Außerdem:
Vereinfachen des Zugriffs auf das `DamageModifier` Objekt. 
Anstelle erst das Objekt aus dem Component abzufragen und dann die Funktionen von `DamageModifier` aufzurufen, kann man diese nun direkt im Component aufrufen. Das vereinfach den Zugriff. 

Die Tests wurden entsprechend angepasst.
Dieser Pull-Request nimmt keine Änderungen am Logging (#683) oder an der Testabdeckung vor. 