### PR TITLE
[GitHub] make Dungeon-Team owner of `build.gradle` and `settings.gradle`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,10 @@
 # global owner
 * @cagix
 
+# gradle
+build.gradle @Programmiermethoden/dungeon
+settings.gradle @Programmiermethoden/dungeon
+
 # game owner
 /game/ @AMatutat @Programmiermethoden/codrs
 


### PR DESCRIPTION
Dieser PR macht das @Programmiermethoden/dungeon -Team Codeowner der `buiild.gradle` und `settings.gradle` im root. 
