### PR TITLE
[GAME] Cause-Entity für Damage-Skills hinzugefügt

### DIFF
--- a/game/src/contrib/utils/components/skill/DamageProjectile.java
+++ b/game/src/contrib/utils/components/skill/DamageProjectile.java
@@ -4,6 +4,7 @@ import contrib.components.CollideComponent;
 import contrib.components.HealthComponent;
 import contrib.components.ProjectileComponent;
 import contrib.utils.components.health.Damage;
+import contrib.utils.components.health.DamageType;
 
 import core.Entity;
 import core.Game;
@@ -29,21 +30,24 @@ public abstract class DamageProjectile implements Consumer<Entity> {
     private float projectileSpeed;
 
     private float projectileRange;
-    private Damage projectileDamage;
+
+    private int damageAmount;
+    private DamageType damageType;
     private Point projectileHitboxSize;
 
     private Supplier<Point> selectionFunction;
 
     /**
      * The DamageProjectile constructor sets the path to the textures of the projectile, the speed
-     * of the projectile, the damage to be dealt, the size of the projectile's hitbox, the target
-     * selection function, and the range of the projectile.
+     * of the projectile, the damage amount and type to be dealt, the size of the projectile's
+     * hitbox, the target selection function, and the range of the projectile.
      *
      * <p>for specific implementation, see {@link contrib.utils.components.skill.FireballSkill}
      *
      * @param pathToTexturesOfProjectile path to the textures of the projectile
      * @param projectileSpeed speed of the projectile
-     * @param projectileDamage damage of the projectile
+     * @param damageAmount amount of damage to be dealt
+     * @param damageType type of damage to be dealt
      * @param projectileHitboxSize size of the Hitbox
      * @param selectionFunction specific functionality of the projectile
      * @param projectileRange range in which the projectile is effective
@@ -51,12 +55,14 @@ public abstract class DamageProjectile implements Consumer<Entity> {
     public DamageProjectile(
             String pathToTexturesOfProjectile,
             float projectileSpeed,
-            Damage projectileDamage,
+            int damageAmount,
+            DamageType damageType,
             Point projectileHitboxSize,
             Supplier<Point> selectionFunction,
             float projectileRange) {
         this.pathToTexturesOfProjectile = pathToTexturesOfProjectile;
-        this.projectileDamage = projectileDamage;
+        this.damageAmount = damageAmount;
+        this.damageType = damageType;
         this.projectileSpeed = projectileSpeed;
         this.projectileRange = projectileRange;
         this.projectileHitboxSize = projectileHitboxSize;
@@ -67,7 +73,13 @@ public abstract class DamageProjectile implements Consumer<Entity> {
      * Performs the necessary actions to create and handle the damage projectile based on the
      * provided entity.
      *
-     * @param entity the entity on which the damage projectile will be applied
+     * <p>The projectile can not collide with the casting entity.
+     *
+     * <p>The cause for the damage will not be the projectile, but the entity that casts the
+     * projectile
+     *
+     * @param entity The entity that casts the projectile. The entity's position will be the start
+     *     position for the projectile.
      * @throws MissingComponentException if the entity does not have a PositionComponent
      */
     @Override
@@ -115,7 +127,8 @@ public abstract class DamageProjectile implements Consumer<Entity> {
                                 .ifPresent(
                                         hc -> {
                                             // Apply the projectile damage to the collided entity
-                                            hc.receiveHit(projectileDamage);
+                                            hc.receiveHit(
+                                                    new Damage(damageAmount, damageType, entity));
 
                                             // Remove the projectile entity from the game
                                             Game.removeEntity(projectile);

--- a/game/src/contrib/utils/components/skill/DamageProjectile.java
+++ b/game/src/contrib/utils/components/skill/DamageProjectile.java
@@ -76,7 +76,7 @@ public abstract class DamageProjectile implements Consumer<Entity> {
      * <p>The projectile can not collide with the casting entity.
      *
      * <p>The cause for the damage will not be the projectile, but the entity that casts the
-     * projectile
+     * projectile.
      *
      * @param entity The entity that casts the projectile. The entity's position will be the start
      *     position for the projectile.

--- a/game/src/contrib/utils/components/skill/FireballSkill.java
+++ b/game/src/contrib/utils/components/skill/FireballSkill.java
@@ -1,6 +1,5 @@
 package contrib.utils.components.skill;
 
-import contrib.utils.components.health.Damage;
 import contrib.utils.components.health.DamageType;
 
 import core.utils.Point;
@@ -14,13 +13,22 @@ import java.util.function.Supplier;
  * specific behavior of the fireball skill.
  */
 public class FireballSkill extends DamageProjectile {
+
+    private static final String PROJECTILE_TEXTURES = "skills/fireball";
+    private static final float PROJECTILE_SPEED = 0.5f;
+    private static final int DAMAGE_AMOUNT = 1;
+    private static final DamageType DAMAGE_TYPE = DamageType.FIRE;
+    private static final Point HITBOX_SIZE = new Point(1, 1);
+    private static final float PROJECTILE_RANGE = 5f;
+
     public FireballSkill(Supplier<Point> targetSelection) {
         super(
-                "skills/fireball",
-                0.5f,
-                new Damage(1, DamageType.FIRE, null),
-                new Point(1, 1),
+                PROJECTILE_TEXTURES,
+                PROJECTILE_SPEED,
+                DAMAGE_AMOUNT,
+                DAMAGE_TYPE,
+                HITBOX_SIZE,
                 targetSelection,
-                5f);
+                PROJECTILE_RANGE);
     }
 }

--- a/game/src/contrib/utils/components/skill/FireballSkill.java
+++ b/game/src/contrib/utils/components/skill/FireballSkill.java
@@ -21,6 +21,13 @@ public class FireballSkill extends DamageProjectile {
     private static final Point HITBOX_SIZE = new Point(1, 1);
     private static final float PROJECTILE_RANGE = 5f;
 
+    /**
+     * Create a {@link DamageProjectile} that looks like a fireball and will cause fire damage.
+     *
+     * @param targetSelection A function used to select the point where the projectile should fly
+     *     to.
+     * @see DamageProjectile
+     */
     public FireballSkill(Supplier<Point> targetSelection) {
         super(
                 PROJECTILE_TEXTURES,


### PR DESCRIPTION
fixes #716 

In `DamageProjectile#accept(Entity entity)` wird nun der `cause` gesetzt. 
Dazu wurde das Attribut `DamageProjectile#projectileDamage` mit den Attributen `int damageAmount` und `DamageType damageType` ersetzt und die Zeile `  ((HealthComponent) hc).receiveHit(projectileDamage);` zu `  ((HealthComponent) hc).receiveHit(new Damage(damageAmount,danageType,entity);` geändert.

Außerdem:
- Parameter zu Konstanten in `FireballSkill` umgewandelt
