### PR TITLE
[DSL] Fix newline chars in `testBranchingReturnNested` test

### DIFF
--- a/dsl/test/interpreter/TestDSLInterpreter.java
+++ b/dsl/test/interpreter/TestDSLInterpreter.java
@@ -908,10 +908,15 @@ public class TestDSLInterpreter {
         DSLInterpreter interpreter = new DSLInterpreter();
         Helpers.generateQuestConfigWithCustomFunctions(program, env, interpreter);
 
-
-
         assertEquals(
-                "branch2 stmt1"+ System.lineSeparator()+"other_func stmt1"+System.lineSeparator()+"other_func stmt2"+System.lineSeparator()+"hello"+System.lineSeparator(),
+                "branch2 stmt1"
+                        + System.lineSeparator()
+                        + "other_func stmt1"
+                        + System.lineSeparator()
+                        + "other_func stmt2"
+                        + System.lineSeparator()
+                        + "hello"
+                        + System.lineSeparator(),
                 outputStream.toString());
     }
 }

--- a/dsl/test/interpreter/TestDSLInterpreter.java
+++ b/dsl/test/interpreter/TestDSLInterpreter.java
@@ -908,8 +908,10 @@ public class TestDSLInterpreter {
         DSLInterpreter interpreter = new DSLInterpreter();
         Helpers.generateQuestConfigWithCustomFunctions(program, env, interpreter);
 
+
+
         assertEquals(
-                "branch2 stmt1\nother_func stmt1\nother_func stmt2\nhello\n",
+                "branch2 stmt1"+ System.lineSeparator()+"other_func stmt1"+System.lineSeparator()+"other_func stmt2"+System.lineSeparator()+"hello"+System.lineSeparator(),
                 outputStream.toString());
     }
 }


### PR DESCRIPTION
Fixes #841 

Windows behandelt newline-chars anders als linux und macOS, daher schlug der Test fehl. Mit `System.lineSeparator` wird das Zeichen eingefügt, was auf dem lokalen System für newlines verwendet wird.