### PR TITLE
[GAME] add throw of `IllegalArgumentException` to `IPathable#findPath` if `start` or `end` are non-accessible

### DIFF
--- a/game/src/contrib/utils/components/ai/AITools.java
+++ b/game/src/contrib/utils/components/ai/AITools.java
@@ -156,7 +156,7 @@ public class AITools {
 
     /**
      * Finds the path to a random (accessible) tile in the given radius, starting from the given
-     * point
+     * point.
      *
      * <p>If there is no accessible tile in the range, the path will be calculated from the given
      * start point to the given start point.

--- a/game/src/contrib/utils/components/ai/AITools.java
+++ b/game/src/contrib/utils/components/ai/AITools.java
@@ -20,8 +20,8 @@ public class AITools {
      * Sets the velocity of the passed entity so that it takes the next necessary step to get to the
      * end of the path.
      *
-     * @param entity Entity moving on the path
-     * @param path Path on which the entity moves
+     * @param entity Entity moving on the path.
+     * @param path Path on which the entity moves.
      */
     public static void move(final Entity entity, final GraphPath<Tile> path) {
         // entity is already at the end
@@ -70,9 +70,12 @@ public class AITools {
     }
 
     /**
-     * @param center center point
-     * @param radius Search radius
-     * @return List of tiles in the given radius around the center point
+     * Get all tile coordinates within a specified range around a given center point. The range is
+     * determined by the provided radius.
+     *
+     * @param center The center point around which the tiles are considered.
+     * @param radius The radius within which the tiles should be located.
+     * @return List of tiles in the given radius around the center point.
      */
     public static List<Tile> tilesInRange(final Point center, final float radius) {
         List<Tile> tiles = new ArrayList<>();
@@ -86,9 +89,12 @@ public class AITools {
     }
 
     /**
-     * @param center center point
-     * @param radius Search radius
-     * @return List of accessible tiles in the given radius around the center point
+     * Get all accessible tile coordinates within a specified range around a given center point. The
+     * range is determined by the provided radius.
+     *
+     * @param center The center point around which the tiles are considered.
+     * @param radius The radius within which the accessible tiles should be located.
+     * @return List of accessible tiles in the given radius around the center point.
      */
     public static List<Tile> accessibleTilesInRange(final Point center, final float radius) {
         List<Tile> tiles = tilesInRange(center, radius);
@@ -97,8 +103,8 @@ public class AITools {
     }
 
     /**
-     * Gets a random accessible tile coordinate within a specified range around a given center
-     * point. The range is determined by the provided radius.
+     * Get a random accessible tile coordinate within a specified range around a given center point.
+     * The range is determined by the provided radius.
      *
      * @param center The center point around which the tiles are considered.
      * @param radius The radius within which the accessible tiles should be located.
@@ -114,18 +120,26 @@ public class AITools {
     }
 
     /**
-     * @param from start point
-     * @param to end point
-     * @return Path from the start point to the end point
+     * Finds the path from the given point to another given point.
+     *
+     * <p>Throws an IllegalArgumentException if 'from' or 'to' is non-accessible.
+     *
+     * @param from The start point.
+     * @param to The end point.
+     * @return Path from the start point to the end point.
      */
     public static GraphPath<Tile> calculatePath(final Point from, final Point to) {
         return calculatePath(from.toCoordinate(), to.toCoordinate());
     }
 
     /**
-     * @param from start coordinate
-     * @param to end coordinate
-     * @return Path from the start coordinate to the end coordinate
+     * Finds the path from the given coordinate to another given coordinate.
+     *
+     * <p>Throws an IllegalArgumentException if start or end is non-accessible.
+     *
+     * @param from The start coordinate.
+     * @param to The end coordinate.
+     * @return Path from the start coordinate to the end coordinate.
      */
     public static GraphPath<Tile> calculatePath(final Coordinate from, final Coordinate to) {
         return Game.findPath(Game.tileAT(from), Game.tileAT(to));
@@ -136,12 +150,14 @@ public class AITools {
      * center point
      *
      * <p>If there is no accessible tile in the range, the path will be calculated from the given
-     * center point to the given center point. This is known misbehavior, see
-     * https://github.com/Programmiermethoden/Dungeon/issues/786
+     * center point to the given center point. This is known misbehavior, see <a
+     * href="https://github.com/Programmiermethoden/Dungeon/issues/786">...</a>
      *
-     * @param point Center point
-     * @param radius Search radius
-     * @return Path from the center point to the randomly selected tile
+     * <p>Throws an IllegalArgumentException if start or end is non-accessible.
+     *
+     * @param point The center point.
+     * @param radius Radius in which the tiles are to be considered.
+     * @return Path from the center point to the randomly selected tile.
      */
     public static GraphPath<Tile> calculatePathToRandomTileInRange(
             final Point point, final float radius) {
@@ -154,9 +170,11 @@ public class AITools {
      * Finds the path to a random (accessible) tile in the given radius, starting from the position
      * of the given entity.
      *
-     * @param entity Entity whose position is the center point
-     * @param radius Search radius
-     * @return Path from the position of the entity to the randomly selected tile
+     * <p>Throws an IllegalArgumentException if start or end is non-accessible.
+     *
+     * @param entity Entity whose position is the center point.
+     * @param radius Radius in which the tiles are to be considered.
+     * @return Path from the position of the entity to the randomly selected tile.
      */
     public static GraphPath<Tile> calculatePathToRandomTileInRange(
             final Entity entity, final float radius) {
@@ -173,9 +191,11 @@ public class AITools {
     /**
      * Finds the path from the position of one entity to the position of another entity.
      *
-     * @param from Entity whose position is the start point
-     * @param to Entity whose position is the goal point
-     * @return Path
+     * <p>Throws an IllegalArgumentException if start or end is non-accessible.
+     *
+     * @param from Entity whose position is the start point.
+     * @param to Entity whose position is the goal point.
+     * @return Path from one entity to the other entity.
      */
     public static GraphPath<Tile> calculatePath(final Entity from, final Entity to) {
         PositionComponent fromPositionComponent =
@@ -185,18 +205,20 @@ public class AITools {
                                         MissingComponentException.build(
                                                 from, PositionComponent.class));
         PositionComponent positionComponent =
-                (PositionComponent)
-                        to.fetch(PositionComponent.class)
-                                .orElseThrow(
-                                        () ->
-                                                MissingComponentException.build(
-                                                        to, PositionComponent.class));
+                to.fetch(PositionComponent.class)
+                        .orElseThrow(
+                                () -> MissingComponentException.build(to, PositionComponent.class));
         return calculatePath(fromPositionComponent.position(), positionComponent.position());
     }
 
     /**
-     * @param entity
-     * @return Path from the entity to the hero, if there is no hero, path from the entity to itself
+     * Finds the path from the position of one entity to the position of the hero.
+     *
+     * <p>Throws an IllegalArgumentException if start or end is non-accessible.
+     *
+     * @param entity Entity from which the path to the hero is calculated.
+     * @return Path from the entity to the hero, if there is no hero, path from the entity to
+     *     itself.
      */
     public static GraphPath<Tile> calculatePathToHero(final Entity entity) {
         Optional<Entity> hero = Game.hero();
@@ -205,20 +227,24 @@ public class AITools {
     }
 
     /**
-     * @param p1 Point A
-     * @param p2 Point B
-     * @param range Radius
-     * @return if the distance between the two points is within the radius
+     * Check if two points are positioned in a specified range from each other.
+     *
+     * @param p1 The first point which is considered.
+     * @param p2 The second point which is considered.
+     * @param range The range in which the two points are positioned from each other.
+     * @return True if the distance between the two points is within the radius, else false.
      */
     public static boolean inRange(final Point p1, final Point p2, final float range) {
         return Point.calculateDistance(p1, p2) <= range;
     }
 
     /**
-     * @param entity1
-     * @param entity2
-     * @param range search radius
-     * @return if the position of the two entities is within the given radius
+     * Check if two entities are positioned in a specified range from each other.
+     *
+     * @param entity1 The first entity which is considered.
+     * @param entity2 The second entity which is to be searched for in the given range.
+     * @param range The range in which the two entities are positioned from each other.
+     * @return True if the position of the two entities is within the given range, else false
      */
     public static boolean entityInRange(
             final Entity entity1, final Entity entity2, final float range) {
@@ -241,10 +267,12 @@ public class AITools {
     }
 
     /**
-     * @param entity Entity whose position specifies the center point
-     * @param range search radius
-     * @return if the position of the player is within the given radius of the position of the given
-     *     entity. If there is no hero, return false.
+     * Check if the player is in the given range of an entity.
+     *
+     * @param entity Entity whose position specifies the center point.
+     * @param range The range within which the player should be located.
+     * @return True if the position of the player is within the given radius of the position of the
+     *     given entity. If there is no hero, return false.
      */
     public static boolean playerInRange(final Entity entity, final float range) {
 
@@ -255,9 +283,9 @@ public class AITools {
     /**
      * Check if the entity is on the end of the path or has left the path.
      *
-     * @param entity Entity
-     * @param path Path
-     * @return true, if the entity is on the end of the path or has left the path
+     * @param entity Entity to be checked.
+     * @param path Path which the entity possibly left or has reached the end.
+     * @return True if the entity is on the end of the path or has left the path, otherwise false.
      */
     public static boolean pathFinishedOrLeft(final Entity entity, final GraphPath<Tile> path) {
         PositionComponent pc =
@@ -271,18 +299,20 @@ public class AITools {
         boolean onPath = false;
         Tile currentTile = Game.tileAT(pc.position());
         for (Tile tile : path) {
-            if (currentTile == tile) onPath = true;
+            if (currentTile == tile) {
+                onPath = true;
+            }
         }
 
         return !onPath || finished;
     }
 
     /**
-     * Check if the entity is on the end of the path
+     * Check if the entity is on the end of the path.
      *
-     * @param entity Entity
-     * @param path Path
-     * @return true, if the entity is on the end of the path.
+     * @param entity Entity to be checked.
+     * @param path Path on which the entity possible reached the end.
+     * @return True if the entity is on the end of the path, otherwise false.
      */
     public static boolean pathFinished(final Entity entity, final GraphPath<Tile> path) {
         PositionComponent pc =
@@ -295,11 +325,11 @@ public class AITools {
     }
 
     /**
-     * Check if the entity has left the path
+     * Check if the entity has left the path.
      *
-     * @param entity Entity
-     * @param path Path
-     * @return true, if the entity has left the path.
+     * @param entity Entity to be checked.
+     * @param path Path to be checked.
+     * @return True if the entity has left the path, otherwise false.
      */
     public static boolean pathLeft(final Entity entity, final GraphPath<Tile> path) {
         PositionComponent pc =
@@ -311,16 +341,18 @@ public class AITools {
         boolean onPath = false;
         Tile currentTile = Game.tileAT(pc.position());
         for (Tile tile : path) {
-            if (currentTile == tile) onPath = true;
+            if (currentTile == tile) {
+                onPath = true;
+            }
         }
         return !onPath;
     }
 
     /**
-     * Get the last Tile in the given GraphPath
+     * Get the last Tile in the given GraphPath.
      *
-     * @param path considered GraphPath
-     * @return last Tile in the given path
+     * @param path Considered GraphPath.
+     * @return Last Tile in the given path.
      * @see GraphPath
      */
     public static Tile lastTile(final GraphPath<Tile> path) {

--- a/game/src/contrib/utils/components/ai/AITools.java
+++ b/game/src/contrib/utils/components/ai/AITools.java
@@ -70,8 +70,11 @@ public class AITools {
     }
 
     /**
-     * Get all tile coordinates within a specified range around a given center point. The range is
-     * determined by the provided radius.
+     * Get all tiles within a specified range around a given center point.
+     *
+     * <p>The range is determined by the provided radius.
+     *
+     * <p>The tile at the given point will be part of the list as well.
      *
      * @param center The center point around which the tiles are considered.
      * @param radius The radius within which the tiles should be located.
@@ -89,8 +92,11 @@ public class AITools {
     }
 
     /**
-     * Get all accessible tile coordinates within a specified range around a given center point. The
-     * range is determined by the provided radius.
+     * Get all accessible tiles within a specified range around a given center point.
+     *
+     * <p>The range is determined by the provided radius.
+     *
+     * <p>The tile at the given point will be part of the list as well, if it is accessible.
      *
      * @param center The center point around which the tiles are considered.
      * @param radius The radius within which the accessible tiles should be located.
@@ -104,7 +110,10 @@ public class AITools {
 
     /**
      * Get a random accessible tile coordinate within a specified range around a given center point.
-     * The range is determined by the provided radius.
+     *
+     * <p>The range is determined by the provided radius.
+     *
+     * <p>The tile at the given point can be the return value as well, if it is accessible.
      *
      * @param center The center point around which the tiles are considered.
      * @param radius The radius within which the accessible tiles should be located.
@@ -122,7 +131,7 @@ public class AITools {
     /**
      * Finds the path from the given point to another given point.
      *
-     * <p>Throws an IllegalArgumentException if 'from' or 'to' is non-accessible.
+     * <p>Throws an IllegalArgumentException if the tile at 'from' or 'to' is non-accessible.
      *
      * @param from The start point.
      * @param to The end point.
@@ -135,7 +144,7 @@ public class AITools {
     /**
      * Finds the path from the given coordinate to another given coordinate.
      *
-     * <p>Throws an IllegalArgumentException if start or end is non-accessible.
+     * <p>Throws an IllegalArgumentException if the tile at the start or end is non-accessible.
      *
      * @param from The start coordinate.
      * @param to The end coordinate.
@@ -147,15 +156,14 @@ public class AITools {
 
     /**
      * Finds the path to a random (accessible) tile in the given radius, starting from the given
-     * center point
+     * point
      *
      * <p>If there is no accessible tile in the range, the path will be calculated from the given
-     * center point to the given center point. This is known misbehavior, see <a
-     * href="https://github.com/Programmiermethoden/Dungeon/issues/786">...</a>
+     * start point to the given start point.
      *
-     * <p>Throws an IllegalArgumentException if start or end is non-accessible.
+     * <p>Throws an IllegalArgumentException if the tile at the start point is non-accessible.
      *
-     * @param point The center point.
+     * @param point The start point.
      * @param radius Radius in which the tiles are to be considered.
      * @return Path from the center point to the randomly selected tile.
      */
@@ -170,7 +178,10 @@ public class AITools {
      * Finds the path to a random (accessible) tile in the given radius, starting from the position
      * of the given entity.
      *
-     * <p>Throws an IllegalArgumentException if start or end is non-accessible.
+     * <p>If there is no accessible tile in the range, the path will be calculated from the given
+     * start point to the given start point.
+     *
+     * <p>Throws an IllegalArgumentException if the entities position is on a non-accessible tile.
      *
      * @param entity Entity whose position is the center point.
      * @param radius Radius in which the tiles are to be considered.
@@ -191,7 +202,7 @@ public class AITools {
     /**
      * Finds the path from the position of one entity to the position of another entity.
      *
-     * <p>Throws an IllegalArgumentException if start or end is non-accessible.
+     * <p>Throws an IllegalArgumentException if one of the entities position is non-accessible.
      *
      * @param from Entity whose position is the start point.
      * @param to Entity whose position is the goal point.
@@ -214,7 +225,10 @@ public class AITools {
     /**
      * Finds the path from the position of one entity to the position of the hero.
      *
-     * <p>Throws an IllegalArgumentException if start or end is non-accessible.
+     * <p>If no hero exist in the game, the path will be calculated from the given entity to the
+     * given entity.
+     *
+     * <p>Throws an IllegalArgumentException if one of the entities position is non-accessible.
      *
      * @param entity Entity from which the path to the hero is calculated.
      * @return Path from the entity to the hero, if there is no hero, path from the entity to
@@ -224,18 +238,6 @@ public class AITools {
         Optional<Entity> hero = Game.hero();
         if (hero.isPresent()) return calculatePath(entity, hero.get());
         else return calculatePath(entity, entity);
-    }
-
-    /**
-     * Check if two points are positioned in a specified range from each other.
-     *
-     * @param p1 The first point which is considered.
-     * @param p2 The second point which is considered.
-     * @param range The range in which the two points are positioned from each other.
-     * @return True if the distance between the two points is within the radius, else false.
-     */
-    public static boolean inRange(final Point p1, final Point p2, final float range) {
-        return Point.calculateDistance(p1, p2) <= range;
     }
 
     /**
@@ -263,7 +265,7 @@ public class AITools {
                                         MissingComponentException.build(
                                                 entity2, PositionComponent.class))
                         .position();
-        return inRange(entity1Position, entity2Position, range);
+        return Point.inRange(entity1Position, entity2Position, range);
     }
 
     /**

--- a/game/src/contrib/utils/components/ai/fight/RangeAI.java
+++ b/game/src/contrib/utils/components/ai/fight/RangeAI.java
@@ -56,7 +56,7 @@ public final class RangeAI implements Consumer<Entity> {
                 boolean newPositionFound = false;
                 for (Tile tile : tiles) {
                     Point newPosition = tile.position();
-                    if (!AITools.inRange(newPosition, positionHero, distance)) {
+                    if (!Point.inRange(newPosition, positionHero, distance)) {
                         path = AITools.calculatePath(positionEntity, newPosition);
                         newPositionFound = true;
                         break;

--- a/game/src/contrib/utils/components/ai/idle/StaticRadiusWalk.java
+++ b/game/src/contrib/utils/components/ai/idle/StaticRadiusWalk.java
@@ -16,8 +16,8 @@ import java.util.function.Consumer;
 
 public class StaticRadiusWalk implements Consumer<Entity> {
     private final float radius;
-    private GraphPath<Tile> path;
     private final int breakTime;
+    private GraphPath<Tile> path;
     private int currentBreak = 0;
     private Point center;
     private Point currentPosition;
@@ -60,6 +60,8 @@ public class StaticRadiusWalk implements Consumer<Entity> {
                 newEndTile =
                         AITools.randomAccessibleTileCoordinateInRange(center, radius)
                                 .map(Coordinate::toPoint)
+                                // center is the start position of the entity, so it must be
+                                // accessible
                                 .orElse(center);
                 path = AITools.calculatePath(currentPosition, newEndTile);
                 accept(entity);

--- a/game/src/core/Game.java
+++ b/game/src/core/Game.java
@@ -571,6 +571,8 @@ public final class Game extends ScreenAdapter implements IOnLevelLoader {
     /**
      * Starts the indexed A* pathfinding algorithm a returns a path
      *
+     * <p>Throws an IllegalArgumentException if start or end is non-accessible.
+     *
      * @param start Start tile
      * @param end End tile
      * @return Generated path

--- a/game/src/core/level/elements/IPathable.java
+++ b/game/src/core/level/elements/IPathable.java
@@ -24,13 +24,21 @@ public interface IPathable extends IndexedGraph<Tile> {
     int getNodeCount();
 
     /**
-     * Starts the indexed A* pathfinding algorithm a returns a path
+     * Starts the indexed A* pathfinding algorithm a returns a path.
+     *
+     * <p>Throws an IllegalArgumentException if start or end is non-accessible.
      *
      * @param start Start tile
      * @param end End tile
      * @return Generated path
      */
     default GraphPath<Tile> findPath(Tile start, Tile end) {
+        if (!start.isAccessible())
+            throw new IllegalArgumentException(
+                    "Can not calculate Path because the start point is non-accessible.");
+        if (!end.isAccessible())
+            throw new IllegalArgumentException(
+                    "Can not calculate Path because the end point is non-accessible.");
         GraphPath<Tile> path = new DefaultGraphPath<>();
         new IndexedAStarPathFinder<>(this).searchNodePath(start, end, tileHeuristic(), path);
         return path;
@@ -58,13 +66,12 @@ public interface IPathable extends IndexedGraph<Tile> {
      * @return Position of the given entity.
      */
     default Point positionOf(Entity entity) {
-        return ((PositionComponent)
-                        entity.fetch(PositionComponent.class)
-                                .orElseThrow(
-                                        () ->
-                                                new MissingComponentException(
-                                                        entity.getClass().getName()
-                                                                + "is missing PositionComponent")))
+        return entity.fetch(PositionComponent.class)
+                .orElseThrow(
+                        () ->
+                                new MissingComponentException(
+                                        entity.getClass().getName()
+                                                + "is missing PositionComponent"))
                 .position();
     }
 }

--- a/game/src/core/level/elements/IPathable.java
+++ b/game/src/core/level/elements/IPathable.java
@@ -67,11 +67,7 @@ public interface IPathable extends IndexedGraph<Tile> {
      */
     default Point positionOf(Entity entity) {
         return entity.fetch(PositionComponent.class)
-                .orElseThrow(
-                        () ->
-                                new MissingComponentException(
-                                        entity.getClass().getName()
-                                                + "is missing PositionComponent"))
+                .orElseThrow(() -> MissingComponentException.build(entity, PositionComponent.class))
                 .position();
     }
 }

--- a/game/src/core/utils/Point.java
+++ b/game/src/core/utils/Point.java
@@ -31,6 +31,18 @@ public class Point {
     }
 
     /**
+     * Check if two points are positioned in a specified range from each other.
+     *
+     * @param p1 The first point which is considered.
+     * @param p2 The second point which is considered.
+     * @param range The range in which the two points are positioned from each other.
+     * @return True if the distance between the two points is within the radius, else false.
+     */
+    public static boolean inRange(final Point p1, final Point p2, final float range) {
+        return calculateDistance(p1, p2) <= range;
+    }
+
+    /**
      * Convert Point to Coordinate by parsing float to int
      *
      * @return the converted point

--- a/game/test/core/level/TileLevelTest.java
+++ b/game/test/core/level/TileLevelTest.java
@@ -303,6 +303,72 @@ public class TileLevelTest {
     }
 
     @Test
+    public void test_findPath_startPositionNotAccessible() {
+        Tile[][] layout = new Tile[3][3];
+        for (int x = 0; x < 3; x++) {
+            for (int y = 0; y < 3; y++) {
+                layout[y][x] = new FloorTile("", new Coordinate(x, y), DesignLabel.DEFAULT, null);
+            }
+        }
+        layout[0][1] = new WallTile("", new Coordinate(1, 0), DesignLabel.DEFAULT, null);
+        TileLevel tileLevel = new TileLevel(layout);
+        var start = tileLevel.tileAt(layout[0][1].coordinate());
+        var end = tileLevel.tileAt(layout[2][1].coordinate());
+
+        Exception e =
+                assertThrows(IllegalArgumentException.class, () -> tileLevel.findPath(start, end));
+        String actualErrorMsg = e.getMessage();
+        String expectedErrorMsg =
+                "Can not calculate Path because the start point is non-accessible.";
+
+        assertTrue(actualErrorMsg.contains(expectedErrorMsg));
+    }
+
+    @Test
+    public void test_findPath_endPositionNotAccessible() {
+        Tile[][] layout = new Tile[3][3];
+        for (int x = 0; x < 3; x++) {
+            for (int y = 0; y < 3; y++) {
+                layout[y][x] = new FloorTile("", new Coordinate(x, y), DesignLabel.DEFAULT, null);
+            }
+        }
+        layout[2][1] = new WallTile("", new Coordinate(1, 2), DesignLabel.DEFAULT, null);
+        TileLevel tileLevel = new TileLevel(layout);
+        var start = tileLevel.tileAt(layout[0][1].coordinate());
+        var end = tileLevel.tileAt(layout[2][1].coordinate());
+
+        Exception e =
+                assertThrows(IllegalArgumentException.class, () -> tileLevel.findPath(start, end));
+        String actualErrorMsg = e.getMessage();
+        String expectedErrorMsg = "Can not calculate Path because the end point is non-accessible.";
+
+        assertTrue(actualErrorMsg.contains(expectedErrorMsg));
+    }
+
+    @Test
+    public void test_findPath_startAndEndPositionNotAccessible() {
+        Tile[][] layout = new Tile[3][3];
+        for (int x = 0; x < 3; x++) {
+            for (int y = 0; y < 3; y++) {
+                layout[y][x] = new FloorTile("", new Coordinate(x, y), DesignLabel.DEFAULT, null);
+            }
+        }
+        layout[0][1] = new WallTile("", new Coordinate(1, 0), DesignLabel.DEFAULT, null);
+        layout[2][1] = new WallTile("", new Coordinate(1, 2), DesignLabel.DEFAULT, null);
+        TileLevel tileLevel = new TileLevel(layout);
+        var start = tileLevel.tileAt(layout[0][1].coordinate());
+        var end = tileLevel.tileAt(layout[2][1].coordinate());
+
+        Exception e =
+                assertThrows(IllegalArgumentException.class, () -> tileLevel.findPath(start, end));
+        String actualErrorMsg = e.getMessage();
+        String expectedErrorMsg =
+                "Can not calculate Path because the start point is non-accessible.";
+
+        assertTrue(actualErrorMsg.contains(expectedErrorMsg));
+    }
+
+    @Test
     public void test_getTileAt() {
         var levelLayout = new LevelElement[3][3];
 
@@ -397,10 +463,10 @@ public class TileLevelTest {
         var level = new TileLevel(tileLayout, DesignLabel.DEFAULT);
         StringBuilder compareString = new StringBuilder();
         for (LevelElement[] tiles : tileLayout) {
-            for (int x = 0; x < tiles.length; x++) {
-                if (tiles[x] == LevelElement.FLOOR) {
+            for (LevelElement tile : tiles) {
+                if (tile == LevelElement.FLOOR) {
                     compareString.append("F");
-                } else if (tiles[x] == LevelElement.WALL) {
+                } else if (tile == LevelElement.WALL) {
                     compareString.append("W");
                 } else {
                     compareString.append("E");


### PR DESCRIPTION
fixes #786 

`IPathable#findPath` überprüft nun, ob die Start- und End- Tile für eine Entity accessible sind. Falls nicht, wird eine IllegalArgumentException geworfen.

Außerdem:
- Testfälle geschrieben für:
    - startTile ist nicht accessible
    - endTile ist nicht accessible
    - startTile und endTile sind nicht accessible
- JavaDoc für `AITools` ergänzt 