### PR TITLE
[DSL] Expression-Grammatik

### DIFF
--- a/dsl/src/antlr/DungeonDSL.g4
+++ b/dsl/src/antlr/DungeonDSL.g4
@@ -48,7 +48,7 @@ fragment STRING_ESCAPE_SEQ
 
 // TODO:
 // - expression grammar
-// - proper stmt definition
+// - proper stmt =efinition
 
 program : definition* EOF
         //| stmt
@@ -140,6 +140,11 @@ param_list
         | primary
         ;
 
+member_access
+        : ID '.' (ID | func_call)
+        | member_access '.' (ID | func_call)
+        ;
+
 primary : ID
         | STRING_LITERAL
         | TRUE
@@ -148,6 +153,7 @@ primary : ID
         | NUM_DEC
         | func_call
         | aggregate_value_def
+        | member_access
         ;
 
 /*

--- a/dsl/src/antlr/DungeonDSL.g4
+++ b/dsl/src/antlr/DungeonDSL.g4
@@ -79,6 +79,7 @@ expression
     ;
 
 assignment
+        // TODO: this should be an expression
     : ( func_call '.' )? ID '=' assignment
     | logic_or
     ;

--- a/dsl/src/antlr/DungeonDSL.g4
+++ b/dsl/src/antlr/DungeonDSL.g4
@@ -73,7 +73,9 @@ stmt
     ;
 
 expression
-    : assignment
+    : assignment                #assignment_expression
+    | expression '.' func_call  #method_call_expression
+    | expression '.' ID         #member_access_expression
     ;
 
 assignment
@@ -82,37 +84,49 @@ assignment
     ;
 
 logic_or
-    : logic_and ( 'or' logic_and )*
+
+    : logic_or ( 'or' logic_and )
+    | logic_and
     ;
 
 logic_and
-    : equality ( 'and' equality )*
+    : logic_and ( 'and' equality )
+    | equality
     ;
 
 equality
-    : comparison ( ( '!=' | '==' ) comparison )*
+    : equality ( ( '!=' | '==' ) comparison )
+    | comparison
     ;
 
 comparison
-    : term ( ( '>' | '>=' | '<' | '<=' ) term )*
+    : comparison ( ( '>' | '>=' | '<' | '<=' ) term )
+    | term
     ;
 
 term
-    : factor ( ( '-' | '+' ) factor )*
+    : term ( ( '-' | '+' ) factor )
+    | factor
     ;
 
 factor
-    : unary ( ( '/' | '*' ) unary )*
+    : factor ( ( '/' | '*' ) unary )
+    | unary
     ;
 
 unary
     : ( '!' | '-' ) unary
-    | func_call
+    | primary
     ;
 
 func_call
-        : primary ('(' param_list? ')' | '.' ID)*
+        : ID ('(' param_list? ')')
         ;
+
+qualified_name
+        : ID ('.' qualified_name)?
+        ;
+
 
 stmt_block
     : '{' stmt_list? '}'
@@ -190,6 +204,7 @@ primary : ID
         | NUM_DEC
         | aggregate_value_def
         | grouped_expression
+        | func_call
         ;
 
 /*

--- a/dsl/src/antlr/DungeonDSL.g4
+++ b/dsl/src/antlr/DungeonDSL.g4
@@ -79,9 +79,14 @@ expression
     ;
 
 assignment
-        // TODO: this should be an expression
-    : ( func_call '.' )? ID '=' assignment
+    : assignee '=' assignment
     | logic_or
+    ;
+
+assignee
+    : func_call '.' assignee    #assignee_func_call
+    | ID '.' assignee           #assignee_qualified_name
+    | ID                        #assignee_identifier
     ;
 
 logic_or
@@ -121,13 +126,8 @@ unary
     ;
 
 func_call
-        : ID ('(' param_list? ')')
+        : ID '(' param_list? ')'
         ;
-
-qualified_name
-        : ID ('.' qualified_name)?
-        ;
-
 
 stmt_block
     : '{' stmt_list? '}'

--- a/dsl/src/antlr/DungeonDSL.g4
+++ b/dsl/src/antlr/DungeonDSL.g4
@@ -85,37 +85,37 @@ assignment
 
 logic_or
 
-    : logic_or ( 'or' logic_and )
+    : logic_or ( or='or' logic_and )
     | logic_and
     ;
 
 logic_and
-    : logic_and ( 'and' equality )
+    : logic_and ( and='and' equality )
     | equality
     ;
 
 equality
-    : equality ( ( '!=' | '==' ) comparison )
+    : equality ( ( neq='!=' | eq='==' ) comparison )
     | comparison
     ;
 
 comparison
-    : comparison ( ( '>' | '>=' | '<' | '<=' ) term )
+    : comparison ( ( gt='>' | geq='>=' | lt='<' | leq='<=' ) term )
     | term
     ;
 
 term
-    : term ( ( '-' | '+' ) factor )
+    : term ( ( minus='-' | plus='+' ) factor )
     | factor
     ;
 
 factor
-    : factor ( ( '/' | '*' ) unary )
+    : factor ( ( div='/' | mult='*' ) unary )
     | unary
     ;
 
 unary
-    : ( '!' | '-' ) unary
+    : ( bang='!' | minus='-' ) unary
     | primary
     ;
 

--- a/dsl/src/antlr/DungeonDSL.g4
+++ b/dsl/src/antlr/DungeonDSL.g4
@@ -66,11 +66,53 @@ fn_def
     ;
 
 stmt
-    : primary ';'
+    : expression ';'
     | stmt_block
     | conditional_stmt
     | return_stmt
     ;
+
+expression
+    : assignment
+    ;
+
+assignment
+    : ( func_call '.' )? ID '=' assignment
+    | logic_or
+    ;
+
+logic_or
+    : logic_and ( 'or' logic_and )*
+    ;
+
+logic_and
+    : equality ( 'and' equality )*
+    ;
+
+equality
+    : comparison ( ( '!=' | '==' ) comparison )*
+    ;
+
+comparison
+    : term ( ( '>' | '>=' | '<' | '<=' ) term )*
+    ;
+
+term
+    : factor ( ( '-' | '+' ) factor )*
+    ;
+
+factor
+    : unary ( ( '/' | '*' ) unary )*
+    ;
+
+unary
+    : ( '!' | '-' ) unary
+    | func_call
+    ;
+
+func_call
+        : primary ('(' param_list? ')' | '.' ID)*
+        ;
 
 stmt_block
     : '{' stmt_list? '}'
@@ -82,11 +124,11 @@ stmt_list
     ;
 
 return_stmt
-    : 'return' primary? ';'
+    : 'return' expression? ';'
     ;
 
 conditional_stmt
-    : 'if' primary stmt else_stmt?
+    : 'if' expression stmt else_stmt?
     ;
 
 else_stmt
@@ -129,20 +171,11 @@ property_def_list
         ;
 
 property_def
-        : ID ':' primary;
-
-func_call
-        : ID '(' param_list? ')'
-        ;
+        : ID ':' expression;
 
 param_list
-        : primary ',' param_list
-        | primary
-        ;
-
-member_access
-        : ID '.' (ID | func_call)
-        | member_access '.' (ID | func_call)
+        : expression ',' param_list
+        | expression
         ;
 
 primary : ID
@@ -151,9 +184,8 @@ primary : ID
         | FALSE
         | NUM
         | NUM_DEC
-        | func_call
         | aggregate_value_def
-        | member_access
+        | '(' expression ')'
         ;
 
 /*

--- a/dsl/src/antlr/DungeonDSL.g4
+++ b/dsl/src/antlr/DungeonDSL.g4
@@ -178,6 +178,10 @@ param_list
         | expression
         ;
 
+grouped_expression
+    : '(' expression ')'
+    ;
+
 primary : ID
         | STRING_LITERAL
         | TRUE
@@ -185,7 +189,7 @@ primary : ID
         | NUM
         | NUM_DEC
         | aggregate_value_def
-        | '(' expression ')'
+        | grouped_expression
         ;
 
 /*

--- a/dsl/src/antlr/DungeonDSL.g4
+++ b/dsl/src/antlr/DungeonDSL.g4
@@ -79,7 +79,7 @@ expression
     ;
 
 assignment
-    : assignee '=' assignment
+    : assignee '=' expression
     | logic_or
     ;
 

--- a/dsl/src/interpreter/DSLInterpreter.java
+++ b/dsl/src/interpreter/DSLInterpreter.java
@@ -788,9 +788,9 @@ public class DSLInterpreter implements AstVisitor<Object> {
         assert Objects.requireNonNull(statementStack.peek()).type == Node.Type.ReturnMark;
         statementStack.pop();
     }
-    //endregion
+    // endregion
 
-    //region ASTVisitor implementation for nodes which do not need to be interpreted
+    // region ASTVisitor implementation for nodes which do not need to be interpreted
     @Override
     public Object visit(Node node) {
         return null;
@@ -820,7 +820,5 @@ public class DSLInterpreter implements AstVisitor<Object> {
     public Object visit(ParamDefNode node) {
         return null;
     }
-
-
-    //endregion
+    // endregion
 }

--- a/dsl/src/interpreter/DSLInterpreter.java
+++ b/dsl/src/interpreter/DSLInterpreter.java
@@ -589,6 +589,60 @@ public class DSLInterpreter implements AstVisitor<Object> {
         return new Value(BuiltInType.boolType, node.getValue());
     }
 
+    @Override
+    public Object visit(MemberAccessNode node) {
+        // TODO: implement
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Object visit(LogicOrNode node) {
+        // TODO: implement
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Object visit(LogicAndNode node) {
+        // TODO: implement
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Object visit(EqualityNode node) {
+        // TODO: implement
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Object visit(ComparisonNode node) {
+        // TODO: implement
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Object visit(TermNode node) {
+        // TODO: implement
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Object visit(FactorNode node) {
+        // TODO: implement
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Object visit(UnaryNode node) {
+        // TODO: implement
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Object visit(AssignmentNode node) {
+        // TODO: implement
+        throw new UnsupportedOperationException();
+    }
+
     // region user defined function execution
 
     /**
@@ -734,6 +788,39 @@ public class DSLInterpreter implements AstVisitor<Object> {
         assert Objects.requireNonNull(statementStack.peek()).type == Node.Type.ReturnMark;
         statementStack.pop();
     }
+    //endregion
 
-    // endregion
+    //region ASTVisitor implementation for nodes which do not need to be interpreted
+    @Override
+    public Object visit(Node node) {
+        return null;
+    }
+
+    @Override
+    public Object visit(BinaryNode node) {
+        return null;
+    }
+
+    @Override
+    public Object visit(EdgeRhsNode node) {
+        return null;
+    }
+
+    @Override
+    public Object visit(EdgeStmtNode node) {
+        return null;
+    }
+
+    @Override
+    public Object visit(EdgeOpNode node) {
+        return null;
+    }
+
+    @Override
+    public Object visit(ParamDefNode node) {
+        return null;
+    }
+
+
+    //endregion
 }

--- a/dsl/src/parser/DungeonASTConverter.java
+++ b/dsl/src/parser/DungeonASTConverter.java
@@ -161,9 +161,7 @@ public class DungeonASTConverter implements antlr.main.DungeonDSLListener {
     }
 
     @Override
-    public void enterAssignee_func_call(DungeonDSLParser.Assignee_func_callContext ctx) {
-
-    }
+    public void enterAssignee_func_call(DungeonDSLParser.Assignee_func_callContext ctx) {}
 
     @Override
     public void exitAssignee_func_call(DungeonDSLParser.Assignee_func_callContext ctx) {
@@ -174,9 +172,7 @@ public class DungeonASTConverter implements antlr.main.DungeonDSLListener {
     }
 
     @Override
-    public void enterAssignee_qualified_name(DungeonDSLParser.Assignee_qualified_nameContext ctx) {
-
-    }
+    public void enterAssignee_qualified_name(DungeonDSLParser.Assignee_qualified_nameContext ctx) {}
 
     @Override
     public void exitAssignee_qualified_name(DungeonDSLParser.Assignee_qualified_nameContext ctx) {
@@ -187,9 +183,7 @@ public class DungeonASTConverter implements antlr.main.DungeonDSLListener {
     }
 
     @Override
-    public void enterAssignee_identifier(DungeonDSLParser.Assignee_identifierContext ctx) {
-
-    }
+    public void enterAssignee_identifier(DungeonDSLParser.Assignee_identifierContext ctx) {}
 
     @Override
     public void exitAssignee_identifier(DungeonDSLParser.Assignee_identifierContext ctx) {
@@ -206,8 +200,7 @@ public class DungeonASTConverter implements antlr.main.DungeonDSLListener {
         Node logicOrNode = rhs;
         if (ctx.or != null) {
             lhs = astStack.pop();
-            logicOrNode =
-                new LogicOrNode(lhs, rhs);
+            logicOrNode = new LogicOrNode(lhs, rhs);
         }
         astStack.push(logicOrNode);
     }
@@ -222,8 +215,7 @@ public class DungeonASTConverter implements antlr.main.DungeonDSLListener {
         Node logicAndNode = rhs;
         if (ctx.and != null) {
             lhs = astStack.pop();
-            logicAndNode =
-                new LogicAndNode(lhs, rhs);
+            logicAndNode = new LogicAndNode(lhs, rhs);
         }
         astStack.push(logicAndNode);
     }
@@ -238,12 +230,10 @@ public class DungeonASTConverter implements antlr.main.DungeonDSLListener {
         Node equalityNode = rhs;
         if (ctx.eq != null) {
             lhs = astStack.pop();
-            equalityNode =
-                new EqualityNode(EqualityNode.EqualityType.equals, lhs, rhs);
+            equalityNode = new EqualityNode(EqualityNode.EqualityType.equals, lhs, rhs);
         } else if (ctx.neq != null) {
             lhs = astStack.pop();
-            equalityNode =
-                new EqualityNode(EqualityNode.EqualityType.notEquals, lhs, rhs);
+            equalityNode = new EqualityNode(EqualityNode.EqualityType.notEquals, lhs, rhs);
         }
         astStack.push(equalityNode);
     }

--- a/dsl/src/parser/DungeonASTConverter.java
+++ b/dsl/src/parser/DungeonASTConverter.java
@@ -491,6 +491,16 @@ public class DungeonASTConverter implements antlr.main.DungeonDSLListener {
     }
 
     @Override
+    public void enterMember_access(DungeonDSLParser.Member_accessContext ctx) {
+
+    }
+
+    @Override
+    public void exitMember_access(DungeonDSLParser.Member_accessContext ctx) {
+
+    }
+
+    @Override
     public void enterPrimary(DungeonDSLParser.PrimaryContext ctx) {}
 
     @Override

--- a/dsl/src/parser/DungeonASTConverter.java
+++ b/dsl/src/parser/DungeonASTConverter.java
@@ -120,7 +120,10 @@ public class DungeonASTConverter implements antlr.main.DungeonDSLListener {
 
     @Override
     public void exitMethod_call_expression(DungeonDSLParser.Method_call_expressionContext ctx) {
-        throw new UnsupportedOperationException();
+        Node funcCall = astStack.pop();
+        Node innerExpression = astStack.pop();
+        Node expression = new MemberAccessNode(innerExpression, funcCall);
+        astStack.push(expression);
     }
 
     @Override
@@ -129,7 +132,10 @@ public class DungeonASTConverter implements antlr.main.DungeonDSLListener {
 
     @Override
     public void exitMember_access_expression(DungeonDSLParser.Member_access_expressionContext ctx) {
-        throw new UnsupportedOperationException();
+        Node identifier = astStack.pop();
+        Node innerExpression = astStack.pop();
+        Node expression = new MemberAccessNode(innerExpression, identifier);
+        astStack.push(expression);
     }
 
     @Override

--- a/dsl/src/parser/DungeonASTConverter.java
+++ b/dsl/src/parser/DungeonASTConverter.java
@@ -250,10 +250,10 @@ public class DungeonASTConverter implements antlr.main.DungeonDSLListener {
         Node termNode = rhs;
         if (ctx.minus != null) {
             lhs = astStack.pop();
-            termNode = new TermNode(TermNode.TermType.plus, lhs, rhs);
+            termNode = new TermNode(TermNode.TermType.minus, lhs, rhs);
         } else if (ctx.plus != null) {
             lhs = astStack.pop();
-            termNode = new TermNode(TermNode.TermType.minus, lhs, rhs);
+            termNode = new TermNode(TermNode.TermType.plus, lhs, rhs);
         }
         astStack.push(termNode);
     }

--- a/dsl/src/parser/DungeonASTConverter.java
+++ b/dsl/src/parser/DungeonASTConverter.java
@@ -116,12 +116,32 @@ public class DungeonASTConverter implements antlr.main.DungeonDSLListener {
     }
 
     @Override
-    public void enterExpression(DungeonDSLParser.ExpressionContext ctx) {
+    public void enterMethod_call_expression(DungeonDSLParser.Method_call_expressionContext ctx) {
 
     }
 
     @Override
-    public void exitExpression(DungeonDSLParser.ExpressionContext ctx) {
+    public void exitMethod_call_expression(DungeonDSLParser.Method_call_expressionContext ctx) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void enterMember_access_expression(DungeonDSLParser.Member_access_expressionContext ctx) {
+
+    }
+
+    @Override
+    public void exitMember_access_expression(DungeonDSLParser.Member_access_expressionContext ctx) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void enterAssignment_expression(DungeonDSLParser.Assignment_expressionContext ctx) {
+
+    }
+
+    @Override
+    public void exitAssignment_expression(DungeonDSLParser.Assignment_expressionContext ctx) {
         throw new UnsupportedOperationException();
     }
 
@@ -544,7 +564,6 @@ public class DungeonASTConverter implements antlr.main.DungeonDSLListener {
     @Override
     public void exitFunc_call(DungeonDSLParser.Func_callContext ctx) {
 
-        // TODO: test this
         // if there are parameters, a paramList will be on stack
         var paramList = Node.NONE;
         if (ctx.param_list() != null) {
@@ -560,6 +579,16 @@ public class DungeonASTConverter implements antlr.main.DungeonDSLListener {
         astStack.push(funcCallNode);
 
         // TODO: modify this for grammar changes, until then, it is unsupported
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void enterQualified_name(DungeonDSLParser.Qualified_nameContext ctx) {
+
+    }
+
+    @Override
+    public void exitQualified_name(DungeonDSLParser.Qualified_nameContext ctx) {
         throw new UnsupportedOperationException();
     }
 
@@ -589,6 +618,17 @@ public class DungeonASTConverter implements antlr.main.DungeonDSLListener {
             var paramList = new Node(Node.Type.ParamList, childList);
             astStack.push(paramList);
         }
+    }
+
+    @Override
+    public void enterGrouped_expression(DungeonDSLParser.Grouped_expressionContext ctx) {
+
+    }
+
+    @Override
+    public void exitGrouped_expression(DungeonDSLParser.Grouped_expressionContext ctx) {
+        throw new UnsupportedOperationException();
+
     }
 
     @Override

--- a/dsl/src/parser/DungeonASTConverter.java
+++ b/dsl/src/parser/DungeonASTConverter.java
@@ -116,9 +116,7 @@ public class DungeonASTConverter implements antlr.main.DungeonDSLListener {
     }
 
     @Override
-    public void enterMethod_call_expression(DungeonDSLParser.Method_call_expressionContext ctx) {
-
-    }
+    public void enterMethod_call_expression(DungeonDSLParser.Method_call_expressionContext ctx) {}
 
     @Override
     public void exitMethod_call_expression(DungeonDSLParser.Method_call_expressionContext ctx) {
@@ -126,9 +124,8 @@ public class DungeonASTConverter implements antlr.main.DungeonDSLListener {
     }
 
     @Override
-    public void enterMember_access_expression(DungeonDSLParser.Member_access_expressionContext ctx) {
-
-    }
+    public void enterMember_access_expression(
+            DungeonDSLParser.Member_access_expressionContext ctx) {}
 
     @Override
     public void exitMember_access_expression(DungeonDSLParser.Member_access_expressionContext ctx) {
@@ -136,9 +133,7 @@ public class DungeonASTConverter implements antlr.main.DungeonDSLListener {
     }
 
     @Override
-    public void enterAssignment_expression(DungeonDSLParser.Assignment_expressionContext ctx) {
-
-    }
+    public void enterAssignment_expression(DungeonDSLParser.Assignment_expressionContext ctx) {}
 
     @Override
     public void exitAssignment_expression(DungeonDSLParser.Assignment_expressionContext ctx) {
@@ -146,90 +141,147 @@ public class DungeonASTConverter implements antlr.main.DungeonDSLListener {
     }
 
     @Override
-    public void enterAssignment(DungeonDSLParser.AssignmentContext ctx) {
-
-    }
+    public void enterAssignment(DungeonDSLParser.AssignmentContext ctx) {}
 
     @Override
     public void exitAssignment(DungeonDSLParser.AssignmentContext ctx) {
-        throw new UnsupportedOperationException();
-
+        if (ctx.ID() != null) {
+            if (ctx.func_call() != null) {
+                // - member access on left
+            } else {
+                // - simple ID assignment
+            }
+        }
+        // - trivial case
     }
 
     @Override
-    public void enterLogic_or(DungeonDSLParser.Logic_orContext ctx) {
-
-    }
+    public void enterLogic_or(DungeonDSLParser.Logic_orContext ctx) {}
 
     @Override
     public void exitLogic_or(DungeonDSLParser.Logic_orContext ctx) {
-        throw new UnsupportedOperationException();
-
+        Node rhs = astStack.pop();
+        Node lhs;
+        Node logicOrNode = rhs;
+        if (ctx.or != null) {
+            lhs = astStack.pop();
+            logicOrNode =
+                new LogicOrNode(lhs, rhs);
+        }
+        astStack.push(logicOrNode);
     }
 
     @Override
-    public void enterLogic_and(DungeonDSLParser.Logic_andContext ctx) {
-
-    }
+    public void enterLogic_and(DungeonDSLParser.Logic_andContext ctx) {}
 
     @Override
     public void exitLogic_and(DungeonDSLParser.Logic_andContext ctx) {
-        throw new UnsupportedOperationException();
-
+        Node rhs = astStack.pop();
+        Node lhs;
+        Node logicAndNode = rhs;
+        if (ctx.and != null) {
+            lhs = astStack.pop();
+            logicAndNode =
+                new LogicAndNode(lhs, rhs);
+        }
+        astStack.push(logicAndNode);
     }
 
     @Override
-    public void enterEquality(DungeonDSLParser.EqualityContext ctx) {
-
-    }
+    public void enterEquality(DungeonDSLParser.EqualityContext ctx) {}
 
     @Override
     public void exitEquality(DungeonDSLParser.EqualityContext ctx) {
-        throw new UnsupportedOperationException();
-
+        Node rhs = astStack.pop();
+        Node lhs;
+        Node equalityNode = rhs;
+        if (ctx.eq != null) {
+            lhs = astStack.pop();
+            equalityNode =
+                new EqualityNode(EqualityNode.EqualityType.equals, lhs, rhs);
+        } else if (ctx.neq != null) {
+            lhs = astStack.pop();
+            equalityNode =
+                new EqualityNode(EqualityNode.EqualityType.notEquals, lhs, rhs);
+        }
+        astStack.push(equalityNode);
     }
 
     @Override
-    public void enterComparison(DungeonDSLParser.ComparisonContext ctx) {
-
-    }
+    public void enterComparison(DungeonDSLParser.ComparisonContext ctx) {}
 
     @Override
     public void exitComparison(DungeonDSLParser.ComparisonContext ctx) {
-        throw new UnsupportedOperationException();
-
+        Node rhs = astStack.pop();
+        Node lhs;
+        Node comparisonNode = rhs;
+        if (ctx.gt != null) {
+            lhs = astStack.pop();
+            comparisonNode =
+                    new ComparisonNode(ComparisonNode.ComparisonType.greaterThan, lhs, rhs);
+        } else if (ctx.geq != null) {
+            lhs = astStack.pop();
+            comparisonNode =
+                    new ComparisonNode(ComparisonNode.ComparisonType.greaterEquals, lhs, rhs);
+        } else if (ctx.lt != null) {
+            lhs = astStack.pop();
+            comparisonNode = new ComparisonNode(ComparisonNode.ComparisonType.lessThan, lhs, rhs);
+        } else if (ctx.leq != null) {
+            lhs = astStack.pop();
+            comparisonNode = new ComparisonNode(ComparisonNode.ComparisonType.lessEquals, lhs, rhs);
+        }
+        astStack.push(comparisonNode);
     }
 
     @Override
-    public void enterTerm(DungeonDSLParser.TermContext ctx) {
-
-    }
+    public void enterTerm(DungeonDSLParser.TermContext ctx) {}
 
     @Override
     public void exitTerm(DungeonDSLParser.TermContext ctx) {
-        throw new UnsupportedOperationException();
-
+        Node rhs = astStack.pop();
+        Node lhs;
+        Node termNode = rhs;
+        if (ctx.minus != null) {
+            lhs = astStack.pop();
+            termNode = new TermNode(TermNode.TermType.plus, lhs, rhs);
+        } else if (ctx.plus != null) {
+            lhs = astStack.pop();
+            termNode = new TermNode(TermNode.TermType.minus, lhs, rhs);
+        }
+        astStack.push(termNode);
     }
 
     @Override
-    public void enterFactor(DungeonDSLParser.FactorContext ctx) {
-
-    }
+    public void enterFactor(DungeonDSLParser.FactorContext ctx) {}
 
     @Override
     public void exitFactor(DungeonDSLParser.FactorContext ctx) {
-        throw new UnsupportedOperationException();
-
+        Node rhs = astStack.pop();
+        Node lhs;
+        Node factorNode = rhs;
+        if (ctx.div != null) {
+            lhs = astStack.pop();
+            factorNode = new FactorNode(FactorNode.FactorType.divide, lhs, rhs);
+        } else if (ctx.mult != null) {
+            lhs = astStack.pop();
+            factorNode = new FactorNode(FactorNode.FactorType.multiply, lhs, rhs);
+        }
+        astStack.push(factorNode);
     }
 
     @Override
-    public void enterUnary(DungeonDSLParser.UnaryContext ctx) {
-
-    }
+    public void enterUnary(DungeonDSLParser.UnaryContext ctx) {}
 
     @Override
     public void exitUnary(DungeonDSLParser.UnaryContext ctx) {
-        throw new UnsupportedOperationException();
+        Node innerNode = astStack.pop();
+        Node unaryNode = innerNode;
+        if (ctx.bang != null) {
+            unaryNode = new UnaryNode(UnaryNode.UnaryType.not, innerNode);
+        } else if (ctx.minus != null) {
+            unaryNode = new UnaryNode(UnaryNode.UnaryType.minus, innerNode);
+        }
+        astStack.push(unaryNode);
     }
 
     @Override
@@ -583,9 +635,7 @@ public class DungeonASTConverter implements antlr.main.DungeonDSLListener {
     }
 
     @Override
-    public void enterQualified_name(DungeonDSLParser.Qualified_nameContext ctx) {
-
-    }
+    public void enterQualified_name(DungeonDSLParser.Qualified_nameContext ctx) {}
 
     @Override
     public void exitQualified_name(DungeonDSLParser.Qualified_nameContext ctx) {
@@ -621,14 +671,11 @@ public class DungeonASTConverter implements antlr.main.DungeonDSLListener {
     }
 
     @Override
-    public void enterGrouped_expression(DungeonDSLParser.Grouped_expressionContext ctx) {
-
-    }
+    public void enterGrouped_expression(DungeonDSLParser.Grouped_expressionContext ctx) {}
 
     @Override
     public void exitGrouped_expression(DungeonDSLParser.Grouped_expressionContext ctx) {
         throw new UnsupportedOperationException();
-
     }
 
     @Override

--- a/dsl/src/parser/DungeonASTConverter.java
+++ b/dsl/src/parser/DungeonASTConverter.java
@@ -145,14 +145,21 @@ public class DungeonASTConverter implements antlr.main.DungeonDSLListener {
 
     @Override
     public void exitAssignment(DungeonDSLParser.AssignmentContext ctx) {
+        // pop the inner node
+        Node assignment = astStack.pop();
         if (ctx.ID() != null) {
+            Node identifier = astStack.pop();
             if (ctx.func_call() != null) {
-                // - member access on left
+                // member access on left
+                Node funcCall = astStack.pop();
+                Node memberAccess = new MemberAccessNode(funcCall, identifier);
+                assignment = new AssignmentNode(memberAccess, assignment);
             } else {
-                // - simple ID assignment
+                // simple ID assignment
+                assignment = new AssignmentNode(identifier, assignment);
             }
         }
-        // - trivial case
+        astStack.push(assignment);
     }
 
     @Override

--- a/dsl/src/parser/DungeonASTConverter.java
+++ b/dsl/src/parser/DungeonASTConverter.java
@@ -137,7 +137,7 @@ public class DungeonASTConverter implements antlr.main.DungeonDSLListener {
 
     @Override
     public void exitAssignment_expression(DungeonDSLParser.Assignment_expressionContext ctx) {
-        throw new UnsupportedOperationException();
+        // just let it bubble up, nothing to do
     }
 
     @Override

--- a/dsl/src/parser/DungeonASTConverter.java
+++ b/dsl/src/parser/DungeonASTConverter.java
@@ -147,19 +147,47 @@ public class DungeonASTConverter implements antlr.main.DungeonDSLListener {
     public void exitAssignment(DungeonDSLParser.AssignmentContext ctx) {
         // pop the inner node
         Node assignment = astStack.pop();
-        if (ctx.ID() != null) {
-            Node identifier = astStack.pop();
-            if (ctx.func_call() != null) {
-                // member access on left
-                Node funcCall = astStack.pop();
-                Node memberAccess = new MemberAccessNode(funcCall, identifier);
-                assignment = new AssignmentNode(memberAccess, assignment);
-            } else {
-                // simple ID assignment
-                assignment = new AssignmentNode(identifier, assignment);
-            }
+        if (ctx.assignee() != null) {
+            Node assignee = astStack.pop();
+            assignment = new AssignmentNode(assignee, assignment);
         }
         astStack.push(assignment);
+    }
+
+    @Override
+    public void enterAssignee_func_call(DungeonDSLParser.Assignee_func_callContext ctx) {
+
+    }
+
+    @Override
+    public void exitAssignee_func_call(DungeonDSLParser.Assignee_func_callContext ctx) {
+        Node rhs = astStack.pop();
+        Node funcCall = astStack.pop();
+        Node assignee = new MemberAccessNode(funcCall, rhs);
+        astStack.push(assignee);
+    }
+
+    @Override
+    public void enterAssignee_qualified_name(DungeonDSLParser.Assignee_qualified_nameContext ctx) {
+
+    }
+
+    @Override
+    public void exitAssignee_qualified_name(DungeonDSLParser.Assignee_qualified_nameContext ctx) {
+        Node rhs = astStack.pop();
+        Node identifier = astStack.pop();
+        Node assignee = new MemberAccessNode(identifier, rhs);
+        astStack.push(assignee);
+    }
+
+    @Override
+    public void enterAssignee_identifier(DungeonDSLParser.Assignee_identifierContext ctx) {
+
+    }
+
+    @Override
+    public void exitAssignee_identifier(DungeonDSLParser.Assignee_identifierContext ctx) {
+        // just let it bubble up, nothing to do
     }
 
     @Override
@@ -636,17 +664,6 @@ public class DungeonASTConverter implements antlr.main.DungeonDSLListener {
 
         var funcCallNode = new FuncCallNode(funcId, paramList);
         astStack.push(funcCallNode);
-
-        // TODO: modify this for grammar changes, until then, it is unsupported
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void enterQualified_name(DungeonDSLParser.Qualified_nameContext ctx) {}
-
-    @Override
-    public void exitQualified_name(DungeonDSLParser.Qualified_nameContext ctx) {
-        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/dsl/src/parser/DungeonASTConverter.java
+++ b/dsl/src/parser/DungeonASTConverter.java
@@ -122,7 +122,7 @@ public class DungeonASTConverter implements antlr.main.DungeonDSLListener {
 
     @Override
     public void exitExpression(DungeonDSLParser.ExpressionContext ctx) {
-
+        throw new UnsupportedOperationException();
     }
 
     @Override
@@ -132,6 +132,7 @@ public class DungeonASTConverter implements antlr.main.DungeonDSLListener {
 
     @Override
     public void exitAssignment(DungeonDSLParser.AssignmentContext ctx) {
+        throw new UnsupportedOperationException();
 
     }
 
@@ -142,6 +143,7 @@ public class DungeonASTConverter implements antlr.main.DungeonDSLListener {
 
     @Override
     public void exitLogic_or(DungeonDSLParser.Logic_orContext ctx) {
+        throw new UnsupportedOperationException();
 
     }
 
@@ -152,6 +154,7 @@ public class DungeonASTConverter implements antlr.main.DungeonDSLListener {
 
     @Override
     public void exitLogic_and(DungeonDSLParser.Logic_andContext ctx) {
+        throw new UnsupportedOperationException();
 
     }
 
@@ -162,6 +165,7 @@ public class DungeonASTConverter implements antlr.main.DungeonDSLListener {
 
     @Override
     public void exitEquality(DungeonDSLParser.EqualityContext ctx) {
+        throw new UnsupportedOperationException();
 
     }
 
@@ -172,6 +176,7 @@ public class DungeonASTConverter implements antlr.main.DungeonDSLListener {
 
     @Override
     public void exitComparison(DungeonDSLParser.ComparisonContext ctx) {
+        throw new UnsupportedOperationException();
 
     }
 
@@ -182,6 +187,7 @@ public class DungeonASTConverter implements antlr.main.DungeonDSLListener {
 
     @Override
     public void exitTerm(DungeonDSLParser.TermContext ctx) {
+        throw new UnsupportedOperationException();
 
     }
 
@@ -192,6 +198,7 @@ public class DungeonASTConverter implements antlr.main.DungeonDSLListener {
 
     @Override
     public void exitFactor(DungeonDSLParser.FactorContext ctx) {
+        throw new UnsupportedOperationException();
 
     }
 
@@ -202,7 +209,7 @@ public class DungeonASTConverter implements antlr.main.DungeonDSLListener {
 
     @Override
     public void exitUnary(DungeonDSLParser.UnaryContext ctx) {
-
+        throw new UnsupportedOperationException();
     }
 
     @Override
@@ -536,6 +543,7 @@ public class DungeonASTConverter implements antlr.main.DungeonDSLListener {
 
     @Override
     public void exitFunc_call(DungeonDSLParser.Func_callContext ctx) {
+
         // TODO: test this
         // if there are parameters, a paramList will be on stack
         var paramList = Node.NONE;
@@ -550,6 +558,9 @@ public class DungeonASTConverter implements antlr.main.DungeonDSLListener {
 
         var funcCallNode = new FuncCallNode(funcId, paramList);
         astStack.push(funcCallNode);
+
+        // TODO: modify this for grammar changes, until then, it is unsupported
+        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/dsl/src/parser/DungeonASTConverter.java
+++ b/dsl/src/parser/DungeonASTConverter.java
@@ -116,6 +116,96 @@ public class DungeonASTConverter implements antlr.main.DungeonDSLListener {
     }
 
     @Override
+    public void enterExpression(DungeonDSLParser.ExpressionContext ctx) {
+
+    }
+
+    @Override
+    public void exitExpression(DungeonDSLParser.ExpressionContext ctx) {
+
+    }
+
+    @Override
+    public void enterAssignment(DungeonDSLParser.AssignmentContext ctx) {
+
+    }
+
+    @Override
+    public void exitAssignment(DungeonDSLParser.AssignmentContext ctx) {
+
+    }
+
+    @Override
+    public void enterLogic_or(DungeonDSLParser.Logic_orContext ctx) {
+
+    }
+
+    @Override
+    public void exitLogic_or(DungeonDSLParser.Logic_orContext ctx) {
+
+    }
+
+    @Override
+    public void enterLogic_and(DungeonDSLParser.Logic_andContext ctx) {
+
+    }
+
+    @Override
+    public void exitLogic_and(DungeonDSLParser.Logic_andContext ctx) {
+
+    }
+
+    @Override
+    public void enterEquality(DungeonDSLParser.EqualityContext ctx) {
+
+    }
+
+    @Override
+    public void exitEquality(DungeonDSLParser.EqualityContext ctx) {
+
+    }
+
+    @Override
+    public void enterComparison(DungeonDSLParser.ComparisonContext ctx) {
+
+    }
+
+    @Override
+    public void exitComparison(DungeonDSLParser.ComparisonContext ctx) {
+
+    }
+
+    @Override
+    public void enterTerm(DungeonDSLParser.TermContext ctx) {
+
+    }
+
+    @Override
+    public void exitTerm(DungeonDSLParser.TermContext ctx) {
+
+    }
+
+    @Override
+    public void enterFactor(DungeonDSLParser.FactorContext ctx) {
+
+    }
+
+    @Override
+    public void exitFactor(DungeonDSLParser.FactorContext ctx) {
+
+    }
+
+    @Override
+    public void enterUnary(DungeonDSLParser.UnaryContext ctx) {
+
+    }
+
+    @Override
+    public void exitUnary(DungeonDSLParser.UnaryContext ctx) {
+
+    }
+
+    @Override
     public void enterStmt_block(DungeonDSLParser.Stmt_blockContext ctx) {}
 
     @Override
@@ -137,7 +227,7 @@ public class DungeonASTConverter implements antlr.main.DungeonDSLListener {
         // pop the inner statement
         assert astStack.size() > 0;
         var innerStmt = Node.NONE;
-        if (ctx.primary() != null) {
+        if (ctx.expression() != null) {
             innerStmt = astStack.pop();
         }
 
@@ -488,16 +578,6 @@ public class DungeonASTConverter implements antlr.main.DungeonDSLListener {
             var paramList = new Node(Node.Type.ParamList, childList);
             astStack.push(paramList);
         }
-    }
-
-    @Override
-    public void enterMember_access(DungeonDSLParser.Member_accessContext ctx) {
-
-    }
-
-    @Override
-    public void exitMember_access(DungeonDSLParser.Member_accessContext ctx) {
-
     }
 
     @Override

--- a/dsl/src/parser/ast/AssignmentNode.java
+++ b/dsl/src/parser/ast/AssignmentNode.java
@@ -1,0 +1,12 @@
+package parser.ast;
+
+public class AssignmentNode extends BinaryNode {
+    public AssignmentNode(Node lhs, Node rhs) {
+        super(Type.Assignment, lhs, rhs);
+    }
+
+    @Override
+    public <T> T accept(AstVisitor<T> visitor) {
+        return visitor.visit(this);
+    }
+}

--- a/dsl/src/parser/ast/AstVisitor.java
+++ b/dsl/src/parser/ast/AstVisitor.java
@@ -12,7 +12,7 @@ public interface AstVisitor<T> {
      * @return T
      */
     default T visit(Node node) {
-        return null;
+        throw new UnsupportedOperationException();
     }
 
     /**
@@ -22,7 +22,7 @@ public interface AstVisitor<T> {
      * @return T
      */
     default T visit(IdNode node) {
-        return null;
+        throw new UnsupportedOperationException();
     }
 
     /**
@@ -32,7 +32,7 @@ public interface AstVisitor<T> {
      * @return T
      */
     default T visit(DecNumNode node) {
-        return null;
+        throw new UnsupportedOperationException();
     }
 
     /**
@@ -42,7 +42,7 @@ public interface AstVisitor<T> {
      * @return T
      */
     default T visit(NumNode node) {
-        return null;
+        throw new UnsupportedOperationException();
     }
 
     /**
@@ -52,7 +52,7 @@ public interface AstVisitor<T> {
      * @return T
      */
     default T visit(StringNode node) {
-        return null;
+        throw new UnsupportedOperationException();
     }
 
     /**
@@ -62,7 +62,7 @@ public interface AstVisitor<T> {
      * @return T
      */
     default T visit(BinaryNode node) {
-        return null;
+        throw new UnsupportedOperationException();
     }
 
     /**
@@ -72,7 +72,7 @@ public interface AstVisitor<T> {
      * @return T
      */
     default T visit(DotDefNode node) {
-        return null;
+        throw new UnsupportedOperationException();
     }
 
     /**
@@ -82,7 +82,7 @@ public interface AstVisitor<T> {
      * @return T
      */
     default T visit(EdgeRhsNode node) {
-        return null;
+        throw new UnsupportedOperationException();
     }
 
     /**
@@ -92,7 +92,7 @@ public interface AstVisitor<T> {
      * @return T
      */
     default T visit(EdgeStmtNode node) {
-        return null;
+        throw new UnsupportedOperationException();
     }
 
     /**
@@ -102,7 +102,7 @@ public interface AstVisitor<T> {
      * @return T
      */
     default T visit(EdgeOpNode node) {
-        return null;
+        throw new UnsupportedOperationException();
     }
 
     /**
@@ -112,7 +112,7 @@ public interface AstVisitor<T> {
      * @return T
      */
     default T visit(PropertyDefNode node) {
-        return null;
+        throw new UnsupportedOperationException();
     }
 
     /**
@@ -122,7 +122,7 @@ public interface AstVisitor<T> {
      * @return T
      */
     default T visit(ObjectDefNode node) {
-        return null;
+        throw new UnsupportedOperationException();
     }
 
     /**
@@ -132,7 +132,7 @@ public interface AstVisitor<T> {
      * @return T
      */
     default T visit(FuncCallNode node) {
-        return null;
+        throw new UnsupportedOperationException();
     }
 
     /**
@@ -142,7 +142,7 @@ public interface AstVisitor<T> {
      * @return T
      */
     default T visit(AggregateValueDefinitionNode node) {
-        return null;
+        throw new UnsupportedOperationException();
     }
 
     /**
@@ -152,7 +152,7 @@ public interface AstVisitor<T> {
      * @return T
      */
     default T visit(FuncDefNode node) {
-        return null;
+        throw new UnsupportedOperationException();
     }
 
     /**
@@ -162,7 +162,7 @@ public interface AstVisitor<T> {
      * @return T
      */
     default T visit(ParamDefNode node) {
-        return null;
+        throw new UnsupportedOperationException();
     }
 
     /**
@@ -172,7 +172,7 @@ public interface AstVisitor<T> {
      * @return T
      */
     default T visit(PrototypeDefinitionNode node) {
-        return null;
+        throw new UnsupportedOperationException();
     }
 
     /**
@@ -182,7 +182,7 @@ public interface AstVisitor<T> {
      * @return T
      */
     default T visit(ReturnStmtNode node) {
-        return null;
+        throw new UnsupportedOperationException();
     }
 
     /**
@@ -192,7 +192,7 @@ public interface AstVisitor<T> {
      * @return T
      */
     default T visit(ConditionalStmtNodeIf node) {
-        return null;
+        throw new UnsupportedOperationException();
     }
 
     /**
@@ -202,7 +202,7 @@ public interface AstVisitor<T> {
      * @return T
      */
     default T visit(ConditionalStmtNodeIfElse node) {
-        return null;
+        throw new UnsupportedOperationException();
     }
 
     /**
@@ -212,7 +212,7 @@ public interface AstVisitor<T> {
      * @return T
      */
     default T visit(StmtBlockNode node) {
-        return null;
+        throw new UnsupportedOperationException();
     }
 
     /**
@@ -222,7 +222,97 @@ public interface AstVisitor<T> {
      * @return T
      */
     default T visit(BoolNode node) {
-        return null;
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Visitor method for MemberAccessNodes
+     *
+     * @param node Node to visit
+     * @return T
+     */
+    default T visit(MemberAccessNode node) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Visitor method for LogicOrNode
+     *
+     * @param node Node to visit
+     * @return T
+     */
+    default T visit(LogicOrNode node) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Visitor method for LogicAndNode
+     *
+     * @param node Node to visit
+     * @return T
+     */
+    default T visit(LogicAndNode node) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Visitor method for EqualityNodes
+     *
+     * @param node Node to visit
+     * @return T
+     */
+    default T visit(EqualityNode node) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Visitor method for ComparisonNodes
+     *
+     * @param node Node to visit
+     * @return T
+     */
+    default T visit(ComparisonNode node) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Visitor method for TermNodes
+     *
+     * @param node Node to visit
+     * @return T
+     */
+    default T visit(TermNode node) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Visitor method for FactorNodes
+     *
+     * @param node Node to visit
+     * @return T
+     */
+    default T visit(FactorNode node) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Visitor method for UnaryNodes
+     *
+     * @param node Node to visit
+     * @return T
+     */
+    default T visit(UnaryNode node) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Visitor method for AssignmentNodes
+     *
+     * @param node Node to visit
+     * @return T
+     */
+    default T visit(AssignmentNode node) {
+        throw new UnsupportedOperationException();
     }
 
     /**

--- a/dsl/src/parser/ast/ComparisonNode.java
+++ b/dsl/src/parser/ast/ComparisonNode.java
@@ -1,7 +1,7 @@
 package parser.ast;
 
 public class ComparisonNode extends BinaryNode {
-    enum ComparisonType {
+    public enum ComparisonType {
         greaterThan,
         greaterEquals,
         lessThan,
@@ -20,4 +20,3 @@ public class ComparisonNode extends BinaryNode {
         return visitor.visit(this);
     }
 }
-

--- a/dsl/src/parser/ast/ComparisonNode.java
+++ b/dsl/src/parser/ast/ComparisonNode.java
@@ -1,0 +1,23 @@
+package parser.ast;
+
+public class ComparisonNode extends BinaryNode {
+    enum ComparisonType {
+        greaterThan,
+        greaterEquals,
+        lessThan,
+        lessEquals
+    }
+
+    private final ComparisonType comparisonType;
+
+    public ComparisonNode(ComparisonType type, Node lhs, Node rhs) {
+        super(Type.Equality, lhs, rhs);
+        this.comparisonType = type;
+    }
+
+    @Override
+    public <T> T accept(AstVisitor<T> visitor) {
+        return visitor.visit(this);
+    }
+}
+

--- a/dsl/src/parser/ast/ComparisonNode.java
+++ b/dsl/src/parser/ast/ComparisonNode.java
@@ -10,8 +10,12 @@ public class ComparisonNode extends BinaryNode {
 
     private final ComparisonType comparisonType;
 
+    public ComparisonType getComparisonType() {
+        return comparisonType;
+    }
+
     public ComparisonNode(ComparisonType type, Node lhs, Node rhs) {
-        super(Type.Equality, lhs, rhs);
+        super(Type.Comparison, lhs, rhs);
         this.comparisonType = type;
     }
 

--- a/dsl/src/parser/ast/EqualityNode.java
+++ b/dsl/src/parser/ast/EqualityNode.java
@@ -1,0 +1,22 @@
+package parser.ast;
+
+public class EqualityNode extends BinaryNode {
+    enum EqualityType {
+        equals,
+        notEquals
+    }
+
+    private final EqualityType equalityType;
+
+    public EqualityNode(EqualityType type, Node lhs, Node rhs) {
+        super(Type.Equality, lhs, rhs);
+        this.equalityType = type;
+    }
+
+    @Override
+    public <T> T accept(AstVisitor<T> visitor) {
+        return visitor.visit(this);
+    }
+}
+
+

--- a/dsl/src/parser/ast/EqualityNode.java
+++ b/dsl/src/parser/ast/EqualityNode.java
@@ -8,6 +8,10 @@ public class EqualityNode extends BinaryNode {
 
     private final EqualityType equalityType;
 
+    public EqualityType getEqualityType() {
+        return equalityType;
+    }
+
     public EqualityNode(EqualityType type, Node lhs, Node rhs) {
         super(Type.Equality, lhs, rhs);
         this.equalityType = type;

--- a/dsl/src/parser/ast/EqualityNode.java
+++ b/dsl/src/parser/ast/EqualityNode.java
@@ -1,7 +1,7 @@
 package parser.ast;
 
 public class EqualityNode extends BinaryNode {
-    enum EqualityType {
+    public enum EqualityType {
         equals,
         notEquals
     }
@@ -18,5 +18,3 @@ public class EqualityNode extends BinaryNode {
         return visitor.visit(this);
     }
 }
-
-

--- a/dsl/src/parser/ast/FactorNode.java
+++ b/dsl/src/parser/ast/FactorNode.java
@@ -1,0 +1,21 @@
+package parser.ast;
+
+public class FactorNode extends BinaryNode {
+    enum FactorType {
+        divide,
+        multiply
+    }
+
+    private final FactorType factorType;
+
+    public FactorNode(FactorType type, Node lhs, Node rhs) {
+        super(Type.Factor, lhs, rhs);
+        this.factorType = type;
+    }
+
+    @Override
+    public <T> T accept(AstVisitor<T> visitor) {
+        return visitor.visit(this);
+    }
+}
+

--- a/dsl/src/parser/ast/FactorNode.java
+++ b/dsl/src/parser/ast/FactorNode.java
@@ -1,7 +1,7 @@
 package parser.ast;
 
 public class FactorNode extends BinaryNode {
-    enum FactorType {
+    public enum FactorType {
         divide,
         multiply
     }
@@ -18,4 +18,3 @@ public class FactorNode extends BinaryNode {
         return visitor.visit(this);
     }
 }
-

--- a/dsl/src/parser/ast/FactorNode.java
+++ b/dsl/src/parser/ast/FactorNode.java
@@ -8,6 +8,10 @@ public class FactorNode extends BinaryNode {
 
     private final FactorType factorType;
 
+    public FactorType getFactorType() {
+        return factorType;
+    }
+
     public FactorNode(FactorType type, Node lhs, Node rhs) {
         super(Type.Factor, lhs, rhs);
         this.factorType = type;

--- a/dsl/src/parser/ast/LogicAndNode.java
+++ b/dsl/src/parser/ast/LogicAndNode.java
@@ -11,4 +11,3 @@ public class LogicAndNode extends BinaryNode {
         return visitor.visit(this);
     }
 }
-

--- a/dsl/src/parser/ast/LogicAndNode.java
+++ b/dsl/src/parser/ast/LogicAndNode.java
@@ -1,0 +1,14 @@
+package parser.ast;
+
+public class LogicAndNode extends BinaryNode {
+
+    public LogicAndNode(Node lhs, Node rhs) {
+        super(Type.LogicAnd, lhs, rhs);
+    }
+
+    @Override
+    public <T> T accept(AstVisitor<T> visitor) {
+        return visitor.visit(this);
+    }
+}
+

--- a/dsl/src/parser/ast/LogicOrNode.java
+++ b/dsl/src/parser/ast/LogicOrNode.java
@@ -10,4 +10,3 @@ public class LogicOrNode extends BinaryNode {
         return visitor.visit(this);
     }
 }
-

--- a/dsl/src/parser/ast/LogicOrNode.java
+++ b/dsl/src/parser/ast/LogicOrNode.java
@@ -1,0 +1,13 @@
+package parser.ast;
+
+public class LogicOrNode extends BinaryNode {
+    public LogicOrNode(Node lhs, Node rhs) {
+        super(Type.LogicOr, lhs, rhs);
+    }
+
+    @Override
+    public <T> T accept(AstVisitor<T> visitor) {
+        return visitor.visit(this);
+    }
+}
+

--- a/dsl/src/parser/ast/MemberAccessNode.java
+++ b/dsl/src/parser/ast/MemberAccessNode.java
@@ -1,0 +1,13 @@
+package parser.ast;
+
+public class MemberAccessNode extends BinaryNode {
+
+    public MemberAccessNode(Node lhs, Node rhs) {
+        super(Type.MemberAccess, lhs, rhs);
+    }
+
+    @Override
+    public <T> T accept(AstVisitor<T> visitor) {
+        return visitor.visit(this);
+    }
+}

--- a/dsl/src/parser/ast/Node.java
+++ b/dsl/src/parser/ast/Node.java
@@ -60,7 +60,8 @@ public class Node {
         Term,
         Factor,
         Unary,
-        MemberAccess
+        MemberAccess,
+        GroupedExpression
     }
 
     public static Node NONE = new Node(Type.NONE, new ArrayList<>());

--- a/dsl/src/parser/ast/Node.java
+++ b/dsl/src/parser/ast/Node.java
@@ -51,7 +51,16 @@ public class Node {
         ConditionalStmtIf,
         Bool,
         ConditionalStmtIfElse,
-        ReturnMark
+        ReturnMark,
+        Assignment,
+        LogicOr,
+        LogicAnd,
+        Equality,
+        Comparison,
+        Term,
+        Factor,
+        Unary,
+        MemberAccess
     }
 
     public static Node NONE = new Node(Type.NONE, new ArrayList<>());

--- a/dsl/src/parser/ast/TermNode.java
+++ b/dsl/src/parser/ast/TermNode.java
@@ -1,12 +1,17 @@
 package parser.ast;
 
 public class TermNode extends BinaryNode {
+
     public enum TermType {
         plus,
         minus
     }
 
     private final TermType termType;
+
+    public TermType getTermType() {
+        return termType;
+    }
 
     public TermNode(TermType type, Node lhs, Node rhs) {
         super(Type.Term, lhs, rhs);

--- a/dsl/src/parser/ast/TermNode.java
+++ b/dsl/src/parser/ast/TermNode.java
@@ -1,0 +1,21 @@
+package parser.ast;
+
+public class TermNode extends BinaryNode {
+    enum TermType {
+        plus,
+        minus
+    }
+
+    private final TermType termType;
+
+    public TermNode(TermType type, Node lhs, Node rhs) {
+        super(Type.Term, lhs, rhs);
+        this.termType = type;
+    }
+
+    @Override
+    public <T> T accept(AstVisitor<T> visitor) {
+        return visitor.visit(this);
+    }
+}
+

--- a/dsl/src/parser/ast/TermNode.java
+++ b/dsl/src/parser/ast/TermNode.java
@@ -1,7 +1,7 @@
 package parser.ast;
 
 public class TermNode extends BinaryNode {
-    enum TermType {
+    public enum TermType {
         plus,
         minus
     }
@@ -18,4 +18,3 @@ public class TermNode extends BinaryNode {
         return visitor.visit(this);
     }
 }
-

--- a/dsl/src/parser/ast/UnaryNode.java
+++ b/dsl/src/parser/ast/UnaryNode.java
@@ -1,0 +1,20 @@
+package parser.ast;
+
+public class UnaryNode extends BinaryNode {
+    enum UnaryType {
+        not,
+        minus
+    }
+
+    private final UnaryType unaryType;
+
+    public UnaryNode(UnaryType type, Node lhs, Node rhs) {
+        super(Type.Factor, lhs, rhs);
+        this.unaryType = type;
+    }
+
+    @Override
+    public <T> T accept(AstVisitor<T> visitor) {
+        return visitor.visit(this);
+    }
+}

--- a/dsl/src/parser/ast/UnaryNode.java
+++ b/dsl/src/parser/ast/UnaryNode.java
@@ -14,6 +14,10 @@ public class UnaryNode extends Node {
 
     private final UnaryType unaryType;
 
+    public UnaryType getUnaryType() {
+        return unaryType;
+    }
+
     public UnaryNode(UnaryType type, Node inner) {
         super(Type.Unary, new ArrayList<>(1));
         this.unaryType = type;

--- a/dsl/src/parser/ast/UnaryNode.java
+++ b/dsl/src/parser/ast/UnaryNode.java
@@ -1,16 +1,23 @@
 package parser.ast;
 
-public class UnaryNode extends BinaryNode {
-    enum UnaryType {
+import java.util.ArrayList;
+
+public class UnaryNode extends Node {
+    public enum UnaryType {
         not,
         minus
     }
 
+    public Node getInnerNode() {
+        return this.getChild(0);
+    }
+
     private final UnaryType unaryType;
 
-    public UnaryNode(UnaryType type, Node lhs, Node rhs) {
-        super(Type.Factor, lhs, rhs);
+    public UnaryNode(UnaryType type, Node inner) {
+        super(Type.Unary, new ArrayList<>(1));
         this.unaryType = type;
+        this.children.add(inner);
     }
 
     @Override

--- a/dsl/src/semanticanalysis/FunctionCallResolver.java
+++ b/dsl/src/semanticanalysis/FunctionCallResolver.java
@@ -146,4 +146,106 @@ public class FunctionCallResolver implements AstVisitor<Void> {
         visitChildren(node);
         return null;
     }
+
+    @Override
+    public Void visit(BinaryNode node) {
+        visitChildren(node);
+        return null;
+    }
+
+    @Override
+    public Void visit(MemberAccessNode node) {
+        visitChildren(node);
+        return null;
+    }
+
+    @Override
+    public Void visit(LogicOrNode node) {
+        visitChildren(node);
+        return null;
+    }
+
+    @Override
+    public Void visit(LogicAndNode node) {
+        visitChildren(node);
+        return null;
+    }
+
+    @Override
+    public Void visit(EqualityNode node) {
+        visitChildren(node);
+        return null;
+    }
+
+    @Override
+    public Void visit(ComparisonNode node) {
+        visitChildren(node);
+        return null;
+    }
+
+    @Override
+    public Void visit(TermNode node) {
+        visitChildren(node);
+        return null;
+    }
+
+    @Override
+    public Void visit(FactorNode node) {
+        visitChildren(node);
+        return null;
+    }
+
+    @Override
+    public Void visit(UnaryNode node) {
+        visitChildren(node);
+        return null;
+    }
+
+    @Override
+    public Void visit(AssignmentNode node) {
+        visitChildren(node);
+        return null;
+    }
+
+    //region ASTVisitor implementation for nodes unrelated to function call resolution
+    @Override
+    public Void visit(DecNumNode node) {
+        return null;
+    }
+
+    @Override
+    public Void visit(NumNode node) {
+        return null;
+    }
+
+    @Override
+    public Void visit(StringNode node) {
+        return null;
+    }
+
+    @Override
+    public Void visit(DotDefNode node) {
+        return null;
+    }
+
+    @Override
+    public Void visit(EdgeRhsNode node) {
+        return null;
+    }
+
+    @Override
+    public Void visit(EdgeStmtNode node) {
+        return null;
+    }
+
+    @Override
+    public Void visit(EdgeOpNode node) {
+        return null;
+    }
+
+    @Override
+    public Void visit(BoolNode node) {
+        return null;
+    }
+    //endregion
 }

--- a/dsl/src/semanticanalysis/FunctionCallResolver.java
+++ b/dsl/src/semanticanalysis/FunctionCallResolver.java
@@ -207,7 +207,7 @@ public class FunctionCallResolver implements AstVisitor<Void> {
         return null;
     }
 
-    //region ASTVisitor implementation for nodes unrelated to function call resolution
+    // region ASTVisitor implementation for nodes unrelated to function call resolution
     @Override
     public Void visit(DecNumNode node) {
         return null;
@@ -247,5 +247,5 @@ public class FunctionCallResolver implements AstVisitor<Void> {
     public Void visit(BoolNode node) {
         return null;
     }
-    //endregion
+    // endregion
 }

--- a/dsl/src/semanticanalysis/SemanticAnalyzer.java
+++ b/dsl/src/semanticanalysis/SemanticAnalyzer.java
@@ -476,4 +476,101 @@ public class SemanticAnalyzer implements AstVisitor<Void> {
         visitChildren(node);
         return null;
     }
+
+    @Override
+    public Void visit(MemberAccessNode node) {
+        // TODO: implement
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Void visit(LogicOrNode node) {
+        // TODO: implement
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Void visit(LogicAndNode node) {
+        // TODO: implement
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Void visit(EqualityNode node) {
+        // TODO: implement
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Void visit(ComparisonNode node) {
+        // TODO: implement
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Void visit(TermNode node) {
+        // TODO: implement
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Void visit(FactorNode node) {
+        // TODO: implement
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Void visit(UnaryNode node) {
+        // TODO: implement
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Void visit(AssignmentNode node) {
+        // TODO: implement
+        throw new UnsupportedOperationException();
+    }
+
+
+    //region ASTVisitor implementation for nodes unrelated to semantic analysis
+    @Override
+    public Void visit(DecNumNode node) {
+        return null;
+    }
+
+    @Override
+    public Void visit(NumNode node) {
+        return null;
+    }
+
+    @Override
+    public Void visit(StringNode node) {
+        return null;
+    }
+
+    @Override
+    public Void visit(DotDefNode node) {
+        return null;
+    }
+
+    @Override
+    public Void visit(EdgeRhsNode node) {
+        return null;
+    }
+
+    @Override
+    public Void visit(EdgeStmtNode node) {
+        return null;
+    }
+
+    @Override
+    public Void visit(EdgeOpNode node) {
+        return null;
+    }
+
+    @Override
+    public Void visit(BoolNode node) {
+        return null;
+    }
+    //endregion
 }

--- a/dsl/src/semanticanalysis/SemanticAnalyzer.java
+++ b/dsl/src/semanticanalysis/SemanticAnalyzer.java
@@ -531,8 +531,7 @@ public class SemanticAnalyzer implements AstVisitor<Void> {
         throw new UnsupportedOperationException();
     }
 
-
-    //region ASTVisitor implementation for nodes unrelated to semantic analysis
+    // region ASTVisitor implementation for nodes unrelated to semantic analysis
     @Override
     public Void visit(DecNumNode node) {
         return null;
@@ -572,5 +571,5 @@ public class SemanticAnalyzer implements AstVisitor<Void> {
     public Void visit(BoolNode node) {
         return null;
     }
-    //endregion
+    // endregion
 }

--- a/dsl/src/semanticanalysis/VariableBinder.java
+++ b/dsl/src/semanticanalysis/VariableBinder.java
@@ -161,4 +161,112 @@ public class VariableBinder implements AstVisitor<Void> {
         }
         return null;
     }
+
+    @Override
+    public Void visit(AssignmentNode node) {
+        // TODO: implement
+        throw new UnsupportedOperationException();
+    }
+
+    //region ASTVisitor implementation of Nodes unrelated to variable binding
+    @Override
+    public Void visit(DecNumNode node) {
+        return null;
+    }
+
+    @Override
+    public Void visit(NumNode node) {
+        return null;
+    }
+
+    @Override
+    public Void visit(EdgeRhsNode node) {
+        return null;
+    }
+
+    @Override
+    public Void visit(EdgeStmtNode node) {
+        return null;
+    }
+
+    @Override
+    public Void visit(EdgeOpNode node) {
+        return null;
+    }
+
+    @Override
+    public Void visit(PropertyDefNode node) {
+        return null;
+    }
+
+    @Override
+    public Void visit(FuncCallNode node) {
+        return null;
+    }
+
+    @Override
+    public Void visit(AggregateValueDefinitionNode node) {
+        return null;
+    }
+
+    @Override
+    public Void visit(ParamDefNode node) {
+        return null;
+    }
+
+    @Override
+    public Void visit(PrototypeDefinitionNode node) {
+        return null;
+    }
+
+    @Override
+    public Void visit(ReturnStmtNode node) {
+        return null;
+    }
+
+    @Override
+    public Void visit(BoolNode node) {
+        return null;
+    }
+
+    @Override
+    public Void visit(MemberAccessNode node) {
+        return null;
+    }
+
+    @Override
+    public Void visit(LogicOrNode node) {
+        return null;
+    }
+
+    @Override
+    public Void visit(LogicAndNode node) {
+        return null;
+    }
+
+    @Override
+    public Void visit(EqualityNode node) {
+        return null;
+    }
+
+    @Override
+    public Void visit(ComparisonNode node) {
+        return null;
+    }
+
+    @Override
+    public Void visit(TermNode node) {
+        return null;
+    }
+
+    @Override
+    public Void visit(FactorNode node) {
+        return null;
+    }
+
+    @Override
+    public Void visit(UnaryNode node) {
+        return null;
+    }
+    //endregion
 }

--- a/dsl/src/semanticanalysis/VariableBinder.java
+++ b/dsl/src/semanticanalysis/VariableBinder.java
@@ -168,7 +168,7 @@ public class VariableBinder implements AstVisitor<Void> {
         throw new UnsupportedOperationException();
     }
 
-    //region ASTVisitor implementation of Nodes unrelated to variable binding
+    // region ASTVisitor implementation of Nodes unrelated to variable binding
     @Override
     public Void visit(DecNumNode node) {
         return null;
@@ -268,5 +268,5 @@ public class VariableBinder implements AstVisitor<Void> {
     public Void visit(UnaryNode node) {
         return null;
     }
-    //endregion
+    // endregion
 }

--- a/dsl/src/semanticanalysis/types/TypeBinder.java
+++ b/dsl/src/semanticanalysis/types/TypeBinder.java
@@ -1,9 +1,6 @@
 package semanticanalysis.types;
 
-import parser.ast.AggregateValueDefinitionNode;
-import parser.ast.AstVisitor;
-import parser.ast.Node;
-import parser.ast.PrototypeDefinitionNode;
+import parser.ast.*;
 
 import runtime.IEvironment;
 
@@ -88,4 +85,151 @@ public class TypeBinder implements AstVisitor<Object> {
         }
         return typeSymbol;
     }
+
+    //region ASTVisitor implementation for nodes unrelated to type binding
+    @Override
+    public Object visit(Node node) {
+        return null;
+    }
+
+    @Override
+    public Object visit(IdNode node) {
+        return null;
+    }
+
+    @Override
+    public Object visit(DecNumNode node) {
+        return null;
+    }
+
+    @Override
+    public Object visit(NumNode node) {
+        return null;
+    }
+
+    @Override
+    public Object visit(StringNode node) {
+        return null;
+    }
+
+    @Override
+    public Object visit(BinaryNode node) {
+        return null;
+    }
+
+    @Override
+    public Object visit(DotDefNode node) {
+        return null;
+    }
+
+    @Override
+    public Object visit(EdgeRhsNode node) {
+        return null;
+    }
+
+    @Override
+    public Object visit(EdgeStmtNode node) {
+        return null;
+    }
+
+    @Override
+    public Object visit(EdgeOpNode node) {
+        return null;
+    }
+
+    @Override
+    public Object visit(PropertyDefNode node) {
+        return null;
+    }
+
+    @Override
+    public Object visit(ObjectDefNode node) {
+        return null;
+    }
+
+    @Override
+    public Object visit(FuncCallNode node) {
+        return null;
+    }
+
+    @Override
+    public Object visit(FuncDefNode node) {
+        return null;
+    }
+
+    @Override
+    public Object visit(ParamDefNode node) {
+        return null;
+    }
+
+    @Override
+    public Object visit(ReturnStmtNode node) {
+        return null;
+    }
+
+    @Override
+    public Object visit(ConditionalStmtNodeIf node) {
+        return null;
+    }
+
+    @Override
+    public Object visit(ConditionalStmtNodeIfElse node) {
+        return null;
+    }
+
+    @Override
+    public Object visit(StmtBlockNode node) {
+        return null;
+    }
+
+    @Override
+    public Object visit(BoolNode node) {
+        return null;
+    }
+
+    @Override
+    public Object visit(MemberAccessNode node) {
+        return null;
+    }
+
+    @Override
+    public Object visit(LogicOrNode node) {
+        return null;
+    }
+
+    @Override
+    public Object visit(LogicAndNode node) {
+        return null;
+    }
+
+    @Override
+    public Object visit(EqualityNode node) {
+        return null;
+    }
+
+    @Override
+    public Object visit(ComparisonNode node) {
+        return null;
+    }
+
+    @Override
+    public Object visit(TermNode node) {
+        return null;
+    }
+
+    @Override
+    public Object visit(FactorNode node) {
+        return null;
+    }
+
+    @Override
+    public Object visit(UnaryNode node) {
+        return null;
+    }
+
+    @Override
+    public Object visit(AssignmentNode node) {
+        return null;
+    }
+    //endregion
 }

--- a/dsl/src/semanticanalysis/types/TypeBinder.java
+++ b/dsl/src/semanticanalysis/types/TypeBinder.java
@@ -86,7 +86,7 @@ public class TypeBinder implements AstVisitor<Object> {
         return typeSymbol;
     }
 
-    //region ASTVisitor implementation for nodes unrelated to type binding
+    // region ASTVisitor implementation for nodes unrelated to type binding
     @Override
     public Object visit(Node node) {
         return null;
@@ -231,5 +231,5 @@ public class TypeBinder implements AstVisitor<Object> {
     public Object visit(AssignmentNode node) {
         return null;
     }
-    //endregion
+    // endregion
 }

--- a/dsl/test/parser/TestDungeonASTConverter.java
+++ b/dsl/test/parser/TestDungeonASTConverter.java
@@ -577,4 +577,124 @@ public class TestDungeonASTConverter {
         var elseStmt = ((ConditionalStmtNodeIfElse) conditionalStmt).getElseStmt();
         Assert.assertEquals(Node.Type.Block, elseStmt.type);
     }
+
+    @Test
+    public void testUnary() {
+        String program =
+                """
+                fn test_func() {
+                    !true;
+                }
+            """;
+
+        var ast = Helpers.getASTFromString(program);
+        var funcDefNode = (FuncDefNode) ast.getChild(0);
+        var stmts = funcDefNode.getStmts();
+        var unaryStmt = stmts.get(0);
+        Assert.assertEquals(Node.Type.Unary, unaryStmt.type);
+    }
+
+    @Test
+    public void testFactor() {
+        String program =
+                """
+                fn test_func() {
+                    !true;
+                }
+            """;
+
+        var ast = Helpers.getASTFromString(program);
+        Assert.assertTrue(false);
+    }
+
+    @Test
+    public void testTerm() {
+        String program =
+                """
+                fn test_func() {
+                    !true;
+                }
+            """;
+
+        var ast = Helpers.getASTFromString(program);
+        Assert.assertTrue(false);
+    }
+
+    @Test
+    public void testEquality() {
+        String program =
+                """
+                fn test_func() {
+                    !true;
+                }
+            """;
+
+        var ast = Helpers.getASTFromString(program);
+        Assert.assertTrue(false);
+    }
+
+    @Test
+    public void testLogicAnd() {
+        String program =
+                """
+                fn test_func() {
+                    !true;
+                }
+            """;
+
+        var ast = Helpers.getASTFromString(program);
+        Assert.assertTrue(false);
+    }
+
+    @Test
+    public void testLogicOr() {
+        String program =
+                """
+                fn test_func() {
+                    !true;
+                }
+            """;
+
+        var ast = Helpers.getASTFromString(program);
+        Assert.assertTrue(false);
+    }
+
+    @Test
+    public void testAssignment() {
+        String program =
+                """
+                fn test_func() {
+                    !true;
+                }
+            """;
+
+        var ast = Helpers.getASTFromString(program);
+        Assert.assertTrue(false);
+    }
+
+    @Test
+    public void testMethodCallExpression() {
+        String program =
+                """
+                fn test_func() {
+                    !true;
+                }
+            """;
+
+        var ast = Helpers.getASTFromString(program);
+        Assert.assertTrue(false);
+    }
+
+    @Test
+    public void testMemberAccessExpression() {
+        String program =
+                """
+                fn test_func() {
+                    !true;
+                }
+            """;
+
+        var ast = Helpers.getASTFromString(program);
+        Assert.assertTrue(false);
+    }
 }

--- a/dsl/test/parser/TestDungeonASTConverter.java
+++ b/dsl/test/parser/TestDungeonASTConverter.java
@@ -578,20 +578,32 @@ public class TestDungeonASTConverter {
         Assert.assertEquals(Node.Type.Block, elseStmt.type);
     }
 
+
     @Test
     public void testUnary() {
         String program =
                 """
                 fn test_func() {
                     !true;
+                    -4;
                 }
             """;
 
         var ast = Helpers.getASTFromString(program);
         var funcDefNode = (FuncDefNode) ast.getChild(0);
         var stmts = funcDefNode.getStmts();
+
+        // first statement
         var unaryStmt = stmts.get(0);
         Assert.assertEquals(Node.Type.Unary, unaryStmt.type);
+        var unaryNode = (UnaryNode) unaryStmt;
+        Assert.assertEquals(UnaryNode.UnaryType.not, unaryNode.getUnaryType());
+
+        // second statement
+        unaryStmt = stmts.get(1);
+        Assert.assertEquals(Node.Type.Unary, unaryStmt.type);
+        unaryNode = (UnaryNode) unaryStmt;
+        Assert.assertEquals(UnaryNode.UnaryType.minus, unaryNode.getUnaryType());
     }
 
     @Test

--- a/dsl/test/parser/TestDungeonASTConverter.java
+++ b/dsl/test/parser/TestDungeonASTConverter.java
@@ -698,6 +698,51 @@ public class TestDungeonASTConverter {
     }
 
     @Test
+    public void testComparison() {
+        String program =
+            """
+            fn test_func() {
+                1 > 5;
+                2 >= 6;
+                3 < 7;
+                4 <= 8;
+            }
+        """;
+
+        var ast = Helpers.getASTFromString(program);
+        var funcDefNode = (FuncDefNode) ast.getChild(0);
+        var stmts = funcDefNode.getStmts();
+
+        // first statement
+        var compStmt = stmts.get(0);
+        Assert.assertEquals(Node.Type.Comparison, compStmt.type);
+
+        ComparisonNode compNode = (ComparisonNode) compStmt;
+        Assert.assertEquals(ComparisonNode.ComparisonType.greaterThan, compNode.getComparisonType());
+
+        // second statement
+        compStmt = stmts.get(1);
+        Assert.assertEquals(Node.Type.Comparison, compStmt.type);
+
+        compNode = (ComparisonNode) compStmt;
+        Assert.assertEquals(ComparisonNode.ComparisonType.greaterEquals, compNode.getComparisonType());
+
+        // third statement
+        compStmt = stmts.get(2);
+        Assert.assertEquals(Node.Type.Comparison, compStmt.type);
+
+        compNode = (ComparisonNode) compStmt;
+        Assert.assertEquals(ComparisonNode.ComparisonType.lessThan, compNode.getComparisonType());
+
+        // fourth statement
+        compStmt = stmts.get(3);
+        Assert.assertEquals(Node.Type.Comparison, compStmt.type);
+
+        compNode = (ComparisonNode) compStmt;
+        Assert.assertEquals(ComparisonNode.ComparisonType.lessEquals, compNode.getComparisonType());
+    }
+
+    @Test
     public void testEquality() {
         String program =
                 """

--- a/dsl/test/parser/TestDungeonASTConverter.java
+++ b/dsl/test/parser/TestDungeonASTConverter.java
@@ -826,11 +826,36 @@ public class TestDungeonASTConverter {
     }
 
     @Test
+    public void testAssignmentMemberAccessWithCall() {
+        String program =
+            """
+            fn test_func() {
+                my_func().test = 4;
+            }
+        """;
+
+        var ast = Helpers.getASTFromString(program);
+        var funcDefNode = (FuncDefNode) ast.getChild(0);
+        var stmts = funcDefNode.getStmts();
+
+        var assignmentStmt = stmts.get(0);
+        Assert.assertEquals(Node.Type.Assignment, assignmentStmt.type);
+
+        AssignmentNode assignmentNode = (AssignmentNode) assignmentStmt;
+        Assert.assertEquals(Node.Type.MemberAccess, assignmentNode.getLhs().type);
+        Assert.assertEquals(Node.Type.Number, assignmentNode.getRhs().type);
+
+        MemberAccessNode memberAccessNode = (MemberAccessNode) assignmentNode.getLhs();
+        Assert.assertEquals(Node.Type.FuncCall, memberAccessNode.getLhs().type);
+        Assert.assertEquals(Node.Type.Identifier, memberAccessNode.getRhs().type);
+    }
+
+    @Test
     public void testAssignmentMemberAccess() {
         String program =
                 """
                 fn test_func() {
-                    my_var = 4;
+                    my_var.test = 4;
                 }
             """;
 
@@ -842,7 +867,12 @@ public class TestDungeonASTConverter {
         Assert.assertEquals(Node.Type.Assignment, assignmentStmt.type);
 
         AssignmentNode assignmentNode = (AssignmentNode) assignmentStmt;
-        Assert.assertEquals(Node.Type.Identifier, assignmentNode.getLhs().type);
+        Assert.assertEquals(Node.Type.MemberAccess, assignmentNode.getLhs().type);
+        Assert.assertEquals(Node.Type.Number, assignmentNode.getRhs().type);
+
+        MemberAccessNode memberAccessNode = (MemberAccessNode) assignmentNode.getLhs();
+        Assert.assertEquals(Node.Type.Identifier, memberAccessNode.getLhs().type);
+        Assert.assertEquals(Node.Type.Identifier, memberAccessNode.getRhs().type);
     }
 
     @Test

--- a/dsl/test/parser/TestDungeonASTConverter.java
+++ b/dsl/test/parser/TestDungeonASTConverter.java
@@ -636,7 +636,7 @@ public class TestDungeonASTConverter {
         Assert.assertEquals(Node.Type.Number, rhs.type);
         Assert.assertEquals(2, ((NumNode)rhs).getValue());
 
-        // seconds statement
+        // second statement
         factorStmt = stmts.get(1);
         Assert.assertEquals(Node.Type.Factor, factorStmt.type);
 
@@ -657,12 +657,44 @@ public class TestDungeonASTConverter {
         String program =
                 """
                 fn test_func() {
-                    !true;
+                    4 + 2;
+                    3 - 1;
                 }
             """;
 
         var ast = Helpers.getASTFromString(program);
-        Assert.assertTrue(false);
+        var funcDefNode = (FuncDefNode) ast.getChild(0);
+        var stmts = funcDefNode.getStmts();
+
+        // first statement
+        var termStmt = stmts.get(0);
+        Assert.assertEquals(Node.Type.Term, termStmt.type);
+
+        TermNode termNode = (TermNode) termStmt;
+        Assert.assertEquals(TermNode.TermType.plus, termNode.getTermType());
+
+        var lhs = termNode.getLhs();
+        Assert.assertEquals(Node.Type.Number, lhs.type);
+        Assert.assertEquals(4, ((NumNode)lhs).getValue());
+
+        var rhs = termNode.getRhs();
+        Assert.assertEquals(Node.Type.Number, rhs.type);
+        Assert.assertEquals(2, ((NumNode)rhs).getValue());
+
+        // second statement
+        termStmt = stmts.get(1);
+        Assert.assertEquals(Node.Type.Term, termStmt.type);
+
+        termNode = (TermNode) termStmt;
+        Assert.assertEquals(TermNode.TermType.minus, termNode.getTermType());
+
+        lhs = termNode.getLhs();
+        Assert.assertEquals(Node.Type.Number, lhs.type);
+        Assert.assertEquals(3, ((NumNode)lhs).getValue());
+
+        rhs = termNode.getRhs();
+        Assert.assertEquals(Node.Type.Number, rhs.type);
+        Assert.assertEquals(1, ((NumNode)rhs).getValue());
     }
 
     @Test

--- a/dsl/test/parser/TestDungeonASTConverter.java
+++ b/dsl/test/parser/TestDungeonASTConverter.java
@@ -630,11 +630,11 @@ public class TestDungeonASTConverter {
 
         var lhs = factorNode.getLhs();
         Assert.assertEquals(Node.Type.Number, lhs.type);
-        Assert.assertEquals(4, ((NumNode)lhs).getValue());
+        Assert.assertEquals(4, ((NumNode) lhs).getValue());
 
         var rhs = factorNode.getRhs();
         Assert.assertEquals(Node.Type.Number, rhs.type);
-        Assert.assertEquals(2, ((NumNode)rhs).getValue());
+        Assert.assertEquals(2, ((NumNode) rhs).getValue());
 
         // second statement
         factorStmt = stmts.get(1);
@@ -645,11 +645,11 @@ public class TestDungeonASTConverter {
 
         lhs = factorNode.getLhs();
         Assert.assertEquals(Node.Type.Number, lhs.type);
-        Assert.assertEquals(3, ((NumNode)lhs).getValue());
+        Assert.assertEquals(3, ((NumNode) lhs).getValue());
 
         rhs = factorNode.getRhs();
         Assert.assertEquals(Node.Type.Number, rhs.type);
-        Assert.assertEquals(1, ((NumNode)rhs).getValue());
+        Assert.assertEquals(1, ((NumNode) rhs).getValue());
     }
 
     @Test
@@ -675,11 +675,11 @@ public class TestDungeonASTConverter {
 
         var lhs = termNode.getLhs();
         Assert.assertEquals(Node.Type.Number, lhs.type);
-        Assert.assertEquals(4, ((NumNode)lhs).getValue());
+        Assert.assertEquals(4, ((NumNode) lhs).getValue());
 
         var rhs = termNode.getRhs();
         Assert.assertEquals(Node.Type.Number, rhs.type);
-        Assert.assertEquals(2, ((NumNode)rhs).getValue());
+        Assert.assertEquals(2, ((NumNode) rhs).getValue());
 
         // second statement
         termStmt = stmts.get(1);
@@ -690,17 +690,17 @@ public class TestDungeonASTConverter {
 
         lhs = termNode.getLhs();
         Assert.assertEquals(Node.Type.Number, lhs.type);
-        Assert.assertEquals(3, ((NumNode)lhs).getValue());
+        Assert.assertEquals(3, ((NumNode) lhs).getValue());
 
         rhs = termNode.getRhs();
         Assert.assertEquals(Node.Type.Number, rhs.type);
-        Assert.assertEquals(1, ((NumNode)rhs).getValue());
+        Assert.assertEquals(1, ((NumNode) rhs).getValue());
     }
 
     @Test
     public void testComparison() {
         String program =
-            """
+                """
             fn test_func() {
                 1 > 5;
                 2 >= 6;
@@ -718,14 +718,16 @@ public class TestDungeonASTConverter {
         Assert.assertEquals(Node.Type.Comparison, compStmt.type);
 
         ComparisonNode compNode = (ComparisonNode) compStmt;
-        Assert.assertEquals(ComparisonNode.ComparisonType.greaterThan, compNode.getComparisonType());
+        Assert.assertEquals(
+                ComparisonNode.ComparisonType.greaterThan, compNode.getComparisonType());
 
         // second statement
         compStmt = stmts.get(1);
         Assert.assertEquals(Node.Type.Comparison, compStmt.type);
 
         compNode = (ComparisonNode) compStmt;
-        Assert.assertEquals(ComparisonNode.ComparisonType.greaterEquals, compNode.getComparisonType());
+        Assert.assertEquals(
+                ComparisonNode.ComparisonType.greaterEquals, compNode.getComparisonType());
 
         // third statement
         compStmt = stmts.get(2);
@@ -808,7 +810,7 @@ public class TestDungeonASTConverter {
     @Test
     public void testAssignmentId() {
         String program =
-            """
+                """
             fn test_func() {
                 my_var = 4;
             }
@@ -828,7 +830,7 @@ public class TestDungeonASTConverter {
     @Test
     public void testAssignmentMemberAccessWithCall() {
         String program =
-            """
+                """
             fn test_func() {
                 my_func().test = 4;
             }

--- a/dsl/test/parser/TestDungeonASTConverter.java
+++ b/dsl/test/parser/TestDungeonASTConverter.java
@@ -747,12 +747,28 @@ public class TestDungeonASTConverter {
         String program =
                 """
                 fn test_func() {
-                    !true;
+                    test == other_test;
+                    test != other_test;
                 }
             """;
 
         var ast = Helpers.getASTFromString(program);
-        Assert.assertTrue(false);
+        var funcDefNode = (FuncDefNode) ast.getChild(0);
+        var stmts = funcDefNode.getStmts();
+
+        // first statement
+        var equalityStmt = stmts.get(0);
+        Assert.assertEquals(Node.Type.Equality, equalityStmt.type);
+
+        EqualityNode equalityNode = (EqualityNode) equalityStmt;
+        Assert.assertEquals(EqualityNode.EqualityType.equals, equalityNode.getEqualityType());
+
+        // second statement
+        equalityStmt = stmts.get(1);
+        Assert.assertEquals(Node.Type.Equality, equalityStmt.type);
+
+        equalityNode = (EqualityNode) equalityStmt;
+        Assert.assertEquals(EqualityNode.EqualityType.notEquals, equalityNode.getEqualityType());
     }
 
     @Test
@@ -760,12 +776,16 @@ public class TestDungeonASTConverter {
         String program =
                 """
                 fn test_func() {
-                    !true;
+                    lhs and rhs;
                 }
             """;
 
         var ast = Helpers.getASTFromString(program);
-        Assert.assertTrue(false);
+        var funcDefNode = (FuncDefNode) ast.getChild(0);
+        var stmts = funcDefNode.getStmts();
+
+        var andStmt = stmts.get(0);
+        Assert.assertEquals(Node.Type.LogicAnd, andStmt.type);
     }
 
     @Test
@@ -773,25 +793,56 @@ public class TestDungeonASTConverter {
         String program =
                 """
                 fn test_func() {
-                    !true;
+                    lhs or rhs;
                 }
             """;
 
         var ast = Helpers.getASTFromString(program);
-        Assert.assertTrue(false);
+        var funcDefNode = (FuncDefNode) ast.getChild(0);
+        var stmts = funcDefNode.getStmts();
+
+        var orStmt = stmts.get(0);
+        Assert.assertEquals(Node.Type.LogicOr, orStmt.type);
     }
 
     @Test
-    public void testAssignment() {
+    public void testAssignmentId() {
+        String program =
+            """
+            fn test_func() {
+                my_var = 4;
+            }
+        """;
+
+        var ast = Helpers.getASTFromString(program);
+        var funcDefNode = (FuncDefNode) ast.getChild(0);
+        var stmts = funcDefNode.getStmts();
+
+        var assignmentStmt = stmts.get(0);
+        Assert.assertEquals(Node.Type.Assignment, assignmentStmt.type);
+
+        AssignmentNode assignmentNode = (AssignmentNode) assignmentStmt;
+        Assert.assertEquals(Node.Type.Identifier, assignmentNode.getLhs().type);
+    }
+
+    @Test
+    public void testAssignmentMemberAccess() {
         String program =
                 """
                 fn test_func() {
-                    !true;
+                    my_var = 4;
                 }
             """;
 
         var ast = Helpers.getASTFromString(program);
-        Assert.assertTrue(false);
+        var funcDefNode = (FuncDefNode) ast.getChild(0);
+        var stmts = funcDefNode.getStmts();
+
+        var assignmentStmt = stmts.get(0);
+        Assert.assertEquals(Node.Type.Assignment, assignmentStmt.type);
+
+        AssignmentNode assignmentNode = (AssignmentNode) assignmentStmt;
+        Assert.assertEquals(Node.Type.Identifier, assignmentNode.getLhs().type);
     }
 
     @Test

--- a/dsl/test/parser/TestDungeonASTConverter.java
+++ b/dsl/test/parser/TestDungeonASTConverter.java
@@ -880,12 +880,24 @@ public class TestDungeonASTConverter {
         String program =
                 """
                 fn test_func() {
-                    !true;
+                    test = expr.func();
                 }
             """;
 
         var ast = Helpers.getASTFromString(program);
-        Assert.assertTrue(false);
+        var funcDefNode = (FuncDefNode) ast.getChild(0);
+        var stmts = funcDefNode.getStmts();
+
+        var assignmentStmt = stmts.get(0);
+        Assert.assertEquals(Node.Type.Assignment, assignmentStmt.type);
+
+        AssignmentNode assignmentNode = (AssignmentNode) assignmentStmt;
+        var rhs = assignmentNode.getRhs();
+        Assert.assertEquals(Node.Type.MemberAccess, rhs.type);
+
+        MemberAccessNode memberAccessNode = (MemberAccessNode) rhs;
+        Assert.assertEquals(Node.Type.Identifier, memberAccessNode.getLhs().type);
+        Assert.assertEquals(Node.Type.FuncCall, memberAccessNode.getRhs().type);
     }
 
     @Test
@@ -893,11 +905,23 @@ public class TestDungeonASTConverter {
         String program =
                 """
                 fn test_func() {
-                    !true;
+                    test = expr.identifier;
                 }
             """;
 
         var ast = Helpers.getASTFromString(program);
-        Assert.assertTrue(false);
+        var funcDefNode = (FuncDefNode) ast.getChild(0);
+        var stmts = funcDefNode.getStmts();
+
+        var assignmentStmt = stmts.get(0);
+        Assert.assertEquals(Node.Type.Assignment, assignmentStmt.type);
+
+        AssignmentNode assignmentNode = (AssignmentNode) assignmentStmt;
+        var rhs = assignmentNode.getRhs();
+        Assert.assertEquals(Node.Type.MemberAccess, rhs.type);
+
+        MemberAccessNode memberAccessNode = (MemberAccessNode) rhs;
+        Assert.assertEquals(Node.Type.Identifier, memberAccessNode.getLhs().type);
+        Assert.assertEquals(Node.Type.Identifier, memberAccessNode.getRhs().type);
     }
 }

--- a/dsl/test/parser/TestDungeonASTConverter.java
+++ b/dsl/test/parser/TestDungeonASTConverter.java
@@ -578,6 +578,7 @@ public class TestDungeonASTConverter {
         Assert.assertEquals(Node.Type.Block, elseStmt.type);
     }
 
+    // TODO: tests for complex expressions
 
     @Test
     public void testUnary() {

--- a/dsl/test/parser/TestDungeonASTConverter.java
+++ b/dsl/test/parser/TestDungeonASTConverter.java
@@ -599,12 +599,44 @@ public class TestDungeonASTConverter {
         String program =
                 """
                 fn test_func() {
-                    !true;
+                    4 * 2;
+                    3 / 1;
                 }
             """;
 
         var ast = Helpers.getASTFromString(program);
-        Assert.assertTrue(false);
+        var funcDefNode = (FuncDefNode) ast.getChild(0);
+        var stmts = funcDefNode.getStmts();
+
+        // first statement
+        var factorStmt = stmts.get(0);
+        Assert.assertEquals(Node.Type.Factor, factorStmt.type);
+
+        FactorNode factorNode = (FactorNode) factorStmt;
+        Assert.assertEquals(FactorNode.FactorType.multiply, factorNode.getFactorType());
+
+        var lhs = factorNode.getLhs();
+        Assert.assertEquals(Node.Type.Number, lhs.type);
+        Assert.assertEquals(4, ((NumNode)lhs).getValue());
+
+        var rhs = factorNode.getRhs();
+        Assert.assertEquals(Node.Type.Number, rhs.type);
+        Assert.assertEquals(2, ((NumNode)rhs).getValue());
+
+        // seconds statement
+        factorStmt = stmts.get(1);
+        Assert.assertEquals(Node.Type.Factor, factorStmt.type);
+
+        factorNode = (FactorNode) factorStmt;
+        Assert.assertEquals(FactorNode.FactorType.divide, factorNode.getFactorType());
+
+        lhs = factorNode.getLhs();
+        Assert.assertEquals(Node.Type.Number, lhs.type);
+        Assert.assertEquals(3, ((NumNode)lhs).getValue());
+
+        rhs = factorNode.getRhs();
+        Assert.assertEquals(Node.Type.Number, rhs.type);
+        Assert.assertEquals(1, ((NumNode)rhs).getValue());
     }
 
     @Test


### PR DESCRIPTION
Fixes #780 

Modifiziert die Grammatik zur Behandlung von Ausdrücken.
Fügt Regeln für arithmetische Ausdrücke, logische Ausdrücke, Vergleichsoperationen, Zuweisungen und Member-Zugriffe hinzu.
Implementiert die Konvertierung in AST-Knoten für die neuen Regeln.
Ändert das `ASTVisitor`-Interface so, dass eine `UnsupportedOperationException` geworfen wird, falls eine Implementierung des Interfaces eine bestimmte Methode nicht implementiert. Dass dies in der Vergangenheit nicht nötig war, hat schon einige Male zu langen Fehlersuchen geführt.