### PR TITLE
[GAME] HUD pausiert `LevelSystem` nicht mehr

### DIFF
--- a/game/src/core/systems/LevelSystem.java
+++ b/game/src/core/systems/LevelSystem.java
@@ -228,4 +228,10 @@ public final class LevelSystem extends System {
         else if (entityStream().anyMatch(this::isOnEndTile)) loadLevel(levelSize);
         drawLevel();
     }
+
+    /** LevelSystem can't be paused. If it is paused, the level will not be shown anymore. */
+    @Override
+    public void stop() {
+        run = true;
+    }
 }


### PR DESCRIPTION
fixes #857

Das `HudSystem` hat beim Aufrufen (Beispielweise bei der Pause-Funktion) alle anderen Systeme gestoppt. Dadurch wurde das `LevelSystem` auch gestoppt und wurde bei offenen "Menüs" nicht mehr gezeichnet. Dies wurde durch das Überschreiben der Funktion `LevelSystem#stop`, welche das pausieren des `LevelSystem`s nun verhindert, gelöst.