### PR TITLE
[Game] Replace collision for item pickup with interaction

### DIFF
--- a/dungeon/test/manual/quizquestion/WizardQuizTest.java
+++ b/dungeon/test/manual/quizquestion/WizardQuizTest.java
@@ -87,7 +87,12 @@ public class WizardQuizTest {
         new DrawComponent(wizard, "character/wizard");
         new TaskComponent(wizard, question);
         new InteractionComponent(
-                wizard, 1, false, UIAnswerCallback.askOnInteraction(question, showAnswersOnHud()));
+                wizard,
+                1,
+                false,
+                (entity, who) ->
+                        UIAnswerCallback.askOnInteraction(question, showAnswersOnHud())
+                                .accept(entity));
     }
 
     private static Consumer<Set<TaskContent>> showAnswersOnHud() {

--- a/game/src/contrib/components/InteractionComponent.java
+++ b/game/src/contrib/components/InteractionComponent.java
@@ -1,18 +1,20 @@
 package contrib.components;
 
+import com.badlogic.gdx.utils.Null;
+
 import core.Component;
 import core.Entity;
 
-import java.util.function.Consumer;
+import java.util.function.BiConsumer;
 
 /**
  * Allows interaction with the associated entity.
  *
- * <p>An interaction can be triggered using {@link #triggerInteraction()}. This happens in the
+ * <p>An interaction can be triggered using {@link #triggerInteraction(Entity)}. This happens in the
  * {@link core.systems.PlayerSystem} if the player presses the corresponding button on the keyboard
  * and is in the interaction range of this component.
  *
- * <p>What happens during an interaction is defined by the {@link Consumer<Entity>} {@link
+ * <p>What happens during an interaction is defined by the {@link BiConsumer<Entity, Entity>} {@link
  * #onInteraction}.
  *
  * <p>An interaction can be repeatable, in which case it can be triggered multiple times. If an
@@ -25,10 +27,10 @@ public final class InteractionComponent extends Component {
     public static final int DEFAULT_INTERACTION_RADIUS = 5;
     public static final boolean DEFAULT_REPEATABLE = true;
 
-    private static final Consumer<Entity> DEFAULT_INTERACTION = entity -> {};
+    private static final BiConsumer<Entity, Entity> DEFAULT_INTERACTION = (entity, who) -> {};
     private final float radius;
     private final boolean repeatable;
-    private final Consumer<Entity> onInteraction;
+    private final BiConsumer<Entity, Entity> onInteraction;
 
     /**
      * Create a new {@link InteractionComponent} and adds it to the associated entity.
@@ -42,7 +44,7 @@ public final class InteractionComponent extends Component {
             final Entity entity,
             float radius,
             boolean repeatable,
-            final Consumer<Entity> onInteraction) {
+            final BiConsumer<Entity, Entity> onInteraction) {
         super(entity);
         this.radius = radius;
         this.repeatable = repeatable;
@@ -68,9 +70,11 @@ public final class InteractionComponent extends Component {
      *
      * <p>If the interaction is not repeatable, this component will be removed from the entity
      * afterwards.
+     *
+     * @param who The entity that triggered the interaction.
      */
-    public void triggerInteraction() {
-        onInteraction.accept(entity);
+    public void triggerInteraction(@Null Entity who) {
+        onInteraction.accept(entity, who);
         if (!repeatable) entity.removeComponent(InteractionComponent.class);
     }
 

--- a/game/src/contrib/entities/EntityFactory.java
+++ b/game/src/contrib/entities/EntityFactory.java
@@ -22,7 +22,7 @@ import core.utils.components.draw.CoreAnimations;
 import java.io.IOException;
 import java.util.Random;
 import java.util.Set;
-import java.util.function.Consumer;
+import java.util.function.BiConsumer;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -214,15 +214,17 @@ public class EntityFactory {
 
         Entity monster = new Entity("monster");
         int itemRoll = RANDOM.nextInt(0, 10);
-        Consumer<Entity> onDeath = entity -> {};
+        BiConsumer<Entity, Entity> onDeath;
         if (itemRoll == 0) {
             ItemDataGenerator itemDataGenerator = new ItemDataGenerator();
             ItemData item = itemDataGenerator.generateItemData();
             InventoryComponent ic = new InventoryComponent(monster, 1);
             ic.add(item);
             onDeath = new DropItemsInteraction();
+        } else {
+            onDeath = (e, who) -> {};
         }
-        new HealthComponent(monster, health, onDeath);
+        new HealthComponent(monster, health, (e) -> onDeath.accept(e, null));
         new PositionComponent(monster);
         new AIComponent(
                 monster,

--- a/game/src/contrib/entities/EntityFactory.java
+++ b/game/src/contrib/entities/EntityFactory.java
@@ -125,7 +125,8 @@ public class EntityFactory {
 
         pc.registerCallback(
                 KeyboardConfig.INTERACT_WORLD.value(),
-                InteractionTool::interactWithClosestInteractable);
+                InteractionTool::interactWithClosestInteractable,
+                false);
 
         // skills
         pc.registerCallback(KeyboardConfig.FIRST_SKILL.value(), fireball::execute);

--- a/game/src/contrib/entities/WorldItemBuilder.java
+++ b/game/src/contrib/entities/WorldItemBuilder.java
@@ -1,12 +1,14 @@
 package contrib.entities;
 
-import contrib.components.CollideComponent;
+import contrib.components.InteractionComponent;
 import contrib.components.ItemComponent;
 import contrib.utils.components.item.ItemData;
 
 import core.Entity;
+import core.Game;
 import core.components.DrawComponent;
 import core.components.PositionComponent;
+import core.utils.Constants;
 import core.utils.Point;
 
 /** Class which creates all needed Components for a basic WorldItem */
@@ -23,11 +25,14 @@ public class WorldItemBuilder {
         new PositionComponent(droppedItem, new Point(0, 0));
         new DrawComponent(droppedItem, itemData.item().worldAnimation());
         new ItemComponent(droppedItem, itemData);
-        CollideComponent component = new CollideComponent(droppedItem);
-        component.collideEnter(
-                (a, b, direction) -> {
-                    itemData.triggerCollect(a, b);
+        new InteractionComponent(
+                droppedItem,
+                Constants.DEFAULT_ITEM_PICKUP_RADIUS,
+                false,
+                e -> {
+                    Game.hero().ifPresent(hero -> itemData.triggerCollect(hero, droppedItem));
                 });
+
         return droppedItem;
     }
 }

--- a/game/src/contrib/entities/WorldItemBuilder.java
+++ b/game/src/contrib/entities/WorldItemBuilder.java
@@ -30,9 +30,22 @@ public class WorldItemBuilder {
                 Constants.DEFAULT_ITEM_PICKUP_RADIUS,
                 false,
                 e -> {
-                    Game.hero().ifPresent(hero -> itemData.triggerCollect(hero, droppedItem));
+                    Game.hero().ifPresent(hero -> itemData.triggerCollect(e, hero));
                 });
 
+        return droppedItem;
+    }
+
+    /**
+     * Creates an Entity which then can be added to the game
+     *
+     * @param itemData the Data which should be given to the world Item
+     * @param position the position where the item should be placed
+     * @return the newly created Entity
+     */
+    public static Entity buildWorldItem(ItemData itemData, Point position) {
+        Entity droppedItem = buildWorldItem(itemData);
+        droppedItem.fetch(PositionComponent.class).ifPresent(pc -> pc.position(position));
         return droppedItem;
     }
 }

--- a/game/src/contrib/entities/WorldItemBuilder.java
+++ b/game/src/contrib/entities/WorldItemBuilder.java
@@ -5,7 +5,6 @@ import contrib.components.ItemComponent;
 import contrib.utils.components.item.ItemData;
 
 import core.Entity;
-import core.Game;
 import core.components.DrawComponent;
 import core.components.PositionComponent;
 import core.utils.Constants;
@@ -26,12 +25,7 @@ public class WorldItemBuilder {
         new DrawComponent(droppedItem, itemData.item().worldAnimation());
         new ItemComponent(droppedItem, itemData);
         new InteractionComponent(
-                droppedItem,
-                Constants.DEFAULT_ITEM_PICKUP_RADIUS,
-                false,
-                e -> {
-                    Game.hero().ifPresent(hero -> itemData.triggerCollect(e, hero));
-                });
+                droppedItem, Constants.DEFAULT_ITEM_PICKUP_RADIUS, false, itemData.onCollect());
 
         return droppedItem;
     }

--- a/game/src/contrib/utils/components/interaction/DropItemsInteraction.java
+++ b/game/src/contrib/utils/components/interaction/DropItemsInteraction.java
@@ -1,5 +1,7 @@
 package contrib.utils.components.interaction;
 
+import com.badlogic.gdx.utils.Null;
+
 import contrib.components.InteractionComponent;
 import contrib.components.InventoryComponent;
 import contrib.utils.components.item.ItemData;
@@ -12,6 +14,7 @@ import core.utils.components.draw.CoreAnimations;
 
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
 /**
@@ -30,7 +33,7 @@ import java.util.function.Consumer;
  * core.utils.components.draw.CoreAnimations#IDLE_RIGHT} animation will be set as the current
  * animation.
  */
-public class DropItemsInteraction implements Consumer<Entity> {
+public class DropItemsInteraction implements BiConsumer<Entity, Entity> {
 
     /**
      * Will drop all the items inside the {@link InventoryComponent} of the associated entity on the
@@ -46,8 +49,9 @@ public class DropItemsInteraction implements Consumer<Entity> {
      * animation.
      *
      * @param entity associated entity
+     * @param who The entity that triggered the interaction (may be null)
      */
-    public void accept(final Entity entity) {
+    public void accept(final Entity entity, final @Null Entity who) {
         InventoryComponent inventoryComponent =
                 entity.fetch(InventoryComponent.class)
                         .orElseThrow(

--- a/game/src/contrib/utils/components/interaction/InteractionTool.java
+++ b/game/src/contrib/utils/components/interaction/InteractionTool.java
@@ -37,7 +37,7 @@ public class InteractionTool {
                         .map(ic1 -> convertToData(ic1, heroPosition))
                         .filter(iReachable::apply)
                         .min((x, y) -> Float.compare(x.dist(), y.dist()));
-        data.ifPresent(x -> x.ic().triggerInteraction());
+        data.ifPresent(x -> x.ic().triggerInteraction(entity));
     }
 
     private static InteractionData convertToData(

--- a/game/src/contrib/utils/components/interaction/InteractionTool.java
+++ b/game/src/contrib/utils/components/interaction/InteractionTool.java
@@ -23,6 +23,12 @@ public class InteractionTool {
         interactWithClosestInteractable(entity, SIMPLE_REACHABLE);
     }
 
+    /**
+     * Interacts with the closest interactable entity.
+     *
+     * @param entity The entity that is interacting
+     * @param iReachable The function that determines if the entity is reachable
+     */
     public static void interactWithClosestInteractable(
             final Entity entity, final Function<InteractionData, Boolean> iReachable) {
         PositionComponent heroPosition =

--- a/game/src/contrib/utils/components/item/ItemData.java
+++ b/game/src/contrib/utils/components/item/ItemData.java
@@ -158,8 +158,7 @@ public class ItemData implements CraftingIngredient, CraftingResult {
      * @param position Position where to drop the item.
      */
     private static void defaultDrop(Entity who, ItemData which, Point position) {
-        Entity droppedItem = WorldItemBuilder.buildWorldItem(which);
-        droppedItem.fetch(PositionComponent.class).ifPresent(x -> x.position(position));
+        WorldItemBuilder.buildWorldItem(which, position);
     }
 
     /**

--- a/game/src/contrib/utils/components/item/ItemData.java
+++ b/game/src/contrib/utils/components/item/ItemData.java
@@ -12,7 +12,6 @@ import contrib.utils.components.stats.DamageModifier;
 
 import core.Entity;
 import core.Game;
-import core.components.PositionComponent;
 import core.utils.Point;
 import core.utils.TriConsumer;
 import core.utils.components.MissingComponentException;

--- a/game/src/core/utils/Constants.java
+++ b/game/src/core/utils/Constants.java
@@ -46,6 +46,7 @@ public final class Constants {
     public static final String QUIZ_MESSAGE_TASK = "Aufgabestellung";
     public static final String QUIZ_MESSAGE_SOLUTION = "Lösung";
     public static final int DEFAULT_INVENTORY_SIZE = 5;
+    public static final float DEFAULT_ITEM_PICKUP_RADIUS = 2.0f;
 
     /**
      * @param path the relative path to the resource

--- a/game/src/core/utils/components/draw/Animation.java
+++ b/game/src/core/utils/components/draw/Animation.java
@@ -120,6 +120,27 @@ public final class Animation {
     }
 
     /**
+     * Create an animation from single frame and the default configuration.
+     *
+     * @param fileName path to the frame
+     * @return The created Animation instance
+     */
+    public static Animation of(String fileName) {
+        return new Animation(List.of(fileName), DEFAULT_FRAME_TIME, DEFAULT_IS_LOOP);
+    }
+
+    /**
+     * Create an animation from single frame and the given configuration.
+     *
+     * @param fileName path to the frame
+     * @param frameTime How many frames to wait, before switching to the next texture?
+     * @return The created Animation instance
+     */
+    public static Animation of(String fileName, int frameTime) {
+        return new Animation(List.of(fileName), frameTime, DEFAULT_IS_LOOP);
+    }
+
+    /**
      * Create a new animation with default settings, and the missing_textures file as animation
      * frames.
      *

--- a/game/test/contrib/components/InteractionComponentTest.java
+++ b/game/test/contrib/components/InteractionComponentTest.java
@@ -8,7 +8,7 @@ import core.Entity;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-import java.util.function.Consumer;
+import java.util.function.BiConsumer;
 
 public class InteractionComponentTest {
 
@@ -26,7 +26,7 @@ public class InteractionComponentTest {
         Entity e = new Entity();
         float radius = 100;
         boolean repeat = true;
-        Consumer<Entity> iInteraction = Mockito.mock(Consumer.class);
+        BiConsumer<Entity, Entity> iInteraction = Mockito.mock(BiConsumer.class);
 
         InteractionComponent component = new InteractionComponent(e, radius, repeat, iInteraction);
 
@@ -36,48 +36,48 @@ public class InteractionComponentTest {
     /** Checks if the iInteraction is called on triggerInteraction */
     @Test
     public void triggerInteractionOnLinkedEntity() {
-        Consumer<Entity> iInteraction = Mockito.mock(Consumer.class);
+        BiConsumer<Entity, Entity> iInteraction = Mockito.mock(BiConsumer.class);
         Entity e = new Entity();
         InteractionComponent component = new InteractionComponent(e, 1, true, iInteraction);
-        component.triggerInteraction();
-        verify(iInteraction).accept(e);
+        component.triggerInteraction(null);
+        verify(iInteraction).accept(e, null);
         assertTrue(e.fetch(InteractionComponent.class).isPresent());
     }
 
     /** Checks if after the interaction the component gets removed */
     @Test
     public void triggerInteractionOnLinkedEntityRemovesComponent() {
-        Consumer<Entity> iInteraction = Mockito.mock(Consumer.class);
+        BiConsumer<Entity, Entity> iInteraction = Mockito.mock(BiConsumer.class);
         Entity e = new Entity();
         InteractionComponent component = new InteractionComponent(e, 1, false, iInteraction);
-        component.triggerInteraction();
-        verify(iInteraction).accept(e);
+        component.triggerInteraction(null);
+        verify(iInteraction).accept(e, null);
         assertFalse(e.fetch(InteractionComponent.class).isPresent());
     }
 
     /** Checks that the interaction only gets triggered for the linked iInteraction */
     @Test
     public void triggerInteractionNonLinkedEntity() {
-        Consumer<Entity> iInteraction = Mockito.mock(Consumer.class);
-        Consumer<Entity> iInteraction2 = Mockito.mock(Consumer.class);
+        BiConsumer<Entity, Entity> iInteraction = Mockito.mock(BiConsumer.class);
+        BiConsumer<Entity, Entity> iInteraction2 = Mockito.mock(BiConsumer.class);
         Entity e = new Entity();
         Entity e2 = new Entity();
         InteractionComponent component = new InteractionComponent(e, 1, true, iInteraction);
         InteractionComponent component2 = new InteractionComponent(e2, 1, true, iInteraction2);
-        component.triggerInteraction();
-        verify(iInteraction2, never()).accept(e);
+        component.triggerInteraction(null);
+        verify(iInteraction2, never()).accept(e, null);
     }
 
     /** Checks that the Component does not ge removed when the interaction was not triggered */
     @Test
     public void triggerInteractionNonLinkedEntityComponentNotRemoved() {
-        Consumer<Entity> iInteraction = Mockito.mock(Consumer.class);
-        Consumer<Entity> iInteraction2 = Mockito.mock(Consumer.class);
+        BiConsumer<Entity, Entity> iInteraction = Mockito.mock(BiConsumer.class);
+        BiConsumer<Entity, Entity> iInteraction2 = Mockito.mock(BiConsumer.class);
         Entity e = new Entity();
         Entity e2 = new Entity();
         InteractionComponent component = new InteractionComponent(e, 1, false, iInteraction);
         InteractionComponent component2 = new InteractionComponent(e2, 1, false, iInteraction2);
-        component.triggerInteraction();
+        component.triggerInteraction(null);
         assertTrue(e2.fetch(InteractionComponent.class).isPresent());
     }
 }

--- a/game/test/contrib/utils/components/interaction/ControlPointReachableTest.java
+++ b/game/test/contrib/utils/components/interaction/ControlPointReachableTest.java
@@ -71,7 +71,7 @@ public class ControlPointReachableTest {
         SimpleCounter s1 = new SimpleCounter();
         Entity e1 = new Entity();
         PositionComponent e1PC = new PositionComponent(e1, e1Point);
-        InteractionComponent e1IC = new InteractionComponent(e1, 3, false, (e) -> s1.inc());
+        InteractionComponent e1IC = new InteractionComponent(e1, 3, false, (e, who) -> s1.inc());
         PreparedEntityWithCounter first = new PreparedEntityWithCounter(e1, s1, e1PC, e1IC);
         return first;
     }

--- a/game/test/contrib/utils/components/interaction/InteractionToolTest.java
+++ b/game/test/contrib/utils/components/interaction/InteractionToolTest.java
@@ -106,7 +106,7 @@ public class InteractionToolTest {
         new PositionComponent(e, new Point(10, 10));
 
         SimpleCounter sc_e = new SimpleCounter();
-        new InteractionComponent(e, 5f, false, (x) -> sc_e.inc());
+        new InteractionComponent(e, 5f, false, (x, who) -> sc_e.inc());
 
         InteractionTool.interactWithClosestInteractable(Game.hero().get());
         assertEquals("No interaction should happen", 0, sc_e.getCount());


### PR DESCRIPTION
(fix #646)
Replaces the `CollisionComponent `on item entities with `InteractionComponent`. Also, it makes sure that only one item is picked up per interaction.