### PR TITLE
[DSL] Rename package CallbackAdapter to callbackadapter

### DIFF
--- a/dsl/src/semanticanalysis/types/TypeBuilder.java
+++ b/dsl/src/semanticanalysis/types/TypeBuilder.java
@@ -5,9 +5,9 @@ import core.utils.TriConsumer;
 import dslToGame.graph.Graph;
 
 import semanticanalysis.*;
-import semanticanalysis.types.CallbackAdapter.ConsumerFunctionTypeBuilder;
-import semanticanalysis.types.CallbackAdapter.FunctionFunctionTypeBuilder;
-import semanticanalysis.types.CallbackAdapter.IFunctionTypeBuilder;
+import semanticanalysis.types.callbackadapter.ConsumerFunctionTypeBuilder;
+import semanticanalysis.types.callbackadapter.FunctionFunctionTypeBuilder;
+import semanticanalysis.types.callbackadapter.IFunctionTypeBuilder;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;

--- a/dsl/src/semanticanalysis/types/TypeInstantiator.java
+++ b/dsl/src/semanticanalysis/types/TypeInstantiator.java
@@ -7,8 +7,8 @@ import runtime.IMemorySpace;
 import runtime.Value;
 
 import semanticanalysis.FunctionSymbol;
-import semanticanalysis.types.CallbackAdapter.CallbackAdapter;
-import semanticanalysis.types.CallbackAdapter.CallbackAdapterBuilder;
+import semanticanalysis.types.callbackadapter.CallbackAdapter;
+import semanticanalysis.types.callbackadapter.CallbackAdapterBuilder;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;

--- a/dsl/src/semanticanalysis/types/callbackadapter/CallbackAdapter.java
+++ b/dsl/src/semanticanalysis/types/callbackadapter/CallbackAdapter.java
@@ -1,4 +1,4 @@
-package semanticanalysis.types.CallbackAdapter;
+package semanticanalysis.types.callbackadapter;
 
 import core.utils.TriConsumer;
 

--- a/dsl/src/semanticanalysis/types/callbackadapter/CallbackAdapterBuilder.java
+++ b/dsl/src/semanticanalysis/types/callbackadapter/CallbackAdapterBuilder.java
@@ -1,4 +1,4 @@
-package semanticanalysis.types.CallbackAdapter;
+package semanticanalysis.types.callbackadapter;
 
 import interpreter.DSLInterpreter;
 

--- a/dsl/src/semanticanalysis/types/callbackadapter/ConsumerFunctionTypeBuilder.java
+++ b/dsl/src/semanticanalysis/types/callbackadapter/ConsumerFunctionTypeBuilder.java
@@ -1,4 +1,4 @@
-package semanticanalysis.types.CallbackAdapter;
+package semanticanalysis.types.callbackadapter;
 
 import semanticanalysis.types.BuiltInType;
 import semanticanalysis.types.FunctionType;

--- a/dsl/src/semanticanalysis/types/callbackadapter/FunctionFunctionTypeBuilder.java
+++ b/dsl/src/semanticanalysis/types/callbackadapter/FunctionFunctionTypeBuilder.java
@@ -1,4 +1,4 @@
-package semanticanalysis.types.CallbackAdapter;
+package semanticanalysis.types.callbackadapter;
 
 import semanticanalysis.types.FunctionType;
 import semanticanalysis.types.IType;

--- a/dsl/src/semanticanalysis/types/callbackadapter/IFunctionTypeBuilder.java
+++ b/dsl/src/semanticanalysis/types/callbackadapter/IFunctionTypeBuilder.java
@@ -1,4 +1,4 @@
-package semanticanalysis.types.CallbackAdapter;
+package semanticanalysis.types.callbackadapter;
 
 import semanticanalysis.types.FunctionType;
 import semanticanalysis.types.TypeBuilder;


### PR DESCRIPTION
Behebt den Benennungsfehler des `CallbackAdapter`-packages.