### PR TITLE
[GAME] use global loggerconfig and only log in file, not on console

### DIFF
--- a/game/src/contrib/components/CollideComponent.java
+++ b/game/src/contrib/components/CollideComponent.java
@@ -8,6 +8,7 @@ import core.utils.Point;
 import core.utils.TriConsumer;
 import core.utils.components.MissingComponentException;
 import core.utils.logging.CustomLogLevel;
+import core.utils.logging.LoggerConfig;
 
 import semanticanalysis.types.DSLContextMember;
 import semanticanalysis.types.DSLType;
@@ -52,7 +53,7 @@ public final class CollideComponent extends Component {
     private final Point size;
     private TriConsumer<Entity, Entity, Tile.Direction> collideEnter;
     private TriConsumer<Entity, Entity, Tile.Direction> collideLeave;
-    private final Logger LOGGER = Logger.getLogger(this.getClass().getName());
+    private final Logger LOGGER = LoggerConfig.getLogger(this.getClass().getName());
 
     /**
      * Create a new CollisionComponent and add it to the associated entity.

--- a/game/src/contrib/components/HealthComponent.java
+++ b/game/src/contrib/components/HealthComponent.java
@@ -9,6 +9,7 @@ import contrib.utils.components.health.DamageType;
 import core.Component;
 import core.Entity;
 import core.utils.logging.CustomLogLevel;
+import core.utils.logging.LoggerConfig;
 
 import semanticanalysis.types.DSLContextMember;
 import semanticanalysis.types.DSLType;
@@ -40,7 +41,7 @@ import java.util.logging.Logger;
 public final class HealthComponent extends Component {
     private final List<Damage> damageToGet;
     private @DSLTypeMember(name = "on_death_function") final Consumer<Entity> onDeath;
-    private final Logger LOGGER = Logger.getLogger(this.getClass().getName());
+    private final Logger LOGGER = LoggerConfig.getLogger(this.getClass().getName());
     private @DSLTypeMember(name = "maximal_health_points") int maximalHealthpoints;
     private int currentHealthpoints;
     private @Null Entity lastCause = null;

--- a/game/src/contrib/components/InventoryComponent.java
+++ b/game/src/contrib/components/InventoryComponent.java
@@ -5,6 +5,7 @@ import contrib.utils.components.item.ItemData;
 import core.Component;
 import core.Entity;
 import core.utils.logging.CustomLogLevel;
+import core.utils.logging.LoggerConfig;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -29,7 +30,7 @@ public final class InventoryComponent extends Component {
 
     private final Set<ItemData> inventory;
     private final int maxSize;
-    private final Logger LOGGER = Logger.getLogger(this.getClass().getName());
+    private final Logger LOGGER = LoggerConfig.getLogger(this.getClass().getName());
 
     /**
      * Create a new {@link InventoryComponent} with the given size and add it to the associated

--- a/game/src/contrib/entities/EntityFactory.java
+++ b/game/src/contrib/entities/EntityFactory.java
@@ -17,6 +17,7 @@ import core.level.utils.LevelElement;
 import core.utils.Point;
 import core.utils.components.MissingComponentException;
 import core.utils.components.draw.CoreAnimations;
+import core.utils.logging.LoggerConfig;
 
 import java.io.IOException;
 import java.util.Random;
@@ -31,7 +32,7 @@ import java.util.stream.IntStream;
  * static methods to construct various types of entities with different components.
  */
 public class EntityFactory {
-    private static final Logger LOGGER = Logger.getLogger(EntityFactory.class.getName());
+    private static final Logger LOGGER = LoggerConfig.getLogger(EntityFactory.class.getName());
     private static final Random RANDOM = new Random();
     private static final String HERO_FILE_PATH = "character/knight";
     private static final float X_SPEED_HERO = 0.3f;

--- a/game/src/contrib/utils/components/Debugger.java
+++ b/game/src/contrib/utils/components/Debugger.java
@@ -24,6 +24,7 @@ import core.utils.IVoidFunction;
 import core.utils.Point;
 import core.utils.components.MissingComponentException;
 import core.utils.logging.CustomLogLevel;
+import core.utils.logging.LoggerConfig;
 
 import java.io.IOException;
 import java.util.logging.Logger;
@@ -41,7 +42,7 @@ import java.util.logging.Logger;
  */
 public class Debugger {
 
-    private static final Logger LOGGER = Logger.getLogger(Debugger.class.getName());
+    private static final Logger LOGGER = LoggerConfig.getLogger(Debugger.class.getName());
 
     /**
      * Zooms the camera in or out by the given amount.

--- a/game/src/contrib/utils/components/skill/DamageProjectile.java
+++ b/game/src/contrib/utils/components/skill/DamageProjectile.java
@@ -13,6 +13,7 @@ import core.level.Tile;
 import core.utils.Point;
 import core.utils.TriConsumer;
 import core.utils.components.MissingComponentException;
+import core.utils.logging.LoggerConfig;
 
 import java.io.IOException;
 import java.util.function.Consumer;
@@ -25,7 +26,7 @@ import java.util.logging.Logger;
  * entity as a parameter.
  */
 public abstract class DamageProjectile implements Consumer<Entity> {
-    private static final Logger LOGGER = Logger.getLogger(DamageProjectile.class.getName());
+    private static final Logger LOGGER = LoggerConfig.getLogger(DamageProjectile.class.getName());
     private String pathToTexturesOfProjectile;
     private float projectileSpeed;
 

--- a/game/src/core/Component.java
+++ b/game/src/core/Component.java
@@ -1,5 +1,7 @@
 package core;
 
+import core.utils.logging.LoggerConfig;
+
 import java.util.logging.Logger;
 
 /**
@@ -30,7 +32,7 @@ public abstract class Component {
     public Component(Entity entity) {
         this.entity = entity;
         entity.addComponent(this);
-        Logger componentLogger = Logger.getLogger(this.getClass().getName());
+        Logger componentLogger = LoggerConfig.getLogger(this.getClass().getName());
         componentLogger.info(
                 "The component '"
                         + this.getClass().getName()

--- a/game/src/core/Entity.java
+++ b/game/src/core/Entity.java
@@ -1,5 +1,7 @@
 package core;
 
+import core.utils.logging.LoggerConfig;
+
 import semanticanalysis.types.DSLContextPush;
 import semanticanalysis.types.DSLType;
 
@@ -34,7 +36,7 @@ import java.util.stream.Stream;
 @DSLType(name = "entity")
 @DSLContextPush(name = "entity")
 public final class Entity implements Comparable<Entity> {
-    private static final Logger LOGGER = Logger.getLogger(Entity.class.getName());
+    private static final Logger LOGGER = LoggerConfig.getLogger(Entity.class.getName());
     private static int nextId = 0;
     private final int id;
     private final String name;

--- a/game/src/core/Game.java
+++ b/game/src/core/Game.java
@@ -32,6 +32,7 @@ import core.utils.DelayedSet;
 import core.utils.IVoidFunction;
 import core.utils.Point;
 import core.utils.components.MissingComponentException;
+import core.utils.logging.LoggerConfig;
 
 import java.io.IOException;
 import java.util.LinkedHashMap;
@@ -52,7 +53,7 @@ public final class Game extends ScreenAdapter {
     /** All entities that are currently active in the dungeon */
     private static final DelayedSet<Entity> entities = new DelayedSet<>();
 
-    private static final Logger LOGGER = Logger.getLogger("Game");
+    private static final Logger LOGGER = LoggerConfig.getLogger("Game");
     /**
      * The width of the game window in pixels.
      *

--- a/game/src/core/System.java
+++ b/game/src/core/System.java
@@ -1,5 +1,7 @@
 package core;
 
+import core.utils.logging.LoggerConfig;
+
 import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -29,7 +31,7 @@ import java.util.stream.Stream;
  * @see Component
  */
 public abstract class System {
-    protected static Logger LOGGER = Logger.getLogger("System");
+    protected static Logger LOGGER = LoggerConfig.getLogger("System");
     private final Set<Entity> entities;
     private final Class<? extends Component> keyComponent;
     private final Set<Class<? extends Component>> additionalComponents;

--- a/game/src/core/components/DrawComponent.java
+++ b/game/src/core/components/DrawComponent.java
@@ -8,6 +8,7 @@ import core.systems.VelocitySystem;
 import core.utils.components.draw.Animation;
 import core.utils.components.draw.CoreAnimations;
 import core.utils.components.draw.IPath;
+import core.utils.logging.LoggerConfig;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -49,7 +50,7 @@ import java.util.stream.Collectors;
  */
 public final class DrawComponent extends Component {
     private final Map<String, Animation> animationMap;
-    private final Logger LOGGER = Logger.getLogger(this.getClass().getName());
+    private final Logger LOGGER = LoggerConfig.getLogger(this.getClass().getName());
     private Animation currentAnimation;
 
     /**

--- a/game/src/core/components/PositionComponent.java
+++ b/game/src/core/components/PositionComponent.java
@@ -7,6 +7,7 @@ import core.level.Tile;
 import core.level.utils.LevelElement;
 import core.utils.Point;
 import core.utils.logging.CustomLogLevel;
+import core.utils.logging.LoggerConfig;
 
 import semanticanalysis.types.DSLContextMember;
 import semanticanalysis.types.DSLType;
@@ -27,7 +28,7 @@ import java.util.logging.Logger;
 @DSLType(name = "position_component")
 public final class PositionComponent extends Component {
 
-    private final Logger LOGGER = Logger.getLogger(this.getClass().getName());
+    private final Logger LOGGER = LoggerConfig.getLogger(this.getClass().getName());
     private Point position;
 
     /**

--- a/game/src/core/components/VelocityComponent.java
+++ b/game/src/core/components/VelocityComponent.java
@@ -3,6 +3,7 @@ package core.components;
 import core.Component;
 import core.Entity;
 import core.utils.logging.CustomLogLevel;
+import core.utils.logging.LoggerConfig;
 
 import semanticanalysis.types.DSLContextMember;
 import semanticanalysis.types.DSLType;
@@ -30,7 +31,7 @@ import java.util.logging.Logger;
  */
 @DSLType(name = "velocity_component")
 public final class VelocityComponent extends Component {
-    private final Logger LOGGER = Logger.getLogger(this.getClass().getName());
+    private final Logger LOGGER = LoggerConfig.getLogger(this.getClass().getName());
     private float currentXVelocity;
     private float currentYVelocity;
     private @DSLTypeMember(name = "x_velocity") float xVelocity;

--- a/game/src/core/systems/LevelSystem.java
+++ b/game/src/core/systems/LevelSystem.java
@@ -15,6 +15,7 @@ import core.utils.IVoidFunction;
 import core.utils.components.MissingComponentException;
 import core.utils.components.draw.Painter;
 import core.utils.components.draw.PainterConfig;
+import core.utils.logging.LoggerConfig;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -56,7 +57,7 @@ public final class LevelSystem extends System {
 
     private final IVoidFunction onLevelLoad;
     private final Painter painter;
-    private final Logger levelAPI_logger = Logger.getLogger(this.getClass().getName());
+    private final Logger LOGGER = LoggerConfig.getLogger(this.getClass().getName());
     private IGenerator gen;
 
     /**
@@ -127,7 +128,7 @@ public final class LevelSystem extends System {
     public void loadLevel(LevelSize size, DesignLabel label) {
         currentLevel = gen.level(label, size);
         onLevelLoad.execute();
-        levelAPI_logger.info("A new level was loaded.");
+        LOGGER.info("A new level was loaded.");
     }
 
     /**

--- a/game/src/core/utils/MissingHeroException.java
+++ b/game/src/core/utils/MissingHeroException.java
@@ -1,6 +1,7 @@
 package core.utils;
 
 import core.utils.logging.CustomLogLevel;
+import core.utils.logging.LoggerConfig;
 
 import java.util.logging.Logger;
 
@@ -14,14 +15,14 @@ public final class MissingHeroException extends NullPointerException {
      */
     public MissingHeroException(final String message) {
         super("There is no hero: " + message);
-        Logger exceptionLogger = Logger.getLogger(this.getClass().getName());
+        Logger exceptionLogger = LoggerConfig.getLogger(this.getClass().getName());
         exceptionLogger.log(CustomLogLevel.FATAL, "There is no hero: " + message);
     }
 
     /** Constructs a new MissingHeroException with default message. */
     public MissingHeroException() {
         super("There is no hero!");
-        Logger exceptionLogger = Logger.getLogger(this.getClass().getName());
+        Logger exceptionLogger = LoggerConfig.getLogger(this.getClass().getName());
         exceptionLogger.log(CustomLogLevel.FATAL, "There is no hero!");
     }
 }

--- a/game/src/core/utils/components/MissingComponentException.java
+++ b/game/src/core/utils/components/MissingComponentException.java
@@ -2,6 +2,7 @@ package core.utils.components;
 
 import core.Entity;
 import core.utils.logging.CustomLogLevel;
+import core.utils.logging.LoggerConfig;
 
 import java.util.logging.Logger;
 
@@ -20,7 +21,7 @@ public final class MissingComponentException extends NullPointerException {
      */
     public MissingComponentException(final String message) {
         super("Missing Component:" + message);
-        Logger exceptionLogger = Logger.getLogger(this.getClass().getName());
+        Logger exceptionLogger = LoggerConfig.getLogger(this.getClass().getName());
         exceptionLogger.log(CustomLogLevel.FATAL, "Missing Component: " + message);
     }
 

--- a/game/src/core/utils/logging/LoggerConfig.java
+++ b/game/src/core/utils/logging/LoggerConfig.java
@@ -41,8 +41,16 @@ public class LoggerConfig {
     public static void initBaseLogger() {
         baseLogger = Logger.getLogger("");
         baseLogger.setLevel(Level.ALL);
+        baseLogger.removeHandler(baseLogger.getHandlers()[0]);
         createCustomFileHandler();
-
         baseLogger.addHandler(customFileHandler);
+    }
+
+    public static Logger getLogger(String name) {
+        // If initBaseLogger() hasn't been called yet, call it now
+        if (baseLogger == null) {
+            initBaseLogger();
+        }
+        return Logger.getLogger(name);
     }
 }

--- a/game/src/starter/Main.java
+++ b/game/src/starter/Main.java
@@ -7,13 +7,14 @@ import contrib.utils.components.Debugger;
 
 import core.Game;
 import core.level.utils.LevelSize;
+import core.utils.logging.LoggerConfig;
 
 import java.io.IOException;
 import java.util.logging.Logger;
 
 public class Main {
     public static void main(String[] args) throws IOException {
-        Logger LOGGER = Logger.getLogger("Main");
+        Logger LOGGER = LoggerConfig.getLogger("Main");
         Debugger debugger = new Debugger();
         // start the game
         Game.hero(EntityFactory.newHero());


### PR DESCRIPTION
Bisher hatten wir alle Lognachrichten auch auf der Konsole ausgegeben. Dadurch wurde die Konsole komplett unübersichtlich und konnte nicht mehr wirklich sinnvoll verwendet werden. Dieser PR sorgt dafür, dass Lognachrichten nur noch im Log-File geschrieben werden und die Konsole dadurch wieder übersichtlicher wird.

Dafür wurde `LoggerConfig` um `#getLogger(String name)` erweitert, und alle im Code erzeugten Logger werden jetzt darüber initialisiert.
Warum? `LoggerConfig #initBaseLogger` wird in `Game#onSetup` aufgerufen. Erst danach wird der Handler für alle anderen erzeugten Logger auf die neue Konfiguration gesetzt.
Das Problem ist, dass bis `Game#onSetup` aufgerufen wird, bereits einige Logger initialisiert wurden (z. B. bei den Systemen).
Richtig glücklich bin ich damit nicht, da wir so immer darauf achten müssen, die Logger entsprechend über die Hilfsmethode zu initialisieren. Aber ich weiß auch nicht, wie wir sonst sicherstellen können, dass `initBaseLogger` vorher aufgerufen wird, ohne das in `Main` zu machen.

@Lena241 @fwatermann @JudiTeller @AHeinisch habt ihr Ideen?

Außerdem bekomme ich jetzt immer drei Dateien pro Run.
- `.log`, wo nur Info-Level geloggt wird
- `.log.1`, wo dann alles geloggt wird
- `.log.lck` ist leer