### PR TITLE
[GAME] Remove console log-handler, make init-logger part of the pre-run configuration.

### DIFF
--- a/dungeon/test/manual/dslFileReader/DslFileReaderTest.java
+++ b/dungeon/test/manual/dslFileReader/DslFileReaderTest.java
@@ -19,6 +19,7 @@ import java.util.stream.Collectors;
 public class DslFileReaderTest {
 
     public static void main(String[] args) throws IOException {
+        Game.initBaseLogger();
         Game.loadConfig(
                 "dungeon_config.json",
                 contrib.configuration.KeyboardConfig.class,

--- a/dungeon/test/manual/quizquestion/QuizQuestionUITest.java
+++ b/dungeon/test/manual/quizquestion/QuizQuestionUITest.java
@@ -22,6 +22,7 @@ import java.util.Random;
 public class QuizQuestionUITest {
 
     public static void main(String[] args) {
+        Game.initBaseLogger();
         Game.userOnFrame(
                 () -> {
                     if (Gdx.input.isKeyJustPressed(Input.Keys.F)) {

--- a/dungeon/test/manual/quizquestion/WizardQuizTest.java
+++ b/dungeon/test/manual/quizquestion/WizardQuizTest.java
@@ -42,6 +42,7 @@ public class WizardQuizTest {
     private static Quiz question = multipleChoiceDummy();
 
     private static void toggleQuiz() {
+        Game.initBaseLogger();
         switch (question.type()) {
             case FREETEXT -> question = singleChoiceDummy();
             case SINGLE_CHOICE -> question = multipleChoiceDummy();

--- a/game/src/core/Game.java
+++ b/game/src/core/Game.java
@@ -2,8 +2,6 @@ package core;
 
 import static com.badlogic.gdx.graphics.GL20.GL_COLOR_BUFFER_BIT;
 
-import static core.utils.logging.LoggerConfig.initBaseLogger;
-
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input;
 import com.badlogic.gdx.ScreenAdapter;
@@ -32,6 +30,7 @@ import core.utils.DelayedSet;
 import core.utils.IVoidFunction;
 import core.utils.Point;
 import core.utils.components.MissingComponentException;
+import core.utils.logging.LoggerConfig;
 
 import java.io.IOException;
 import java.util.LinkedHashMap;
@@ -326,6 +325,15 @@ public final class Game extends ScreenAdapter {
      */
     public static void disableAudio(boolean disableAudio) {
         DISABLE_AUDIO = disableAudio;
+    }
+
+    /**
+     * Initialize the base logger.
+     *
+     * <p>Will remove the console handler and put all log messages in the log files.
+     */
+    public static void initBaseLogger() {
+        LoggerConfig.initBaseLogger();
     }
 
     /**
@@ -644,7 +652,6 @@ public final class Game extends ScreenAdapter {
     private void onSetup() {
         doSetup = false;
         CameraSystem.camera().zoom = Constants.DEFAULT_ZOOM_FACTOR;
-        initBaseLogger();
         createSystems();
         setupStage();
     }

--- a/game/src/core/utils/logging/LoggerConfig.java
+++ b/game/src/core/utils/logging/LoggerConfig.java
@@ -41,8 +41,9 @@ public class LoggerConfig {
     public static void initBaseLogger() {
         baseLogger = Logger.getLogger("");
         baseLogger.setLevel(Level.ALL);
+        // remove console handler
+        baseLogger.removeHandler(baseLogger.getHandlers()[0]);
         createCustomFileHandler();
-
         baseLogger.addHandler(customFileHandler);
     }
 }

--- a/game/src/starter/Main.java
+++ b/game/src/starter/Main.java
@@ -13,6 +13,7 @@ import java.util.logging.Logger;
 
 public class Main {
     public static void main(String[] args) throws IOException {
+        Game.initBaseLogger();
         Logger LOGGER = Logger.getLogger("Main");
         Debugger debugger = new Debugger();
         // start the game


### PR DESCRIPTION
Damit die Konsole nicht mehr mit Log-Nachrichten geflutet wird, habe ich den Console-Handler aus dem Logger entfernt.
Zeitgleich wurde das Initialisieren des Base-Loggers Teil der Pre-Run-Konfiguration (muss daher in der `main` aufgerufen werden).
Damit die Konfiguration direkt zu Beginn gesetzt wird, sollte dies der erste Aufruf sein.
Log-Nachrichten, die vor `initBaseLogger()` erstellt werden, werden nämlich weiterhin auf der Konsole ausgegeben (der Console-Handler wurde ja schließlich nicht entfernt).
Um bei der aktuellen Pre-Run-API zu bleiben, wurde eine Hilfsmethode zum Initialisieren in `Game` angelegt.