### PR TITLE
[GAME] remove impliziertes registrieren von `System`s beim `Game` 

### DIFF
--- a/game/src/core/System.java
+++ b/game/src/core/System.java
@@ -9,6 +9,8 @@ import java.util.stream.Stream;
 /**
  * A System implements a specific game logic (a gameplay mechanic).
  *
+ * <p>A System needs to be registered with the Game via {@link Game#addSystem(System)}.
+ *
  * <p>This class is the abstract base class for each system. It implements the basic functionality
  * each system has. For example, it allows the system to be paused and unpause.
  *
@@ -69,7 +71,9 @@ public abstract class System {
     protected Consumer<Entity> onEntityShow = (e) -> {};
 
     /**
-     * Create a new system and add it to the game. {@link Game#addSystem}
+     * Create a new system.
+     *
+     * <p>A System needs to be registered with the Game via {@link Game#addSystem(System)}.
      *
      * <p>For each already existing entity in the game, check if the entity is accepted by {@link
      * #accept} and add it to the local set if so.
@@ -86,7 +90,6 @@ public abstract class System {
         if (additionalComponents != null) this.additionalComponents = Set.of(additionalComponents);
         else this.additionalComponents = new HashSet<>();
         entities = new HashSet<>();
-        Game.addSystem(this);
         Game.entityStream().forEach(this::showEntity);
         run = true;
         LOGGER.info("A new " + this.getClass().getName() + " was created");

--- a/game/test/contrib/entities/ChestTest.java
+++ b/game/test/contrib/entities/ChestTest.java
@@ -106,7 +106,7 @@ public class ChestTest {
     }*/
     @Test
     public void checkGeneratorMethod() throws IOException {
-        new LevelSystem(null, null, () -> {});
+        Game.addSystem(new LevelSystem(null, null, () -> {}));
 
         Game.currentLevel(
                 new TileLevel(

--- a/game/test/contrib/entities/MonsterTest.java
+++ b/game/test/contrib/entities/MonsterTest.java
@@ -25,7 +25,7 @@ import java.util.Optional;
 public class MonsterTest {
     @Before
     public void setup() {
-        new LevelSystem(null, null, () -> {});
+        Game.addSystem(new LevelSystem(null, null, () -> {}));
     }
 
     @After

--- a/game/test/contrib/systems/AISystemTest.java
+++ b/game/test/contrib/systems/AISystemTest.java
@@ -7,6 +7,7 @@ import contrib.components.AIComponent;
 import core.Entity;
 import core.Game;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -21,6 +22,7 @@ public class AISystemTest {
         Game.removeAllEntities();
         Game.removeAllSystems();
         system = new AISystem();
+        Game.addSystem(system);
         entity = new Entity();
         new AIComponent(
                 entity,
@@ -32,6 +34,13 @@ public class AISystemTest {
                 });
 
         updateCounter = 0;
+    }
+
+    @After
+    public void cleanup() {
+        Game.removeAllEntities();
+        Game.currentLevel(null);
+        Game.removeAllSystems();
     }
 
     @Test

--- a/game/test/contrib/systems/CollisionSystemTest.java
+++ b/game/test/contrib/systems/CollisionSystemTest.java
@@ -11,6 +11,7 @@ import core.level.Tile;
 import core.utils.Point;
 import core.utils.TriConsumer;
 
+import org.junit.After;
 import org.junit.Test;
 
 import testingUtils.SimpleCounter;
@@ -24,6 +25,13 @@ public class CollisionSystemTest {
             "Collision between the two hitboxes should be detected.";
     private static final String MISSING_POSITION_COMPONENT =
             "PositionComponent did get removed Test no longer valid";
+
+    @After
+    public void cleanup() {
+        Game.removeAllEntities();
+        Game.currentLevel(null);
+        Game.removeAllSystems();
+    }
 
     /**
      * Helper to clean up used Class Attributes to avoid interfering with other tests
@@ -63,6 +71,7 @@ public class CollisionSystemTest {
     public void checkForCollisionRight() {
         prepareEnvironment();
         CollisionSystem cs = new CollisionSystem();
+        Game.addSystem(cs);
         Point offset = new Point(0, 0);
         Point size = new Point(1, 1);
         Entity e1 = prepareEntityWithPosition(new Point(0, 0));
@@ -93,6 +102,7 @@ public class CollisionSystemTest {
     public void checkForCollisionRightNoIntersection() {
         prepareEnvironment();
         CollisionSystem cs = new CollisionSystem();
+        Game.addSystem(cs);
         Point offset = new Point(0, 0);
         Point size = new Point(1, 1);
         Entity e1 = prepareEntityWithPosition(new Point(0, 0));
@@ -123,6 +133,7 @@ public class CollisionSystemTest {
     public void checkForCollisionLeft() {
         prepareEnvironment();
         CollisionSystem cs = new CollisionSystem();
+        Game.addSystem(cs);
         Point offset = new Point(0, 0);
         Point size = new Point(1, 1);
         Entity e1 = prepareEntityWithPosition(new Point(0, 0));
@@ -152,7 +163,7 @@ public class CollisionSystemTest {
     public void checkForCollisionLeftNoIntersection() {
         prepareEnvironment();
         CollisionSystem cs = new CollisionSystem();
-
+        Game.addSystem(cs);
         Entity e1 = prepareEntityWithPosition(new Point(0, 0));
 
         Point offset = new Point(0, 0);
@@ -182,6 +193,7 @@ public class CollisionSystemTest {
     public void checkForCollisionBottomWithIntersection() {
         prepareEnvironment();
         CollisionSystem cs = new CollisionSystem();
+        Game.addSystem(cs);
         Point offset = new Point(0, 0);
         Point size = new Point(1, 1);
         Entity e1 = prepareEntityWithPosition(new Point(0, 0));
@@ -210,6 +222,7 @@ public class CollisionSystemTest {
     public void checkForCollisionBottomWithNoIntersection() {
         prepareEnvironment();
         CollisionSystem cs = new CollisionSystem();
+        Game.addSystem(cs);
         Point offset = new Point(0, 0);
         Point size = new Point(1, 1);
         Entity e1 = prepareEntityWithPosition(new Point(0, 0));
@@ -237,6 +250,7 @@ public class CollisionSystemTest {
     public void checkForCollisionTopWithIntersection() {
         prepareEnvironment();
         CollisionSystem cs = new CollisionSystem();
+        Game.addSystem(cs);
         Point offset = new Point(0, 0);
         Point size = new Point(1, 1);
         Entity e1 = prepareEntityWithPosition(new Point(0, 0));
@@ -265,6 +279,7 @@ public class CollisionSystemTest {
     public void checkForCollisionTopNoIntersection() {
         prepareEnvironment();
         CollisionSystem cs = new CollisionSystem();
+        Game.addSystem(cs);
         Point offset = new Point(0, 0);
         Point size = new Point(1, 1);
         Entity e1 = prepareEntityWithPosition(new Point(0, 0));
@@ -291,6 +306,7 @@ public class CollisionSystemTest {
     public void checkForCollisionBoxAAroundB() {
         prepareEnvironment();
         CollisionSystem cs = new CollisionSystem();
+        Game.addSystem(cs);
         Entity e1 = prepareEntityWithPosition(new Point(-.1f, -.1f));
         TriConsumer<Entity, Entity, Tile.Direction> collider = (a, b, c) -> {};
         CollideComponent hb1 =
@@ -324,6 +340,7 @@ public class CollisionSystemTest {
     public void checkForCollisionBoxBAroundA() {
         prepareEnvironment();
         CollisionSystem cs = new CollisionSystem();
+        Game.addSystem(cs);
         Entity e1 = prepareEntityWithPosition(new Point(0, 0));
         TriConsumer<Entity, Entity, Tile.Direction> collider = (a, b, c) -> {};
         CollideComponent hb1 =
@@ -353,7 +370,9 @@ public class CollisionSystemTest {
     @Test
     public void checkInverseN() {
         prepareEnvironment();
-        assertEquals(Tile.Direction.S, new CollisionSystem().inverse(Tile.Direction.N));
+        CollisionSystem cs = new CollisionSystem();
+        Game.addSystem(cs);
+        assertEquals(Tile.Direction.S, cs.inverse(Tile.Direction.N));
         cleanUpEnvironment();
     }
 
@@ -361,7 +380,9 @@ public class CollisionSystemTest {
     @Test
     public void checkInverseE() {
         prepareEnvironment();
-        assertEquals(Tile.Direction.W, new CollisionSystem().inverse(Tile.Direction.E));
+        CollisionSystem cs = new CollisionSystem();
+        Game.addSystem(cs);
+        assertEquals(Tile.Direction.W, cs.inverse(Tile.Direction.E));
         cleanUpEnvironment();
     }
 
@@ -369,7 +390,9 @@ public class CollisionSystemTest {
     @Test
     public void checkInverseS() {
         prepareEnvironment();
-        assertEquals(Tile.Direction.N, new CollisionSystem().inverse(Tile.Direction.S));
+        CollisionSystem cs = new CollisionSystem();
+        Game.addSystem(cs);
+        assertEquals(Tile.Direction.N, cs.inverse(Tile.Direction.S));
         cleanUpEnvironment();
     }
 
@@ -377,7 +400,9 @@ public class CollisionSystemTest {
     @Test
     public void checkInverseW() {
         prepareEnvironment();
-        assertEquals(Tile.Direction.E, new CollisionSystem().inverse(Tile.Direction.W));
+        CollisionSystem cs = new CollisionSystem();
+        Game.addSystem(cs);
+        assertEquals(Tile.Direction.E, cs.inverse(Tile.Direction.W));
         cleanUpEnvironment();
     }
 
@@ -386,6 +411,7 @@ public class CollisionSystemTest {
     public void checkUpdateNoEntities() {
         prepareEnvironment();
         CollisionSystem cs = new CollisionSystem();
+        Game.addSystem(cs);
         cs.execute();
         cleanUpEnvironment();
     }
@@ -395,6 +421,7 @@ public class CollisionSystemTest {
     public void checkUpdateNoEntitiesWithHitboxComponent() {
         prepareEnvironment();
         CollisionSystem cs = new CollisionSystem();
+        Game.addSystem(cs);
         prepareEntityWithPosition(new Point(0, 0));
         cs.execute();
         cleanUpEnvironment();
@@ -407,6 +434,7 @@ public class CollisionSystemTest {
     public void checkUpdateOneEntityWithHitboxComponent() {
         prepareEnvironment();
         CollisionSystem cs = new CollisionSystem();
+        Game.addSystem(cs);
         Entity e1 = prepareEntityWithPosition(new Point(0, 0));
         SimpleCounter sc1OnEnter = new SimpleCounter();
         SimpleCounter sc1OnLeave = new SimpleCounter();
@@ -427,6 +455,7 @@ public class CollisionSystemTest {
     public void checkUpdateTwoEntitiesWithHitboxComponentNonColliding() {
         prepareEnvironment();
         CollisionSystem cs = new CollisionSystem();
+        Game.addSystem(cs);
         Entity e1 = prepareEntityWithPosition(new Point(0, 0));
         SimpleCounter sc1OnEnter = new SimpleCounter();
         SimpleCounter sc1OnLeave = new SimpleCounter();

--- a/game/test/contrib/systems/HealthSystemTest.java
+++ b/game/test/contrib/systems/HealthSystemTest.java
@@ -12,6 +12,7 @@ import core.Entity;
 import core.Game;
 import core.components.DrawComponent;
 
+import org.junit.After;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -21,6 +22,13 @@ import java.util.function.Consumer;
 public class HealthSystemTest {
     private static final String ANIMATION_PATH = "character/blue_knight";
 
+    @After
+    public void cleanup() {
+        Game.removeAllEntities();
+        Game.currentLevel(null);
+        Game.removeAllSystems();
+    }
+
     @Test
     public void updateEntityDies() throws IOException {
         Game.removeAllEntities();
@@ -29,6 +37,7 @@ public class HealthSystemTest {
         DrawComponent ac = new DrawComponent(entity, ANIMATION_PATH);
         HealthComponent component = new HealthComponent(entity, 1, onDeath);
         HealthSystem system = new HealthSystem();
+        Game.addSystem(system);
         component.currentHealthpoints(0);
         system.showEntity(entity);
 
@@ -47,6 +56,7 @@ public class HealthSystemTest {
         component.receiveHit(new Damage(5, DamageType.FIRE, null));
         component.receiveHit(new Damage(2, DamageType.FIRE, null));
         HealthSystem system = new HealthSystem();
+        Game.addSystem(system);
         system.showEntity(entity);
 
         system.execute();
@@ -64,6 +74,7 @@ public class HealthSystemTest {
         component.currentHealthpoints(3);
         component.receiveHit(new Damage(-3, DamageType.FIRE, null));
         HealthSystem system = new HealthSystem();
+        Game.addSystem(system);
         system.showEntity(entity);
         system.execute();
         assertEquals(6, component.currentHealthpoints());
@@ -79,6 +90,7 @@ public class HealthSystemTest {
         HealthComponent component = new HealthComponent(entity, 10, onDeath);
         component.receiveHit(new Damage(0, DamageType.FIRE, null));
         HealthSystem system = new HealthSystem();
+        Game.addSystem(system);
         system.showEntity(entity);
         system.execute();
         assertEquals(10, component.currentHealthpoints());
@@ -89,6 +101,7 @@ public class HealthSystemTest {
     public void updateWithoutHealthComponent() {
         Game.removeAllEntities();
         HealthSystem system = new HealthSystem();
+        Game.addSystem(system);
         system.execute();
     }
 
@@ -106,6 +119,7 @@ public class HealthSystemTest {
         healthComponent.receiveHit(new Damage(10, DamageType.PHYSICAL, null));
 
         HealthSystem system = new HealthSystem();
+        Game.addSystem(system);
         system.showEntity(entity);
 
         system.execute();
@@ -127,6 +141,7 @@ public class HealthSystemTest {
         healthComponent.receiveHit(new Damage(10, DamageType.PHYSICAL, null));
 
         HealthSystem system = new HealthSystem();
+        Game.addSystem(system);
         system.showEntity(entity);
 
         system.execute();
@@ -148,6 +163,7 @@ public class HealthSystemTest {
         healthComponent.receiveHit(new Damage(10, DamageType.PHYSICAL, null));
 
         HealthSystem system = new HealthSystem();
+        Game.addSystem(system);
         system.showEntity(entity);
 
         system.execute();
@@ -169,6 +185,7 @@ public class HealthSystemTest {
         healthComponent.receiveHit(new Damage(10, DamageType.PHYSICAL, null));
 
         HealthSystem system = new HealthSystem();
+        Game.addSystem(system);
         system.showEntity(entity);
 
         system.execute();

--- a/game/test/contrib/systems/XPSystemTest.java
+++ b/game/test/contrib/systems/XPSystemTest.java
@@ -7,12 +7,20 @@ import contrib.components.XPComponent;
 import core.Entity;
 import core.Game;
 
+import org.junit.After;
 import org.junit.Test;
 import org.mockito.Mockito;
 
 import java.util.function.Consumer;
 
 public class XPSystemTest {
+
+    @After
+    public void cleanup() {
+        Game.removeAllEntities();
+        Game.currentLevel(null);
+        Game.removeAllSystems();
+    }
 
     /** Test if the xp component ist initialized with zero xp and level zero. */
     @Test
@@ -24,6 +32,7 @@ public class XPSystemTest {
         Consumer<Entity> levelUp = Mockito.mock(Consumer.class);
         XPComponent xpComponent = new XPComponent(entity, levelUp);
         XPSystem xpSystem = new XPSystem();
+        Game.addSystem(xpSystem);
         xpSystem.showEntity(entity);
         assertEquals(0, xpComponent.currentXP());
         assertEquals(0, xpComponent.characterLevel());
@@ -42,6 +51,7 @@ public class XPSystemTest {
         Consumer<Entity> levelUp = Mockito.mock(Consumer.class);
         XPComponent xpComponent = new XPComponent(entity, levelUp);
         XPSystem xpSystem = new XPSystem();
+        Game.addSystem(xpSystem);
         xpSystem.showEntity(entity);
         /* Test */
         xpComponent.addXP(99); // First level is reached with 100 XP
@@ -59,6 +69,7 @@ public class XPSystemTest {
         Consumer<Entity> levelUp = Mockito.mock(Consumer.class);
         XPComponent xpComponent = new XPComponent(entity, levelUp);
         XPSystem xpSystem = new XPSystem();
+        Game.addSystem(xpSystem);
         xpSystem.showEntity(entity);
         /* Test */
         xpComponent.addXP(100); // First level is reached with 100 XP
@@ -78,6 +89,7 @@ public class XPSystemTest {
         Consumer<Entity> levelUp = Mockito.mock(Consumer.class);
         XPComponent xpComponent = new XPComponent(entity, levelUp);
         XPSystem xpSystem = new XPSystem();
+        Game.addSystem(xpSystem);
         xpSystem.showEntity(entity);
         /* Test */
         xpComponent.addXP(120); // First level is reached with 100 XP
@@ -99,6 +111,7 @@ public class XPSystemTest {
         Consumer<Entity> levelUp = Mockito.mock(Consumer.class);
         XPComponent xpComponent = new XPComponent(entity, levelUp);
         XPSystem xpSystem = new XPSystem();
+        Game.addSystem(xpSystem);
         xpSystem.showEntity(entity);
         /* Test */
         xpComponent.addXP(201);
@@ -122,6 +135,7 @@ public class XPSystemTest {
         Consumer<Entity> levelUp = Mockito.mock(Consumer.class);
         XPComponent xpComponent = new XPComponent(entity, levelUp);
         XPSystem xpSystem = new XPSystem();
+        Game.addSystem(xpSystem);
         xpSystem.showEntity(entity);
         /* Test */
 
@@ -141,6 +155,7 @@ public class XPSystemTest {
         Consumer<Entity> levelUp = Mockito.mock(Consumer.class);
         XPComponent xpComponent = new XPComponent(entity, levelUp);
         XPSystem xpSystem = new XPSystem();
+        Game.addSystem(xpSystem);
         xpSystem.showEntity(entity);
         /* Test */
         xpComponent.addXP(-1);

--- a/game/test/contrib/utils/components/interaction/ControlPointReachableTest.java
+++ b/game/test/contrib/utils/components/interaction/ControlPointReachableTest.java
@@ -78,7 +78,7 @@ public class ControlPointReachableTest {
 
     @Before
     public void setup() {
-        new LevelSystem(null, null, () -> {});
+        Game.addSystem(new LevelSystem(null, null, () -> {}));
         Game.currentLevel(new TileLevel(testLayout, DesignLabel.DEFAULT));
     }
 

--- a/game/test/core/level/TileLevelAPITest.java
+++ b/game/test/core/level/TileLevelAPITest.java
@@ -60,6 +60,7 @@ public class TileLevelAPITest {
         onLevelLoader = Mockito.mock(IVoidFunction.class);
         level = Mockito.mock(TileLevel.class);
         api = new LevelSystem(painter, generator, onLevelLoader);
+        Game.addSystem(api);
     }
 
     @After

--- a/game/test/core/systems/CameraSystemTest.java
+++ b/game/test/core/systems/CameraSystemTest.java
@@ -34,15 +34,17 @@ public class CameraSystemTest {
     @Before
     public void setup() {
         cameraSystem = new CameraSystem();
+        Game.addSystem(cameraSystem);
         Mockito.when(startTile.position()).thenReturn(testPoint);
         Mockito.when(level.randomTilePoint(Mockito.any())).thenReturn(testPoint);
         Mockito.when(level.startTile()).thenReturn(startTile);
-        new LevelSystem(null, null, () -> {});
+        Game.addSystem(new LevelSystem(null, null, () -> {}));
     }
 
     @After
     public void cleanup() {
         Game.removeAllEntities();
+        Game.currentLevel(null);
         Game.removeAllSystems();
     }
 

--- a/game/test/core/systems/VelocitySystemTest.java
+++ b/game/test/core/systems/VelocitySystemTest.java
@@ -38,11 +38,12 @@ public class VelocitySystemTest {
 
     @Before
     public void setup() throws IOException {
-        new LevelSystem(null, null, () -> {});
+        Game.addSystem(new LevelSystem(null, null, () -> {}));
         Game.currentLevel(level);
         Mockito.when(level.tileAt((Point) Mockito.any())).thenReturn(tile);
         entity = new Entity();
         velocitySystem = new VelocitySystem();
+        Game.addSystem(velocitySystem);
         velocityComponent = new VelocityComponent(entity, xVelocity, yVelocity);
         positionComponent =
                 new PositionComponent(entity, new Point(startXPosition, startYPosition));
@@ -53,6 +54,7 @@ public class VelocitySystemTest {
     @After
     public void cleanup() {
         Game.removeAllEntities();
+        Game.currentLevel(null);
         Game.removeAllSystems();
     }
 


### PR DESCRIPTION
fixes  #886


- entfernt das impliziere Registrieren der Systeme bei `Game` 
- Hinweis auf das registrieren in die javadoc aufgenommen
- Tests entsprechend angepasst
    - Immer wen ein System erzeugt wurde, habe ich ein `Game.addSystem` hinzugefügt
    - Cleanup Methode hinzugefügt, wenn diese Gefehlt hat.  