### PR TITLE
[GAME] add transfer function to inventory component

### DIFF
--- a/game/src/contrib/components/InventoryComponent.java
+++ b/game/src/contrib/components/InventoryComponent.java
@@ -87,6 +87,28 @@ public final class InventoryComponent extends Component {
     }
 
     /**
+     * Transfer the given item from this inventory to the given inventory.
+     *
+     * <p>If the given item is not present in this inventory or the other inventory is full, the
+     * transfer will not be successful.
+     *
+     * <p>If the transfer was successful, the given item will be removed from this inventory.
+     *
+     * <p>Will not trigger {@link ItemData#onCollect()} or {@link ItemData#onDrop()}.
+     *
+     * <p>Cannot transfer the item to itself.
+     *
+     * @param itemData Item to transfer.
+     * @param other {@link InventoryComponent} to transfer the item to.
+     * @return true if the transfer was successful, false if not.
+     */
+    public boolean transfer(final ItemData itemData, final InventoryComponent other) {
+        if (!other.equals(this) && inventory.contains(itemData) && other.add(itemData))
+            return remove(itemData);
+        return false;
+    }
+
+    /**
      * Get the number of items stored.
      *
      * @return The number of items that are stored in this component.

--- a/game/test/contrib/components/InventoryComponentTest.java
+++ b/game/test/contrib/components/InventoryComponentTest.java
@@ -7,12 +7,21 @@ import static org.junit.Assert.assertTrue;
 import contrib.utils.components.item.ItemData;
 
 import core.Entity;
+import core.Game;
 
+import org.junit.After;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import java.util.Set;
 
 public class InventoryComponentTest {
+
+    @After
+    public void cleanup() {
+        Game.removeAllEntities();
+    }
+
     /** constructor should create the inventory with the given parameters. */
     @Test
     public void validCreation() {
@@ -137,5 +146,47 @@ public class InventoryComponentTest {
         Set<ItemData> list = ic.items();
         assertEquals("should have no Items", 0, list.size());
         assertFalse("Item should be in returned List", list.contains(itemData));
+    }
+
+    @Test
+    public void tranfserItem() {
+        InventoryComponent ic = new InventoryComponent(new Entity(), 1);
+        InventoryComponent other = new InventoryComponent(new Entity(), 1);
+        ItemData item = Mockito.mock(ItemData.class);
+        ic.add(item);
+        assertTrue(ic.items().contains(item));
+        assertTrue(ic.transfer(item, other));
+        assertTrue(other.items().contains(item));
+        assertFalse("Item should be removed from this inventroy.", ic.items().contains(item));
+    }
+
+    @Test
+    public void tranfserItemNoSpace() {
+        InventoryComponent ic = new InventoryComponent(new Entity(), 1);
+        InventoryComponent other = new InventoryComponent(new Entity(), 0);
+        ItemData item = Mockito.mock(ItemData.class);
+        ic.add(item);
+        assertTrue(ic.items().contains(item));
+        assertFalse("Other inventory is full, no transfer possible", ic.transfer(item, other));
+        assertFalse("Item should not be transfered", other.items().contains(item));
+        assertTrue("Item should still be in tis inventroy.", ic.items().contains(item));
+    }
+
+    @Test
+    public void tranfserItemNoItem() {
+        InventoryComponent ic = new InventoryComponent(new Entity(), 1);
+        InventoryComponent other = new InventoryComponent(new Entity(), 1);
+        ItemData item = Mockito.mock(ItemData.class);
+        assertFalse("No item, no transfer", ic.transfer(item, other));
+    }
+
+    @Test
+    public void transferToItself() {
+        InventoryComponent ic = new InventoryComponent(new Entity(), 1);
+        ItemData item = Mockito.mock(ItemData.class);
+        ic.add(item);
+        assertTrue(ic.items().contains(item));
+        assertFalse("Can not transfer item to itself.", ic.transfer(item, ic));
+        assertTrue("Item should still be in tis inventroy.", ic.items().contains(item));
     }
 }

--- a/game/test/contrib/components/InventoryComponentTest.java
+++ b/game/test/contrib/components/InventoryComponentTest.java
@@ -154,9 +154,9 @@ public class InventoryComponentTest {
         InventoryComponent other = new InventoryComponent(new Entity(), 1);
         ItemData item = Mockito.mock(ItemData.class);
         ic.add(item);
-        assertTrue(ic.items().contains(item));
-        assertTrue(ic.transfer(item, other));
-        assertTrue(other.items().contains(item));
+        assertTrue("Item should be in the inventory.", ic.items().contains(item));
+        assertTrue("Transfer should be successfully.", ic.transfer(item, other));
+        assertTrue("Item should now be in the other inventory.", other.items().contains(item));
         assertFalse("Item should be removed from this inventroy.", ic.items().contains(item));
     }
 
@@ -166,7 +166,7 @@ public class InventoryComponentTest {
         InventoryComponent other = new InventoryComponent(new Entity(), 0);
         ItemData item = Mockito.mock(ItemData.class);
         ic.add(item);
-        assertTrue(ic.items().contains(item));
+        assertTrue("Item should be in the inventory.", ic.items().contains(item));
         assertFalse("Other inventory is full, no transfer possible", ic.transfer(item, other));
         assertFalse("Item should not be transfered", other.items().contains(item));
         assertTrue("Item should still be in tis inventroy.", ic.items().contains(item));
@@ -181,11 +181,11 @@ public class InventoryComponentTest {
     }
 
     @Test
-    public void transferToItself() {
+    public void transferItemToItself() {
         InventoryComponent ic = new InventoryComponent(new Entity(), 1);
         ItemData item = Mockito.mock(ItemData.class);
         ic.add(item);
-        assertTrue(ic.items().contains(item));
+        assertTrue("Item should be in the inventory.", ic.items().contains(item));
         assertFalse("Can not transfer item to itself.", ic.transfer(item, ic));
         assertTrue("Item should still be in tis inventroy.", ic.items().contains(item));
     }


### PR DESCRIPTION
Logik für #491

Erlaubt das transferieren von Items aus einem inventar in das andere.
Damit das Issue resolved ist, müsste die Funktionalität in #234 noch hinzugefügt werden. 