### PR TITLE
[Game] fix:  Healthbars misalign on window rescale due to missing window to stage coordinate conversion

### DIFF
--- a/game/src/contrib/systems/HealthbarSystem.java
+++ b/game/src/contrib/systems/HealthbarSystem.java
@@ -2,6 +2,7 @@ package contrib.systems;
 
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.math.Vector3;
+import com.badlogic.gdx.scenes.scene2d.Stage;
 import com.badlogic.gdx.scenes.scene2d.ui.Container;
 import com.badlogic.gdx.scenes.scene2d.ui.ProgressBar;
 
@@ -103,8 +104,16 @@ public final class HealthbarSystem extends System {
     /** moves the Progressbar to follow the Entity */
     private void updatePosition(ProgressBar pb, PositionComponent pc) {
         Point position = pc.position();
-        Vector3 screenPosition =
-                CameraSystem.camera().project(new Vector3(position.x, position.y, 0));
+        Vector3 conveered = new Vector3(position.x, position.y, 0);
+        // map Entity coordinates to window coords
+        Vector3 screenPosition = CameraSystem.camera().project(conveered);
+        // get the stage of the progressbar
+        Stage stage = pb.getStage();
+        // remap window coords again stage coords
+        screenPosition.x =
+                screenPosition.x / stage.getViewport().getScreenWidth() * stage.getWidth();
+        screenPosition.y =
+                screenPosition.y / stage.getViewport().getScreenHeight() * stage.getHeight();
         pb.setPosition(screenPosition.x, screenPosition.y);
     }
 

--- a/game/src/contrib/systems/HealthbarSystem.java
+++ b/game/src/contrib/systems/HealthbarSystem.java
@@ -10,6 +10,7 @@ import contrib.components.HealthComponent;
 import contrib.hud.heroUI.HeroUITools;
 
 import core.Entity;
+import core.Game;
 import core.System;
 import core.components.PositionComponent;
 import core.components.UIComponent;
@@ -107,8 +108,8 @@ public final class HealthbarSystem extends System {
         Vector3 conveered = new Vector3(position.x, position.y, 0);
         // map Entity coordinates to window coords
         Vector3 screenPosition = CameraSystem.camera().project(conveered);
-        // get the stage of the progressbar
-        Stage stage = pb.getStage();
+        // get the stage of the Game
+        Stage stage = Game.stage().orElseThrow(() -> new RuntimeException("No Stage available"));
         // remap window coords again stage coords
         screenPosition.x =
                 screenPosition.x / stage.getViewport().getScreenWidth() * stage.getWidth();


### PR DESCRIPTION
fixes #899 

irgendwie ist die letzte konvertierung verloren gegangen um die einzelnen schritte vielleicht besser zu verstehen comments hinzugefügt