### PR TITLE
[GAME] ProtectOnAttack `peek` vs `filter` überarbeitet

### DIFF
--- a/game/src/contrib/utils/components/ai/transition/ProtectOnAttack.java
+++ b/game/src/contrib/utils/components/ai/transition/ProtectOnAttack.java
@@ -8,8 +8,10 @@ import core.utils.components.MissingComponentException;
 
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 /**
  * Implements an AI that protects a specific entity with a HealthComponent, if the hero dealt damage
@@ -44,6 +46,7 @@ public class ProtectOnAttack implements Function<Entity, Boolean> {
      * @param entities - Entities that are protected
      */
     public ProtectOnAttack(final Collection<Entity> entities) {
+        // throw an exception for every entity that does not have a HealthComponent
         entities.stream()
                 .filter(e -> e.fetch(HealthComponent.class).isEmpty())
                 .map(e -> MissingComponentException.build(e, HealthComponent.class))
@@ -52,7 +55,12 @@ public class ProtectOnAttack implements Function<Entity, Boolean> {
                             throw mce;
                         });
 
-        toProtect.addAll(entities);
+        // collect every entity with a HealthComponent to add to the protection list
+        List<Entity> toAdd = entities.stream()
+                .filter(e -> e.fetch(HealthComponent.class).isPresent())
+                    .toList();
+
+        toProtect.addAll(toAdd);
     }
 
     /**

--- a/game/src/contrib/utils/components/ai/transition/ProtectOnAttack.java
+++ b/game/src/contrib/utils/components/ai/transition/ProtectOnAttack.java
@@ -42,14 +42,11 @@ public class ProtectOnAttack implements Function<Entity, Boolean> {
      * @param entities - Entities that are protected
      */
     public ProtectOnAttack(final Collection<Entity> entities) {
-        // throw an exception for every entity that does not have a HealthComponent
         // add every entity with a HealthComponent to the protection list
+        // throw an exception for every entity that does not have a HealthComponent
         for (Entity entity : entities) {
-            if (entity.fetch(HealthComponent.class).isEmpty()) {
-                throw MissingComponentException.build(entity, HealthComponent.class);
-            } else {
-                toProtect.add(entity);
-            }
+            if (entity.isPresent(HealthComponent.class)) toProtect.add(entity);
+            else throw MissingComponentException.build(entity, HealthComponent.class);
         }
     }
 

--- a/game/src/contrib/utils/components/ai/transition/ProtectOnAttack.java
+++ b/game/src/contrib/utils/components/ai/transition/ProtectOnAttack.java
@@ -6,10 +6,7 @@ import core.Entity;
 import core.components.PlayerComponent;
 import core.utils.components.MissingComponentException;
 
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.function.Function;
 
 /**
@@ -46,19 +43,14 @@ public class ProtectOnAttack implements Function<Entity, Boolean> {
      */
     public ProtectOnAttack(final Collection<Entity> entities) {
         // throw an exception for every entity that does not have a HealthComponent
-        entities.stream()
-                .filter(e -> e.fetch(HealthComponent.class).isEmpty())
-                .map(e -> MissingComponentException.build(e, HealthComponent.class))
-                .forEach(
-                        mce -> {
-                            throw mce;
-                        });
-
-        // collect every entity with a HealthComponent to add to the protection list
-        List<Entity> toAdd =
-                entities.stream().filter(e -> e.fetch(HealthComponent.class).isPresent()).toList();
-
-        toProtect.addAll(toAdd);
+        // add every entity with a HealthComponent to the protection list
+        for (Entity entity : entities) {
+            if (entity.fetch(HealthComponent.class).isEmpty()) {
+                throw MissingComponentException.build(entity, HealthComponent.class);
+            } else {
+                toProtect.add(entity);
+            }
+        }
     }
 
     /**

--- a/game/src/contrib/utils/components/ai/transition/ProtectOnAttack.java
+++ b/game/src/contrib/utils/components/ai/transition/ProtectOnAttack.java
@@ -45,14 +45,14 @@ public class ProtectOnAttack implements Function<Entity, Boolean> {
      */
     public ProtectOnAttack(final Collection<Entity> entities) {
         entities.stream()
-                .peek(
-                        entity ->
-                                entity.fetch(HealthComponent.class)
-                                        .orElseThrow(
-                                                () ->
-                                                        MissingComponentException.build(
-                                                                entity, HealthComponent.class)))
-                .forEach(this.toProtect::add);
+                .filter(e -> e.fetch(HealthComponent.class).isEmpty())
+                .map(e -> MissingComponentException.build(e, HealthComponent.class))
+                .forEach(
+                        mce -> {
+                            throw mce;
+                        });
+
+        toProtect.addAll(entities);
     }
 
     /**

--- a/game/src/contrib/utils/components/ai/transition/ProtectOnAttack.java
+++ b/game/src/contrib/utils/components/ai/transition/ProtectOnAttack.java
@@ -11,7 +11,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 /**
  * Implements an AI that protects a specific entity with a HealthComponent, if the hero dealt damage
@@ -56,9 +55,8 @@ public class ProtectOnAttack implements Function<Entity, Boolean> {
                         });
 
         // collect every entity with a HealthComponent to add to the protection list
-        List<Entity> toAdd = entities.stream()
-                .filter(e -> e.fetch(HealthComponent.class).isPresent())
-                    .toList();
+        List<Entity> toAdd =
+                entities.stream().filter(e -> e.fetch(HealthComponent.class).isPresent()).toList();
 
         toProtect.addAll(toAdd);
     }


### PR DESCRIPTION
closes #751

In diesem PR wird die Nutzung eines peek durch einen übersichtlicheren Filterablauf ersetzt