### PR TITLE
[DSL] Implementieren von `getConfigs`

### DIFF
--- a/dsl/src/interpreter/DSLEntryPointFinder.java
+++ b/dsl/src/interpreter/DSLEntryPointFinder.java
@@ -20,9 +20,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
 
-/**
- * AstVisitor implementation to search for quest_config definition.
- */
+/** AstVisitor implementation to search for quest_config definition. */
 public class DSLEntryPointFinder implements AstVisitor<Object> {
     private ArrayList<DSLEntryPoint> entryPoints;
     private ParsedFile parsedFile;
@@ -31,8 +29,7 @@ public class DSLEntryPointFinder implements AstVisitor<Object> {
     private final HashMap<Path, ParsedFile> parsedFiles;
 
     /**
-     * Constructor.
-     * Creates a GameEnvironment to get the {@link semanticanalysis.types.IType} for
+     * Constructor. Creates a GameEnvironment to get the {@link semanticanalysis.types.IType} for
      * {@link QuestConfig}.
      */
     public DSLEntryPointFinder() {
@@ -49,15 +46,12 @@ public class DSLEntryPointFinder implements AstVisitor<Object> {
     }
 
     /**
-     * Creates an AST vor the file of the passed filePath, searches it
-     * for quest_config definitions and creates {@link DSLEntryPoint}
-     * instances for each one.
+     * Creates an AST vor the file of the passed filePath, searches it for quest_config definitions
+     * and creates {@link DSLEntryPoint} instances for each one.
      *
-     * @param filePath the path of the file to search for quest_config definitions
-     *                 in
-     * @return an empty optional, if reading the file caused an error or it does not
-     * contain any quest_config definitions, the list of found quest_config objects
-     * otherwise
+     * @param filePath the path of the file to search for quest_config definitions in
+     * @return an empty optional, if reading the file caused an error or it does not contain any
+     *     quest_config definitions, the list of found quest_config objects otherwise
      */
     public Optional<List<DSLEntryPoint>> getEntryPoints(Path filePath) {
         try {

--- a/dsl/src/interpreter/DSLEntryPointFinder.java
+++ b/dsl/src/interpreter/DSLEntryPointFinder.java
@@ -117,7 +117,7 @@ public class DSLEntryPointFinder implements AstVisitor<Object> {
             // found one
             String configName = node.getIdName();
             String displayName = getDisplayName(node);
-            this.entryPoints.add(new DSLEntryPoint(this.parsedFile, displayName, configName, node));
+            this.entryPoints.add(new DSLEntryPoint(this.parsedFile, displayName, node));
         }
         return null;
     }

--- a/dsl/src/interpreter/DSLEntryPointFinder.java
+++ b/dsl/src/interpreter/DSLEntryPointFinder.java
@@ -1,0 +1,127 @@
+package interpreter;
+
+import dslToGame.DSLEntryPoint;
+import dslToGame.QuestConfig;
+import parser.DungeonASTConverter;
+import parser.ast.*;
+import runtime.GameEnvironment;
+import semanticanalysis.Symbol;
+import semanticanalysis.types.AggregateType;
+
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+public class DSLEntryPointFinder implements AstVisitor<Object> {
+    private ArrayList<DSLEntryPoint> entryPoints;
+    private Path filePath;
+    private final GameEnvironment environment;
+    private AggregateType questConfigDataType;
+
+    public DSLEntryPointFinder() {
+        this.environment = new GameEnvironment();
+        var symbols = environment.getGlobalScope().getSymbols();
+        for (Symbol symbol : symbols) {
+            if (symbol instanceof AggregateType aggregateType) {
+                if (aggregateType.getOriginType().equals(QuestConfig.class)) {
+                    this.questConfigDataType = aggregateType;
+                }
+            }
+        }
+    }
+
+    public Optional<List<DSLEntryPoint>> getEntryPoints(Path filePath) {
+        try {
+            // we don't want to do the whole interpretation here...
+            // we only want to know, which (well formed) entry points exist
+            // would be enough to do this in a light AST-Visitor..
+            String content = Files.readString(filePath);
+            Node programAST = DungeonASTConverter.getProgramAST(content);
+
+            List<DSLEntryPoint> list = findEntryPoints(filePath, programAST);
+            return Optional.of(list);
+        } catch (IOException e) {
+            // ok, be like that then..
+            return Optional.empty();
+        }
+    }
+
+
+    private List<DSLEntryPoint> findEntryPoints(Path filePath, Node programAST) {
+        this.entryPoints = new ArrayList<>();
+        this.filePath = filePath;
+        programAST.accept(this);
+        return entryPoints;
+    }
+
+    @Override
+    public Object visit(Node node) {
+        switch (node.type) {
+            case Program:
+                visitChildren(node);
+                break;
+            default:
+                break;
+        }
+        return null;
+    }
+
+    @Override
+    public Object visit(IdNode node) {
+        return node.getName();
+    }
+
+    @Override
+    public Object visit(StringNode node) {
+        return node.getValue();
+    }
+
+    @Override
+    public Object visit(ListTypeIdentifierNode node) {
+        return node.getName();
+    }
+
+    @Override
+    public Object visit(SetTypeIdentifierNode node) {
+        return node.getName();
+    }
+
+    @Override
+    public Object visit(DotDefNode node) {
+        return null;
+    }
+
+    private String getDisplayName(ObjectDefNode questConfigDefNode) {
+        String displayName = questConfigDefNode.getIdName();
+        for (Node node : questConfigDefNode.getPropertyDefinitions()) {
+            PropertyDefNode propertyDefNode = (PropertyDefNode) node;
+            if (propertyDefNode.getIdName().equals("name")) {
+                displayName = (String) propertyDefNode.getStmtNode().accept(this);
+            }
+        }
+        return displayName;
+    }
+
+    @Override
+    public Object visit(ObjectDefNode node) {
+        Node typeSpecifier = node.getTypeSpecifier();
+        String typeSpecifierName = (String)typeSpecifier.accept(this);
+        if (typeSpecifierName.equals(questConfigDataType.getName())) {
+            // found one
+            String configName = node.getIdName();
+            String displayName = getDisplayName(node);
+            this.entryPoints.add(new DSLEntryPoint(this.filePath, displayName, configName));
+        }
+        return null;
+    }
+
+    @Override
+    public Object visit(FuncDefNode node) {
+        return null;
+    }
+}

--- a/dsl/src/interpreter/DSLEntryPointFinder.java
+++ b/dsl/src/interpreter/DSLEntryPointFinder.java
@@ -117,7 +117,7 @@ public class DSLEntryPointFinder implements AstVisitor<Object> {
             // found one
             String configName = node.getIdName();
             String displayName = getDisplayName(node);
-            this.entryPoints.add(new DSLEntryPoint(this.parsedFile, displayName, configName));
+            this.entryPoints.add(new DSLEntryPoint(this.parsedFile, displayName, configName, node));
         }
         return null;
     }

--- a/dsl/src/parser/DungeonASTConverter.java
+++ b/dsl/src/parser/DungeonASTConverter.java
@@ -3,6 +3,8 @@ package parser;
 import antlr.main.DungeonDSLLexer;
 import antlr.main.DungeonDSLParser;
 
+import org.antlr.v4.runtime.CharStreams;
+import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.tree.ErrorNode;
 import org.antlr.v4.runtime.tree.ParseTree;
@@ -37,6 +39,18 @@ public class DungeonASTConverter implements antlr.main.DungeonDSLListener {
     /** Constructor */
     public DungeonASTConverter() {
         astStack = new Stack<>();
+    }
+
+    public static Node getProgramAST(String program) {
+        var stream = CharStreams.fromString(program);
+        var lexer = new DungeonDSLLexer(stream);
+
+        var tokenStream = new CommonTokenStream(lexer);
+        var parser = new DungeonDSLParser(tokenStream);
+        var programParseTree = parser.program();
+
+        DungeonASTConverter astConverter = new DungeonASTConverter();
+        return astConverter.walk(programParseTree);
     }
 
     /**

--- a/dsl/test/interpreter/TetsDSLEntryPointFinder.java
+++ b/dsl/test/interpreter/TetsDSLEntryPointFinder.java
@@ -1,0 +1,67 @@
+package interpreter;
+
+import dslToGame.DSLEntryPoint;
+import helpers.Helpers;
+import org.antlr.v4.runtime.CharStreams;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.FileReader;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+public class TetsDSLEntryPointFinder {
+
+    @Test
+    public void testReadEntrtyPoints() {
+        List<DSLEntryPoint> entryPoints = new ArrayList<>();
+        DSLEntryPointFinder finder = new DSLEntryPointFinder();
+        URL resource1 = getClass().getClassLoader().getResource("config1.dng");
+        assert resource1 != null;
+        Path firstPath = null;
+        try {
+            firstPath = Path.of(resource1.toURI());
+            var entryPointsFromFile = finder.getEntryPoints(firstPath).get();
+            entryPoints.addAll(entryPointsFromFile);
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+
+        URL resource2 = getClass().getClassLoader().getResource("config2.dng");
+        assert resource2 != null;
+        Path secondPath = null;
+        try {
+            secondPath = Path.of(resource2.toURI());
+            var entryPointsFromFile = finder.getEntryPoints(secondPath).get();
+            entryPoints.addAll(entryPointsFromFile);
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+
+        Assert.assertEquals(4, entryPoints.size());
+
+        DSLEntryPoint firstEntryPoint = entryPoints.get(0);
+        Assert.assertEquals("This is my config 1", firstEntryPoint.displayName());
+        Assert.assertEquals("my_config", firstEntryPoint.configName());
+        Assert.assertEquals(firstPath, firstEntryPoint.filePath());
+
+        DSLEntryPoint secondEntryPoint = entryPoints.get(1);
+        Assert.assertEquals("my_other_config", secondEntryPoint.displayName());
+        Assert.assertEquals("my_other_config", secondEntryPoint.configName());
+        Assert.assertEquals(firstPath, secondEntryPoint.filePath());
+
+        DSLEntryPoint thirdEntryPoint = entryPoints.get(2);
+        Assert.assertEquals("This is my config 2", thirdEntryPoint.displayName());
+        Assert.assertEquals("my_other_config", thirdEntryPoint.configName());
+        Assert.assertEquals(secondPath, thirdEntryPoint.filePath());
+
+        DSLEntryPoint forthEntryPoint = entryPoints.get(3);
+        Assert.assertEquals("my_completely_other_config", forthEntryPoint.displayName());
+        Assert.assertEquals("my_completely_other_config", forthEntryPoint.configName());
+        Assert.assertEquals(secondPath, forthEntryPoint.filePath());
+    }
+}

--- a/dsl/test/interpreter/TetsDSLEntryPointFinder.java
+++ b/dsl/test/interpreter/TetsDSLEntryPointFinder.java
@@ -41,24 +41,22 @@ public class TetsDSLEntryPointFinder {
 
         Assert.assertEquals(4, entryPoints.size());
 
+        // TODO: test stored AST-Nodes
+
         DSLEntryPoint firstEntryPoint = entryPoints.get(0);
         Assert.assertEquals("This is my config 1", firstEntryPoint.displayName());
-        Assert.assertEquals("my_config", firstEntryPoint.configName());
         Assert.assertEquals(firstPath, firstEntryPoint.file().filePath());
 
         DSLEntryPoint secondEntryPoint = entryPoints.get(1);
         Assert.assertEquals("my_other_config", secondEntryPoint.displayName());
-        Assert.assertEquals("my_other_config", secondEntryPoint.configName());
         Assert.assertEquals(firstPath, secondEntryPoint.file().filePath());
 
         DSLEntryPoint thirdEntryPoint = entryPoints.get(2);
         Assert.assertEquals("This is my config 2", thirdEntryPoint.displayName());
-        Assert.assertEquals("my_other_config", thirdEntryPoint.configName());
         Assert.assertEquals(secondPath, thirdEntryPoint.file().filePath());
 
         DSLEntryPoint forthEntryPoint = entryPoints.get(3);
         Assert.assertEquals("my_completely_other_config", forthEntryPoint.displayName());
-        Assert.assertEquals("my_completely_other_config", forthEntryPoint.configName());
         Assert.assertEquals(secondPath, forthEntryPoint.file().filePath());
     }
 }

--- a/dsl/test/interpreter/TetsDSLEntryPointFinder.java
+++ b/dsl/test/interpreter/TetsDSLEntryPointFinder.java
@@ -1,13 +1,10 @@
 package interpreter;
 
 import dslToGame.DSLEntryPoint;
-import helpers.Helpers;
-import org.antlr.v4.runtime.CharStreams;
+
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.io.File;
-import java.io.FileReader;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Path;
@@ -47,21 +44,21 @@ public class TetsDSLEntryPointFinder {
         DSLEntryPoint firstEntryPoint = entryPoints.get(0);
         Assert.assertEquals("This is my config 1", firstEntryPoint.displayName());
         Assert.assertEquals("my_config", firstEntryPoint.configName());
-        Assert.assertEquals(firstPath, firstEntryPoint.filePath());
+        Assert.assertEquals(firstPath, firstEntryPoint.file().filePath());
 
         DSLEntryPoint secondEntryPoint = entryPoints.get(1);
         Assert.assertEquals("my_other_config", secondEntryPoint.displayName());
         Assert.assertEquals("my_other_config", secondEntryPoint.configName());
-        Assert.assertEquals(firstPath, secondEntryPoint.filePath());
+        Assert.assertEquals(firstPath, secondEntryPoint.file().filePath());
 
         DSLEntryPoint thirdEntryPoint = entryPoints.get(2);
         Assert.assertEquals("This is my config 2", thirdEntryPoint.displayName());
         Assert.assertEquals("my_other_config", thirdEntryPoint.configName());
-        Assert.assertEquals(secondPath, thirdEntryPoint.filePath());
+        Assert.assertEquals(secondPath, thirdEntryPoint.file().filePath());
 
         DSLEntryPoint forthEntryPoint = entryPoints.get(3);
         Assert.assertEquals("my_completely_other_config", forthEntryPoint.displayName());
         Assert.assertEquals("my_completely_other_config", forthEntryPoint.configName());
-        Assert.assertEquals(secondPath, forthEntryPoint.filePath());
+        Assert.assertEquals(secondPath, forthEntryPoint.file().filePath());
     }
 }

--- a/dsl/test_resources/config1.dng
+++ b/dsl/test_resources/config1.dng
@@ -1,0 +1,14 @@
+single_choice_task my_task {
+    description: "Hello",
+    answers: ["1", "2", "3"],
+    correct_answer_index: 2
+}
+
+quest_config my_config {
+    name: "This is my config 1",
+    tasks: [my_task]
+}
+
+quest_config my_other_config {
+    tasks: [my_task]
+}

--- a/dsl/test_resources/config2.dng
+++ b/dsl/test_resources/config2.dng
@@ -1,0 +1,14 @@
+single_choice_task my_task {
+    description: "Kuckuck",
+    answers: ["1", "2", "3"],
+    correct_answer_index: 2
+}
+
+quest_config my_other_config {
+    name: "This is my config 2",
+    tasks: [my_task]
+}
+
+quest_config my_completely_other_config {
+    tasks: [my_task]
+}

--- a/dungeon/src/dslToGame/DSLEntryPoint.java
+++ b/dungeon/src/dslToGame/DSLEntryPoint.java
@@ -2,4 +2,4 @@ package dslToGame;
 
 import parser.ast.ObjectDefNode;
 
-public record DSLEntryPoint(ParsedFile file, String displayName, String configName, ObjectDefNode configDefinitionNode) {}
+public record DSLEntryPoint(ParsedFile file, String displayName, ObjectDefNode configDefinitionNode) {}

--- a/dungeon/src/dslToGame/DSLEntryPoint.java
+++ b/dungeon/src/dslToGame/DSLEntryPoint.java
@@ -1,5 +1,3 @@
 package dslToGame;
 
-import java.nio.file.Path;
-
-public record DSLEntryPoint (Path filePath, String displayName, String configName) { }
+public record DSLEntryPoint(ParsedFile file, String displayName, String configName) {}

--- a/dungeon/src/dslToGame/DSLEntryPoint.java
+++ b/dungeon/src/dslToGame/DSLEntryPoint.java
@@ -1,0 +1,5 @@
+package dslToGame;
+
+import java.nio.file.Path;
+
+public record DSLEntryPoint (Path filePath, String displayName, String configName) { }

--- a/dungeon/src/dslToGame/DSLEntryPoint.java
+++ b/dungeon/src/dslToGame/DSLEntryPoint.java
@@ -1,3 +1,5 @@
 package dslToGame;
 
-public record DSLEntryPoint(ParsedFile file, String displayName, String configName) {}
+import parser.ast.ObjectDefNode;
+
+public record DSLEntryPoint(ParsedFile file, String displayName, String configName, ObjectDefNode configDefinitionNode) {}

--- a/dungeon/src/dslToGame/DSLEntryPoint.java
+++ b/dungeon/src/dslToGame/DSLEntryPoint.java
@@ -2,4 +2,5 @@ package dslToGame;
 
 import parser.ast.ObjectDefNode;
 
-public record DSLEntryPoint(ParsedFile file, String displayName, ObjectDefNode configDefinitionNode) {}
+public record DSLEntryPoint(
+        ParsedFile file, String displayName, ObjectDefNode configDefinitionNode) {}

--- a/dungeon/src/dslToGame/ParsedFile.java
+++ b/dungeon/src/dslToGame/ParsedFile.java
@@ -1,0 +1,7 @@
+package dslToGame;
+
+import parser.ast.Node;
+
+import java.nio.file.Path;
+
+public record ParsedFile(Path filePath, Node rootASTNode) {}

--- a/dungeon/src/dslToGame/QuestConfig.java
+++ b/dungeon/src/dslToGame/QuestConfig.java
@@ -19,5 +19,5 @@ public record QuestConfig(
         @DSLTypeMember int questPoints,
         @DSLTypeMember String password,
         @DSLTypeMember Entity entity,
-        @DSLTypeMember(name="name") String displayName,
+        @DSLTypeMember(name = "name") String displayName,
         @DSLTypeMember List<Task> tasks) {}

--- a/dungeon/src/dslToGame/QuestConfig.java
+++ b/dungeon/src/dslToGame/QuestConfig.java
@@ -19,4 +19,5 @@ public record QuestConfig(
         @DSLTypeMember int questPoints,
         @DSLTypeMember String password,
         @DSLTypeMember Entity entity,
+        @DSLTypeMember(name="name") String displayName,
         @DSLTypeMember List<Task> tasks) {}


### PR DESCRIPTION
Fixes #869 

Implementiert die Suche nach Einstiegspunkten (QuestConfigs) in `DSLEntryPointFinder` (als `ASTVisitor`-Implementierung).
Sammelt die nötigen Informationen (Dateipfad, Anzeige-Name, AST-Knoten) einer QuestConfig in der `DSLEntryPoint` Recordklasse.

Die Logik wird dabei bewusst vom `DSLInterpreter` abgekapselt, da für die Suche nach QuestConfig-Definitionen möglichst wenig Overhead entstehen soll, daher reicht es aus, hier nur auf der AST-Ebene zu bleiben. Der für die Datei erstellte AST wird in einer `ParsedFile`-Instanz zusammen mit dem Dateipfad gespeichert. 

Beispiel:
```
quest_config my_config {
  name: "Tolle QuestConfig",
  ...
}
```

Im obigen Beispiel ist der Config-Name "my_config" (also der Name der QuestConfig Objektdefinition). Der Anzeigename ist "Tolle QuestConfig" und kann genutzt werden, um eine nutzerfreundlichere Bezeichnung zur Auswahl der QuestConfig anzugeben.