### PR TITLE
[Game] Verbesserung der Bewegung im Dungeon

### DIFF
--- a/game/src/contrib/entities/EntityFactory.java
+++ b/game/src/contrib/entities/EntityFactory.java
@@ -35,9 +35,9 @@ public class EntityFactory {
     private static final Logger LOGGER = Logger.getLogger(EntityFactory.class.getName());
     private static final Random RANDOM = new Random();
     private static final String HERO_FILE_PATH = "character/knight";
-    private static final float X_SPEED_HERO = 0.3f;
-    private static final float Y_SPEED_HERO = 0.3f;
-    private static final int FIREBALL_COOL_DOWN = 2;
+    private static final float X_SPEED_HERO = 7.5f;
+    private static final float Y_SPEED_HERO = 7.5f;
+    private static final int FIREBALL_COOL_DOWN = 1;
     private static final String[] MONSTER_FILE_PATHS = {
         "character/monster/chort", "character/monster/imp"
     };
@@ -46,8 +46,8 @@ public class EntityFactory {
 
     // NOTE: +1 for health as nextInt() is exclusive
     private static final int MAX_MONSTER_HEALTH = 5 + 1;
-    private static final float MIN_MONSTER_SPEED = 0.1f;
-    private static final float MAX_MONSTER_SPEED = 0.25f;
+    private static final float MIN_MONSTER_SPEED = 3.0f;
+    private static final float MAX_MONSTER_SPEED = 7.5f;
 
     /**
      * Create a new Entity that can be used as a playable character. It will have a {@link

--- a/game/src/contrib/utils/components/skill/FireballSkill.java
+++ b/game/src/contrib/utils/components/skill/FireballSkill.java
@@ -15,7 +15,7 @@ import java.util.function.Supplier;
 public class FireballSkill extends DamageProjectile {
 
     private static final String PROJECTILE_TEXTURES = "skills/fireball";
-    private static final float PROJECTILE_SPEED = 0.5f;
+    private static final float PROJECTILE_SPEED = 15.0f;
     private static final int DAMAGE_AMOUNT = 1;
     private static final DamageType DAMAGE_TYPE = DamageType.FIRE;
     private static final Point HITBOX_SIZE = new Point(1, 1);

--- a/game/src/core/level/Tile.java
+++ b/game/src/core/level/Tile.java
@@ -9,6 +9,7 @@ import core.level.elements.astar.TileConnection;
 import core.level.utils.Coordinate;
 import core.level.utils.DesignLabel;
 import core.level.utils.LevelElement;
+import core.utils.Constants;
 import core.utils.Point;
 
 import java.util.ArrayList;
@@ -28,7 +29,29 @@ public abstract class Tile {
     protected LevelElement levelElement;
     protected transient Array<Connection<Tile>> connections = new Array<>();
     protected int index;
+    private final float friction;
 
+    /**
+     * Creates a new Tile.
+     *
+     * @param texturePath Path to the texture of the tile.
+     * @param globalPosition Position of the tile in the global system.
+     * @param designLabel Design of the Tile
+     * @param level The level this Tile belongs to
+     * @param friction The friction of this Tile
+     */
+    public Tile(
+            String texturePath,
+            Coordinate globalPosition,
+            DesignLabel designLabel,
+            ILevel level,
+            float friction) {
+        this.texturePath = texturePath;
+        this.globalPosition = globalPosition;
+        this.designLabel = designLabel;
+        this.level = level;
+        this.friction = friction;
+    }
     /**
      * Creates a new Tile.
      *
@@ -39,10 +62,7 @@ public abstract class Tile {
      */
     public Tile(
             String texturePath, Coordinate globalPosition, DesignLabel designLabel, ILevel level) {
-        this.texturePath = texturePath;
-        this.globalPosition = globalPosition;
-        this.designLabel = designLabel;
-        this.level = level;
+        this(texturePath, globalPosition, designLabel, level, Constants.DEFAULT_FRICTION);
     }
 
     /**
@@ -137,6 +157,15 @@ public abstract class Tile {
      */
     public void index(int index) {
         this.index = index;
+    }
+
+    /**
+     * Get friction of this tile.
+     *
+     * @return the friction of this tile
+     */
+    public float friction() {
+        return this.friction;
     }
 
     /**

--- a/game/src/core/systems/VelocitySystem.java
+++ b/game/src/core/systems/VelocitySystem.java
@@ -58,9 +58,11 @@ public final class VelocitySystem extends System {
 
     private void updatePosition(VSData vsd) {
         Vector2 velocity = new Vector2(vsd.vc.currentXVelocity(), vsd.vc.currentYVelocity());
-        float len = velocity.len();
-        velocity.nor();
-        velocity.scl(len);
+        float maxSpeed = Math.max(Math.abs(vsd.vc.xVelocity()), Math.abs(vsd.vc.yVelocity()));
+        if (velocity.len() > maxSpeed) {
+            velocity.nor();
+            velocity.scl(maxSpeed);
+        }
         if (Gdx.graphics != null) {
             velocity.scl(Gdx.graphics.getDeltaTime());
         }

--- a/game/src/core/systems/VelocitySystem.java
+++ b/game/src/core/systems/VelocitySystem.java
@@ -83,9 +83,10 @@ public final class VelocitySystem extends System {
         // tiles
         else if (vsd.e.fetch(ProjectileComponent.class).isPresent()) Game.remove(vsd.e);
 
-        float newVX = vsd.vc.currentXVelocity() * (1.0f - Constants.DEFAULT_FRICTION);
+        float friction = Game.tileAT(vsd.pc.position()).friction();
+        float newVX = vsd.vc.currentXVelocity() * (Math.min(1.0f, 1.0f - friction));
         if (Math.abs(newVX) < 0.01f) newVX = 0.0f;
-        float newVY = vsd.vc.currentYVelocity() * (1.0f - Constants.DEFAULT_FRICTION);
+        float newVY = vsd.vc.currentYVelocity() * (Math.min(1.0f, 1.0f - friction));
         if (Math.abs(newVY) < 0.01f) newVY = 0.0f;
 
         vsd.vc.currentYVelocity(newVY);

--- a/game/src/core/systems/VelocitySystem.java
+++ b/game/src/core/systems/VelocitySystem.java
@@ -12,7 +12,6 @@ import core.System;
 import core.components.DrawComponent;
 import core.components.PositionComponent;
 import core.components.VelocityComponent;
-import core.utils.Constants;
 import core.utils.Point;
 import core.utils.components.MissingComponentException;
 import core.utils.components.draw.CoreAnimations;
@@ -61,7 +60,10 @@ public final class VelocitySystem extends System {
         Vector2 velocity = new Vector2(vsd.vc.currentXVelocity(), vsd.vc.currentYVelocity());
         float len = velocity.len();
         velocity.nor();
-        velocity.scl(len * Constants.DEFAULT_FRICTION * Gdx.graphics.getDeltaTime());
+        velocity.scl(len);
+        if (Gdx.graphics != null) {
+            velocity.scl(Gdx.graphics.getDeltaTime());
+        }
 
         float newX = vsd.pc.position().x + velocity.x;
         float newY = vsd.pc.position().y + velocity.y;

--- a/game/src/core/systems/VelocitySystem.java
+++ b/game/src/core/systems/VelocitySystem.java
@@ -59,6 +59,7 @@ public final class VelocitySystem extends System {
     private void updatePosition(VSData vsd) {
         Vector2 velocity = new Vector2(vsd.vc.currentXVelocity(), vsd.vc.currentYVelocity());
         float maxSpeed = Math.max(Math.abs(vsd.vc.xVelocity()), Math.abs(vsd.vc.yVelocity()));
+        // Limit velocity to maxSpeed (primarily for diagonal movement)
         if (velocity.len() > maxSpeed) {
             velocity.nor();
             velocity.scl(maxSpeed);

--- a/game/src/core/utils/Constants.java
+++ b/game/src/core/utils/Constants.java
@@ -47,6 +47,7 @@ public final class Constants {
     public static final String QUIZ_MESSAGE_SOLUTION = "Lösung";
     public static final int DEFAULT_INVENTORY_SIZE = 5;
     public static final float DEFAULT_ITEM_PICKUP_RADIUS = 2.0f;
+    public static final float DEFAULT_FRICTION = 0.8f;
 
     /**
      * @param path the relative path to the resource

--- a/game/test/core/systems/VelocitySystemTest.java
+++ b/game/test/core/systems/VelocitySystemTest.java
@@ -4,6 +4,8 @@ import static junit.framework.TestCase.assertTrue;
 
 import static org.junit.Assert.assertEquals;
 
+import com.badlogic.gdx.math.Vector2;
+
 import core.Entity;
 import core.Game;
 import core.components.DrawComponent;
@@ -66,10 +68,25 @@ public class VelocitySystemTest {
         Mockito.when(tile.isAccessible()).thenReturn(true);
         velocityComponent.currentXVelocity(xVelocity);
         velocityComponent.currentYVelocity(yVelocity);
+
+        Vector2 velocity =
+                new Vector2(
+                        velocityComponent.currentXVelocity(), velocityComponent.currentYVelocity());
+        if (velocity.len()
+                > Math.max(
+                        Math.abs(velocityComponent.xVelocity()),
+                        Math.abs(velocityComponent.yVelocity()))) {
+            velocity.setLength(
+                    Math.max(
+                            Math.abs(velocityComponent.xVelocity()),
+                            Math.abs(velocityComponent.yVelocity())));
+        }
+
         velocitySystem.execute();
         Point position = positionComponent.position();
-        assertEquals(startXPosition + xVelocity, position.x, 0.001);
-        assertEquals(startYPosition + yVelocity, position.y, 0.001);
+
+        assertEquals(startXPosition + velocity.x, position.x, 0.001);
+        assertEquals(startYPosition + velocity.y, position.y, 0.001);
         assertEquals(
                 xVelocity * (1.0f - tile.friction()), velocityComponent.currentXVelocity(), 0.001);
         assertEquals(
@@ -79,13 +96,30 @@ public class VelocitySystemTest {
     @Test
     public void updateValidMoveWithNegativeVelocity() {
         Mockito.when(tile.isAccessible()).thenReturn(true);
+        velocityComponent.xVelocity(4);
+        velocityComponent.yVelocity(8);
         velocityComponent.currentXVelocity(-4);
         velocityComponent.currentYVelocity(-8);
+
+        Vector2 velocity =
+                new Vector2(
+                        velocityComponent.currentXVelocity(), velocityComponent.currentYVelocity());
+        if (velocity.len()
+                > Math.max(
+                        Math.abs(velocityComponent.xVelocity()),
+                        Math.abs(velocityComponent.yVelocity()))) {
+            velocity.setLength(
+                    Math.max(
+                            Math.abs(velocityComponent.xVelocity()),
+                            Math.abs(velocityComponent.yVelocity())));
+        }
+
         velocitySystem.execute();
         System.out.println(tile.friction());
         Point position = positionComponent.position();
-        assertEquals(startXPosition - 4, position.x, 0.001);
-        assertEquals(startYPosition - 8, position.y, 0.001);
+
+        assertEquals(startXPosition + velocity.x, position.x, 0.001);
+        assertEquals(startYPosition + velocity.y, position.y, 0.001);
         assertEquals(-4 * (1.0f - tile.friction()), velocityComponent.currentXVelocity(), 0.001);
         assertEquals(-8 * (1.0f - tile.friction()), velocityComponent.currentYVelocity(), 0.001);
     }

--- a/game/test/core/systems/VelocitySystemTest.java
+++ b/game/test/core/systems/VelocitySystemTest.java
@@ -40,6 +40,7 @@ public class VelocitySystemTest {
     public void setup() throws IOException {
         Game.add(new LevelSystem(null, null, () -> {}));
         Game.currentLevel(level);
+        Mockito.when(tile.friction()).thenReturn(0.75f);
         Mockito.when(level.tileAt((Point) Mockito.any())).thenReturn(tile);
         entity = new Entity();
         velocitySystem = new VelocitySystem();
@@ -69,8 +70,10 @@ public class VelocitySystemTest {
         Point position = positionComponent.position();
         assertEquals(startXPosition + xVelocity, position.x, 0.001);
         assertEquals(startYPosition + yVelocity, position.y, 0.001);
-        assertEquals(0, velocityComponent.currentXVelocity(), 0.001);
-        assertEquals(0, velocityComponent.currentYVelocity(), 0.001);
+        assertEquals(
+                xVelocity * (1.0f - tile.friction()), velocityComponent.currentXVelocity(), 0.001);
+        assertEquals(
+                yVelocity * (1.0f - tile.friction()), velocityComponent.currentYVelocity(), 0.001);
     }
 
     @Test
@@ -79,11 +82,12 @@ public class VelocitySystemTest {
         velocityComponent.currentXVelocity(-4);
         velocityComponent.currentYVelocity(-8);
         velocitySystem.execute();
+        System.out.println(tile.friction());
         Point position = positionComponent.position();
         assertEquals(startXPosition - 4, position.x, 0.001);
         assertEquals(startYPosition - 8, position.y, 0.001);
-        assertEquals(0, velocityComponent.currentXVelocity(), 0.001);
-        assertEquals(0, velocityComponent.currentYVelocity(), 0.001);
+        assertEquals(-4 * (1.0f - tile.friction()), velocityComponent.currentXVelocity(), 0.001);
+        assertEquals(-8 * (1.0f - tile.friction()), velocityComponent.currentYVelocity(), 0.001);
     }
 
     @Test
@@ -95,8 +99,10 @@ public class VelocitySystemTest {
         Point position = positionComponent.position();
         assertEquals(startXPosition, position.x, 0.001);
         assertEquals(startYPosition, position.y, 0.001);
-        assertEquals(0, velocityComponent.currentXVelocity(), 0.001);
-        assertEquals(0, velocityComponent.currentYVelocity(), 0.001);
+        assertEquals(
+                xVelocity * (1.0f - tile.friction()), velocityComponent.currentXVelocity(), 0.001);
+        assertEquals(
+                yVelocity * (1.0f - tile.friction()), velocityComponent.currentYVelocity(), 0.001);
     }
 
     @Test
@@ -108,8 +114,8 @@ public class VelocitySystemTest {
         Point position = positionComponent.position();
         assertEquals(startXPosition, position.x, 0.001);
         assertEquals(startYPosition, position.y, 0.001);
-        assertEquals(0, velocityComponent.currentXVelocity(), 0.001);
-        assertEquals(0, velocityComponent.currentYVelocity(), 0.001);
+        assertEquals(-4 * (1.0f - tile.friction()), velocityComponent.currentXVelocity(), 0.001);
+        assertEquals(-8 * (1.0f - tile.friction()), velocityComponent.currentYVelocity(), 0.001);
     }
 
     @Test


### PR DESCRIPTION
(closes #935)

- Hinzufügen von Reibungswiderstand
- Berücksichtigen der Delta-Time für Bewegung (→ Bewegung wird bei Einbruch der Framerate mit gleicher Geschwindigkeit im nächsten Frame fortgesetzt)