### PR TITLE
[GAME] use map `Set<EntiteSystemMapper>` with `ILevel` to create a link between the level and the entities

### DIFF
--- a/dungeon/test/manual/dslFileReader/DslFileReaderTest.java
+++ b/dungeon/test/manual/dslFileReader/DslFileReaderTest.java
@@ -2,7 +2,6 @@ package manual.dslFileReader;
 
 import core.Game;
 import core.hud.UITools;
-import core.utils.IVoidFunction;
 
 import dslToGame.DslFileLoader;
 import dslToGame.DummyDSLFunctions;
@@ -24,26 +23,23 @@ public class DslFileReaderTest {
                 core.configuration.KeyboardConfig.class);
         Game.disableAudio(true);
         Game.userOnLevelLoad(
-                new IVoidFunction() {
-                    @Override
-                    public void execute() {
-                        Set<File> files = DslFileLoader.dslFiles();
-                        Set<String> fileContents =
-                                files.stream()
-                                        .map(DslFileLoader::fileToString)
-                                        .collect(Collectors.toSet());
-                        Set<Map<String, String>> configs =
-                                fileContents.stream()
-                                        .map(DummyDSLFunctions::getConfigs)
-                                        .collect(Collectors.toSet());
+                b -> {
+                    Set<File> files = DslFileLoader.dslFiles();
+                    Set<String> fileContents =
+                            files.stream()
+                                    .map(DslFileLoader::fileToString)
+                                    .collect(Collectors.toSet());
+                    Set<Map<String, String>> configs =
+                            fileContents.stream()
+                                    .map(DummyDSLFunctions::getConfigs)
+                                    .collect(Collectors.toSet());
 
-                        AtomicReference<String> f = new AtomicReference<>("");
-                        files.forEach(v -> f.set(f.get() + v + System.lineSeparator()));
-                        UITools.generateNewTextDialog(f.get(), "Ok", "Files");
+                    AtomicReference<String> f = new AtomicReference<>("");
+                    files.forEach(v -> f.set(f.get() + v + System.lineSeparator()));
+                    UITools.generateNewTextDialog(f.get(), "Ok", "Files");
 
-                        // for the start: print on console
-                        configs.forEach(map -> map.values().forEach(System.out::println));
-                    }
+                    // for the start: print on console
+                    configs.forEach(map -> map.values().forEach(System.out::println));
                 });
 
         Game.run();

--- a/dungeon/test/manual/dslFileReader/DslFileReaderTest.java
+++ b/dungeon/test/manual/dslFileReader/DslFileReaderTest.java
@@ -23,7 +23,7 @@ public class DslFileReaderTest {
                 core.configuration.KeyboardConfig.class);
         Game.disableAudio(true);
         Game.userOnLevelLoad(
-                b -> {
+                loadFirstTime -> {
                     Set<File> files = DslFileLoader.dslFiles();
                     Set<String> fileContents =
                             files.stream()

--- a/dungeon/test/manual/quizquestion/CallbackTest.java
+++ b/dungeon/test/manual/quizquestion/CallbackTest.java
@@ -74,9 +74,9 @@ public class CallbackTest {
                     if (Gdx.input.isKeyJustPressed(Input.Keys.V)) toggleQuiz();
                 });
         Game.userOnLevelLoad(
-                (b) -> {
+                (loadFirstTime) -> {
                     try {
-                        if (b) Game.add(questWizard());
+                        if (loadFirstTime) Game.add(questWizard());
                     } catch (IOException e) {
                         throw new RuntimeException();
                     }

--- a/dungeon/test/manual/quizquestion/CallbackTest.java
+++ b/dungeon/test/manual/quizquestion/CallbackTest.java
@@ -74,9 +74,9 @@ public class CallbackTest {
                     if (Gdx.input.isKeyJustPressed(Input.Keys.V)) toggleQuiz();
                 });
         Game.userOnLevelLoad(
-                () -> {
+                (b) -> {
                     try {
-                        Game.add(questWizard());
+                        if (b) Game.add(questWizard());
                     } catch (IOException e) {
                         throw new RuntimeException();
                     }

--- a/dungeon/test/manual/taskgeneration/TaskGenerationTest.java
+++ b/dungeon/test/manual/taskgeneration/TaskGenerationTest.java
@@ -56,23 +56,27 @@ public class TaskGenerationTest {
                     }
                 });
         Game.userOnLevelLoad(
-                () -> {
-                    try {
-                        Game.add(EntityFactory.randomMonster());
-                        Game.add(EntityFactory.newChest());
-                    } catch (IOException e) {
-                        // oh well
+                (b) -> {
+                    if (b) {
+                        try {
+
+                            Game.add(EntityFactory.randomMonster());
+                            Game.add(EntityFactory.newChest());
+
+                        } catch (IOException e) {
+                            // oh well
+                        }
+
+                        Set<File> files = DslFileLoader.dslFiles();
+                        List<String> fileContents =
+                                files.stream()
+                                        .filter(f -> f.getName().endsWith("task_test.dng"))
+                                        .map(DslFileLoader::fileToString)
+                                        .toList();
+
+                        // for the start: print on console
+                        buildScenarios(fileContents.get(0));
                     }
-
-                    Set<File> files = DslFileLoader.dslFiles();
-                    List<String> fileContents =
-                            files.stream()
-                                    .filter(f -> f.getName().endsWith("task_test.dng"))
-                                    .map(DslFileLoader::fileToString)
-                                    .toList();
-
-                    // for the start: print on console
-                    buildScenarios(fileContents.get(0));
                 });
 
         Game.windowTitle("Task Test");

--- a/dungeon/test/manual/taskgeneration/TaskGenerationTest.java
+++ b/dungeon/test/manual/taskgeneration/TaskGenerationTest.java
@@ -56,8 +56,8 @@ public class TaskGenerationTest {
                     }
                 });
         Game.userOnLevelLoad(
-                (b) -> {
-                    if (b) {
+                (loadFirstTime) -> {
+                    if (loadFirstTime) {
                         try {
 
                             Game.add(EntityFactory.randomMonster());

--- a/game/src/core/utils/EntitySystemMapper.java
+++ b/game/src/core/utils/EntitySystemMapper.java
@@ -221,4 +221,12 @@ public final class EntitySystemMapper {
     public boolean has(final System system) {
         return systems.contains(system);
     }
+
+    public void triggerAllOnAdd() {
+        systems.forEach(s -> entities.forEach(s::triggerOnAdd));
+    }
+
+    public void triggerAllOnRemove() {
+        systems.forEach(s -> entities.forEach(s::triggerOnRemove));
+    }
 }

--- a/game/src/core/utils/EntitySystemMapper.java
+++ b/game/src/core/utils/EntitySystemMapper.java
@@ -221,12 +221,4 @@ public final class EntitySystemMapper {
     public boolean has(final System system) {
         return systems.contains(system);
     }
-
-    public void triggerAllOnAdd() {
-        systems.forEach(s -> entities.forEach(s::triggerOnAdd));
-    }
-
-    public void triggerAllOnRemove() {
-        systems.forEach(s -> entities.forEach(s::triggerOnRemove));
-    }
 }

--- a/game/src/starter/Main.java
+++ b/game/src/starter/Main.java
@@ -36,18 +36,20 @@ public class Main {
                     }
                 });
         Game.userOnLevelLoad(
-                () -> {
-                    try {
+                (firstTime) -> {
+                    if (firstTime) {
+                        try {
 
-                        Game.add(EntityFactory.newChest());
-                        for (int i = 0; i < 5; i++) {
-                            Game.add(EntityFactory.randomMonster());
+                            Game.add(EntityFactory.newChest());
+                            for (int i = 0; i < 5; i++) {
+                                Game.add(EntityFactory.randomMonster());
+                            }
+                        } catch (IOException e) {
+                            LOGGER.warning("Could not create new Chest: " + e.getMessage());
+                            throw new RuntimeException();
                         }
-                    } catch (IOException e) {
-                        LOGGER.warning("Could not create new Chest: " + e.getMessage());
-                        throw new RuntimeException();
+                        Game.levelSize(LevelSize.randomSize());
                     }
-                    Game.levelSize(LevelSize.randomSize());
                 });
         Game.userOnFrame(debugger::execute);
         Game.windowTitle("My Dungeon");


### PR DESCRIPTION
fixes #900 

- Fügt in der Klasse `Game` die `Map<ILevel, Set<EntityStorageMapper>>` hinzu. 
- Die Map stellt die Verbindung zwischen den Leveln und den Entitäten her.
- Der aktive Storage ist das `Set<EntityStorageMapper>` des aktiven Levels.
- Im `Game#onLevelLoad` werden jetzt alle Systeme aus dem "alten" `Set<EntityStorageMapper>` entfernt. Dadurch werden alle `System#onEntityRemove`-Methoden ausgelöst, ohne die Entitäten tatsächlich zu löschen (denn diese werden beim Neuladen des Levels noch benötigt).
- Für das neue Level werden die Systeme anschließend wieder hinzugefügt, was jeweils jedes `System#onEntityAdd` auslöst.
- `userOnLevelLoad` ist nun ein `Consumer<Boolean>`. Der Boolean gibt an, ob das Level schon einmal geladen wurde. Dadurch können Monster und Schatzkisten nur beim ersten Mal hinzugefügt werden.