### PR TITLE
[DUNGEON] add `jarConverter.sh` to create Jar Files 

### DIFF
--- a/doc/jar_converter/readme.md
+++ b/doc/jar_converter/readme.md
@@ -1,0 +1,26 @@
+---
+title: "Jar Converter: How to"
+---
+
+## Was ist `jarConvert.sh`
+
+`jarConverter.sh` ist ein Bash-Skript, das dazu dient, Dateien und Verzeichnisse zu kopieren und sie anschließend in einer JAR-Datei zu exportieren.
+Das Skript ermöglicht es dir, Dateien und Verzeichnisse mit relativen Pfaden als Befehlszeilenargumente anzugeben.
+Diese Dateien und Verzeichnisse werden dann in einen neu erstellten Ordner mit dem Namen "scripts" kopiert.
+Nachdem die Dateien und Verzeichnisse kopiert wurden, erstellt das Skript eine JAR-Datei mit dem Namen "scripts.jar", die den Inhalt des "scripts"-Ordners enthält.
+
+`jarConverter.sh` kann genutzt werden, um verschiedene DSL-Skripte in einer JAR-Datei zu sammeln, um sie dann im Spiel einzulesen zu lassen.
+
+## How to use
+
+1. Open your terminal.
+2. Navigate to the directory where the script is located (if you're not already there).
+3. To use the script, provide the relative paths of the files and directories you want to include in the JAR file as arguments. For example:
+
+   ```bash
+   ./jarConverter.sh file1.dng directory1 file2.dng
+   ```
+
+   Replace `file1.dng`, `directory1`, and `file2.dng` with the actual relative paths of the files and directories you want to include.
+
+4. The script will copy the specified files and directories to a new folder named "scripts" and create a JAR file named "scripts.jar" containing the contents of the "scripts" folder.

--- a/doc/jar_converter/readme.md
+++ b/doc/jar_converter/readme.md
@@ -11,16 +11,16 @@ Nachdem die Dateien und Verzeichnisse kopiert wurden, erstellt das Skript eine J
 
 `jarConverter.sh` kann genutzt werden, um verschiedene DSL-Skripte in einer JAR-Datei zu sammeln, um sie dann im Spiel einzulesen zu lassen.
 
-## How to use
+## Anwenden
 
-1. Open your terminal.
-2. Navigate to the directory where the script is located (if you're not already there).
-3. To use the script, provide the relative paths of the files and directories you want to include in the JAR file as arguments. For example:
+1. Öffnen Sie Ihr Terminal.
+2. Navigieren Sie zum Verzeichnis, in dem sich das Skript befindet (falls Sie sich dort nicht bereits befinden).
+3. Um das Skript zu verwenden, geben Sie die relativen Pfade der Dateien und Verzeichnisse an, die Sie in die JAR-Datei aufnehmen möchten, als Argumente. Zum Beispiel:
 
    ```bash
-   ./jarConverter.sh file1.dng directory1 file2.dng
+   ./jarConverter.sh datei1.dng verzeichnis1 datei2.dng
    ```
 
-   Replace `file1.dng`, `directory1`, and `file2.dng` with the actual relative paths of the files and directories you want to include.
+   Ersetzen Sie `datei1.dng`, `verzeichnis1` und `datei2.dng` durch die tatsächlichen relativen Pfade der Dateien und Verzeichnisse, die Sie aufnehmen möchten.
 
-4. The script will copy the specified files and directories to a new folder named "scripts" and create a JAR file named "scripts.jar" containing the contents of the "scripts" folder.
+4. Das Skript kopiert die angegebenen Dateien und Verzeichnisse in einen neuen Ordner namens "scripts" und erstellt eine JAR-Datei mit dem Namen "scripts.jar", die den Inhalt des Ordners "scripts" enthält.

--- a/jarConverter.sh
+++ b/jarConverter.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Erstelle den Ordner "scripts", falls er nicht existiert
+mkdir -p scripts
+
+# Iteriere über alle übergebenen Argumente
+for arg in "$@"; do
+    # Prüfe, ob das Argument eine Datei oder ein Verzeichnis ist
+    if [ -e "$arg" ]; then
+        # Extrahiere den Dateinamen aus dem Pfad
+        filename=$(basename "$arg")
+        # Kopiere die Datei oder das Verzeichnis in den "scripts"-Ordner
+        cp -r "$arg" "scripts/$filename"
+    else
+        echo "Das Argument '$arg' ist keine gültige Datei oder Verzeichnis."
+    fi
+done
+
+# Erstelle die JAR-Datei
+jar -cvf scripts.jar scripts
+
+echo "Die Dateien und Verzeichnisse wurden in den 'scripts'-Ordner kopiert und als 'scripts.jar' exportiert."


### PR DESCRIPTION
fixes #881

- Fügt Skript hinzu
- Fügt Anleitung zur Verwendung hinzu
- Anders als in #881 beschrieben, verarbeitet das Skript nicht automatisch alle Dateien im Verzeichnis. Stattdessen werden Befehlszeilenargumente (CLA) erwartet. Dies mag die Verwendung etwas umständlicher machen, aber ich habe Bedenken, dass sonst jemand das Skript auf dem Desktop ausführt und das gesamte System in eine JAR-Datei kopiert.


Falls sich wer fragt, warum der `scripts` Ordner am Ende nicht gelöscht wird:
1. Dann kann man relativ einfach gucken ob wirklich alles enthalten ist was man wollte
2. Falls es schon ein `scripts` Ordner gibt bevor das Skript startet, will ich nichts vom User löschen. Lieber lasse ich den User selber aufräumen als ausversehen irgendwelche Daten zu löschen