### PR TITLE
[GAME] add unterscheidung von Dateiverarbeitung in IDE und JAR im `DrawComponent` 

### DIFF
--- a/game/src/core/components/DrawComponent.java
+++ b/game/src/core/components/DrawComponent.java
@@ -3,7 +3,6 @@ package core.components;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.files.FileHandle;
 
-import contrib.crafting.Crafting;
 import contrib.utils.components.draw.AdditionalAnimations;
 
 import core.Component;
@@ -76,18 +75,18 @@ public final class DrawComponent implements Component {
         // fetch available animations
         try {
             FileHandle directory = null;
-            FileHandle directoryd = null;
-            if (Objects.requireNonNull(Crafting.class.getResource("."))
-                    .toString()
-                    .startsWith("jar:")) {
-                java.lang.System.out.println("Test");
+            if (isRunningFromJar()) {
+                // working dir? relativer pfad der jar über cla bzw java start argumente
+                // how to get in the jar Dungeon => Dungeon.jar
+                directory = Gdx.files.internal("./Dungeon/" + path);
+
             } else {
                 directory = Gdx.files.internal("./game/assets/" + path);
-                directoryd = Gdx.files.internal(".");
             }
 
-            java.lang.System.out.println(directoryd.isDirectory());
-            Arrays.stream(directoryd.list()).forEach(f -> java.lang.System.out.println(f));
+            java.lang.System.out.println(directory.isDirectory());
+            Arrays.stream(directory.list()).forEach(f -> java.lang.System.out.println(f));
+            java.lang.System.out.println("---------------------- END --------------");
             animationMap =
                     Arrays.stream(directory.list())
                             .filter(FileHandle::isDirectory)
@@ -219,5 +218,11 @@ public final class DrawComponent implements Component {
      */
     public boolean isCurrentAnimationFinished() {
         return currentAnimation.isFinished();
+    }
+
+    private static boolean isRunningFromJar() {
+        String className = DrawComponent.class.getName().replace('.', '/');
+        String classJar = DrawComponent.class.getResource("/" + className + ".class").toString();
+        return classJar.startsWith("jar:");
     }
 }

--- a/game/src/core/components/DrawComponent.java
+++ b/game/src/core/components/DrawComponent.java
@@ -213,30 +213,59 @@ public final class DrawComponent implements Component {
     }
 
     private void loadAnimationsFromJar(String path, File jarFile) throws IOException {
+        // This function will create a map of directories (String) and the files
+        // (LinkedList<String>) inside these directories.
+        // The map will be filled with the directories inside the given path (e.g.,
+        // "character/knight").
+        // Ultimately, this function will manually create an Animation for each entry within this
+        // map.
+
         JarFile jar = new JarFile(jarFile);
         Enumeration<JarEntry> entries = jar.entries(); // gives ALL entries in jar
+
+        // This will be used to map the directory names (e.g., "idle") and the texture files.
+        // Ultimately, we will create animations out of this by using the
+        // Animation(LinkedList<String>) constructor.
+
         HashMap<String, List<String>> storage = new HashMap<>();
         animationMap = new HashMap<>();
 
-        while (entries.hasMoreElements()) {
+        // Iterate over each file and directory in the JAR.
 
+        while (entries.hasMoreElements()) {
             // example: character/knight/idle/idle_knight_1.png
             // but also: character/knight/idle/
             // and: character/knight/
             String fileName = entries.nextElement().getName();
+
+            // If the entry starts with the path name (character/knight/idle),
+            // this is true for entries like (character/knight/idle/idle_knight_1.png) and
+            // (character/knight/idle/).
             if (fileName.startsWith(path + File.separator)) {
-                // Extract the last part of the path as the fileName
+
+                // Get the index of the last FileSeparator; every character after that separator is
+                // part of the filename.
                 int lastSlashIndex = fileName.lastIndexOf(File.separator);
-                // ignore directory's
+
+                // Ignore directories, so we only work with strings like
+                // (character/knight/idle/idle_knight_1.png).
                 if (lastSlashIndex != fileName.length() - 1) {
-                    // Extract the second-to-last part of the path as the lastDir
+                    // Get the index of the second-to-last part of the string.
+                    // For example, in "character/knight/idle/idle_knight_1.png", this would be the
+                    // index of the slash in "/idle".
+
                     int secondLastSlashIndex =
                             fileName.lastIndexOf(File.separator, lastSlashIndex - 1);
-                    // example: idle
-                    // this is the key of the animation map
+
+                    // Get the name of the directory. The directory name is between the
+                    // second-to-last and the last separator index.
+                    // The directory name serves as the key of the animation in the animation map
+                    // (similar to what the IPATh values are for them).
+                    // For example: "idle"
+
                     String lastDir = fileName.substring(secondLastSlashIndex + 1, lastSlashIndex);
 
-                    // add animation to new or existing list
+                    // add animation-files to new or existing storage map
                     if (storage.containsKey(lastDir)) storage.get(lastDir).add(fileName);
                     else {
                         LinkedList<String> list = new LinkedList<>();

--- a/game/src/core/components/DrawComponent.java
+++ b/game/src/core/components/DrawComponent.java
@@ -1,5 +1,9 @@
 package core.components;
 
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.files.FileHandle;
+
+import contrib.crafting.Crafting;
 import contrib.utils.components.draw.AdditionalAnimations;
 
 import core.Component;
@@ -9,7 +13,6 @@ import core.utils.components.draw.Animation;
 import core.utils.components.draw.CoreAnimations;
 import core.utils.components.draw.IPath;
 
-import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.*;
@@ -72,12 +75,23 @@ public final class DrawComponent implements Component {
     public DrawComponent(final String path) throws IOException {
         // fetch available animations
         try {
-            ClassLoader classLoader = getClass().getClassLoader();
-            File directory = new File(classLoader.getResource(path).getFile());
+            FileHandle directory = null;
+            FileHandle directoryd = null;
+            if (Objects.requireNonNull(Crafting.class.getResource("."))
+                    .toString()
+                    .startsWith("jar:")) {
+                java.lang.System.out.println("Test");
+            } else {
+                directory = Gdx.files.internal("./game/assets/" + path);
+                directoryd = Gdx.files.internal(".");
+            }
+
+            java.lang.System.out.println(directoryd.isDirectory());
+            Arrays.stream(directoryd.list()).forEach(f -> java.lang.System.out.println(f));
             animationMap =
-                    Arrays.stream(directory.listFiles())
-                            .filter(File::isDirectory)
-                            .collect(Collectors.toMap(File::getName, Animation::of));
+                    Arrays.stream(directory.list())
+                            .filter(FileHandle::isDirectory)
+                            .collect(Collectors.toMap(FileHandle::name, Animation::of));
 
             currentAnimation(
                     CoreAnimations.IDLE_DOWN,

--- a/game/src/core/utils/components/draw/Animation.java
+++ b/game/src/core/utils/components/draw/Animation.java
@@ -95,6 +95,11 @@ public final class Animation {
      * @return The created Animation instance
      */
     public static Animation of(FileHandle subDir, int frameTime, boolean loop) {
+        System.out.println("Animation");
+        System.out.println(subDir);
+        System.out.println(subDir.isDirectory());
+        Arrays.stream(subDir.list()).forEach(f -> System.out.println(f));
+        System.out.println("-------------- Animation End ----------");
         List<String> fileNames =
                 Arrays.stream(Objects.requireNonNull(subDir.list()))
                         .filter(fh -> !fh.isDirectory())

--- a/game/src/core/utils/components/draw/Animation.java
+++ b/game/src/core/utils/components/draw/Animation.java
@@ -107,10 +107,11 @@ public final class Animation {
                 Arrays.stream(Objects.requireNonNull(subDir.listFiles()))
                         .filter(File::isFile)
                         .map(File::getPath)
+                        // sort the files in lexicographic order (like the most os) so animations
+                        // will be played in order
                         .sorted()
                         .collect(Collectors.toList());
-        // sort the files in lexicographic order (like the most os)
-        // animations will be played in order
+
         return new Animation(fileNames, frameTime, loop);
     }
 

--- a/game/src/core/utils/components/draw/Animation.java
+++ b/game/src/core/utils/components/draw/Animation.java
@@ -1,7 +1,6 @@
 package core.utils.components.draw;
 
-import com.badlogic.gdx.files.FileHandle;
-
+import java.io.File;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -75,6 +74,15 @@ public final class Animation {
     }
 
     /**
+     * Creates an animation with the default configuration.
+     *
+     * @param animationFrames The list of textures that builds the animation. Must be in order.
+     */
+    public Animation(Collection<String> animationFrames) {
+        this(animationFrames, DEFAULT_FRAME_TIME, true);
+    }
+
+    /**
      * Creates an animation containing only one frame. repeats forever
      *
      * @param animationFrame The texture that builds the animation.
@@ -94,16 +102,11 @@ public final class Animation {
      * @param loop should the Animation continue to repeat ?
      * @return The created Animation instance
      */
-    public static Animation of(FileHandle subDir, int frameTime, boolean loop) {
-        System.out.println("Animation");
-        System.out.println(subDir);
-        System.out.println(subDir.isDirectory());
-        Arrays.stream(subDir.list()).forEach(f -> System.out.println(f));
-        System.out.println("-------------- Animation End ----------");
+    public static Animation of(File subDir, int frameTime, boolean loop) {
         List<String> fileNames =
-                Arrays.stream(Objects.requireNonNull(subDir.list()))
-                        .filter(fh -> !fh.isDirectory())
-                        .map(FileHandle::path)
+                Arrays.stream(Objects.requireNonNull(subDir.listFiles()))
+                        .filter(File::isFile)
+                        .map(File::getPath)
                         .sorted()
                         .collect(Collectors.toList());
         // sort the files in lexicographic order (like the most os)
@@ -120,7 +123,7 @@ public final class Animation {
      * @param subDir Path to the subdirectory where the animation frames are stored
      * @return The created Animation instance
      */
-    public static Animation of(FileHandle subDir) {
+    public static Animation of(File subDir) {
         return Animation.of(subDir, DEFAULT_FRAME_TIME, DEFAULT_IS_LOOP);
     }
 

--- a/game/src/core/utils/components/draw/Animation.java
+++ b/game/src/core/utils/components/draw/Animation.java
@@ -1,6 +1,7 @@
 package core.utils.components.draw;
 
-import java.io.File;
+import com.badlogic.gdx.files.FileHandle;
+
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -93,16 +94,15 @@ public final class Animation {
      * @param loop should the Animation continue to repeat ?
      * @return The created Animation instance
      */
-    public static Animation of(File subDir, int frameTime, boolean loop) {
+    public static Animation of(FileHandle subDir, int frameTime, boolean loop) {
         List<String> fileNames =
-                Arrays.stream(Objects.requireNonNull(subDir.listFiles()))
-                        .filter(File::isFile)
-                        .map(File::getPath)
+                Arrays.stream(Objects.requireNonNull(subDir.list()))
+                        .filter(fh -> !fh.isDirectory())
+                        .map(FileHandle::path)
+                        .sorted()
                         .collect(Collectors.toList());
-
         // sort the files in lexicographic order (like the most os)
         // animations will be played in order
-        Collections.sort(fileNames);
         return new Animation(fileNames, frameTime, loop);
     }
 
@@ -115,7 +115,7 @@ public final class Animation {
      * @param subDir Path to the subdirectory where the animation frames are stored
      * @return The created Animation instance
      */
-    public static Animation of(File subDir) {
+    public static Animation of(FileHandle subDir) {
         return Animation.of(subDir, DEFAULT_FRAME_TIME, DEFAULT_IS_LOOP);
     }
 


### PR DESCRIPTION
Fixes #932

Dieser PR fügt dem `DrawComponent` eine Fallunterscheidung hinzu, die prüft, ob das Programm in der IDE oder in einer JAR-Datei ausgeführt wird. Abhängig davon werden unterschiedliche Logiken zum Einlesen der Animationsdateien angewendet.

Für die Ausführung in der IDE hat sich nicht viel geändert. Wir lesen nach wie vor alle Verzeichnisse im übergebenen Pfad ein und ordnen sie der Funktion `Animation#of` zu.

Wenn das Programm in einer JAR-Datei ausgeführt wird, sind andere Schritte erforderlich. Zunächst lesen wir alle Dateien und Verzeichnisse in der gesamten JAR-Datei ein (Verwendung von `Enumeration<JarEntry> entries = jar.entries();`). Da wir innerhalb einer JAR-Datei nicht mit dem Datentyp `File` arbeiten können, erfolgt die Verarbeitung auf der Ebene Strings. Zunächst ignorieren wir alles, was sich außerhalb des betrachteten Pfads befindet. Unser betrachteter Bereich (für "character/knight")sieht dann folgendermaßen aus:

```
character/knight/
character/knight/idle/
character/knight/idle/idle_knight_2.png
character/knight/idle/idle_knight_1.png
character/knight/fight_left/
```

Anschließend erfolgen folgende Schritte:
- Entfernung aller Zeichenketten, die keine Dateiendung haben.
- Erstellung einer Hilfsmap, die jedem Verzeichnispfad (z. B. `character/knight/idle/`) eine Liste von Dateinamen zuordnet (`idle_knight_1.png`, `idle_knight_2.png` usw.).
- Abschließend werden die Einträge aus der Hilfsmap verwendet, um die eigentliche Animationsmap zu erstellen. Hierbei wird die `new Animation`-Funktion verwendet, anstelle von `Animation.of`.

@malt-r, nochmals vielen Dank für den entscheidenden Tipp.
