### PR TITLE
[GAME] add `PositionSystem`

### DIFF
--- a/game/src/core/Game.java
+++ b/game/src/core/Game.java
@@ -820,6 +820,7 @@ public final class Game extends ScreenAdapter {
 
     /** Create the systems. */
     private void createSystems() {
+        add(new PositionSystem());
         add(new CameraSystem());
         add(
                 new LevelSystem(

--- a/game/src/core/components/PositionComponent.java
+++ b/game/src/core/components/PositionComponent.java
@@ -24,6 +24,7 @@ import java.util.logging.Logger;
 @DSLType(name = "position_component")
 public final class PositionComponent implements Component {
 
+    public static final Point ILLEGAL_POSITION = new Point(-100, -100);
     private final Logger LOGGER = Logger.getLogger(this.getClass().getName());
     private Point position;
 
@@ -51,18 +52,19 @@ public final class PositionComponent implements Component {
     }
 
     /**
-     * Create a new PositionComponent with random position.
+     * Creates a new PositionComponent with a random position.
      *
      * <p>Sets the position of this entity on a random floor tile in the level. If no level is
-     * loaded, set the position to (0,0). Beware that (0,0) may not necessarily be a playable area
-     * within the level, it could be a wall or an "out of level" area.
+     * loaded, the position is set to {@link #ILLEGAL_POSITION}. Keep in mind that if the associated
+     * entity is processed by the {@link core.systems.PositionSystem}, {@link #ILLEGAL_POSITION}
+     * will be replaced with a random accessible position.
      */
     public PositionComponent() {
 
         if (Game.currentLevel() != null) {
             position = Game.randomTilePoint(LevelElement.FLOOR);
         } else {
-            position = new Point(0, 0);
+            position = ILLEGAL_POSITION;
         }
     }
 

--- a/game/src/core/systems/PositionSystem.java
+++ b/game/src/core/systems/PositionSystem.java
@@ -1,0 +1,53 @@
+package core.systems;
+
+import core.Entity;
+import core.Game;
+import core.System;
+import core.components.PositionComponent;
+import core.level.utils.LevelElement;
+import core.utils.components.MissingComponentException;
+
+/**
+ * The {@link PositionSystem} checks if an entity has an illegal position and then changes the
+ * position to a random position in the currently active level.
+ *
+ * <p>Entities with the {@link PositionComponent} will be processed by this system.
+ *
+ * <p>If the position of an entity is equal to {@link PositionComponent#ILLEGAL_POSITION}, the
+ * position of the entity will be set to a random accessible tile in the current level.
+ *
+ * <p>Note: In most cases, the position of an entity equals {@link
+ * PositionComponent#ILLEGAL_POSITION} during the first frame of the currently active level. This
+ * occurs because sometimes entities are created before the level is loaded.
+ */
+public class PositionSystem extends System {
+
+    /** Create a new VelocitySystem */
+    public PositionSystem() {
+        super(PositionComponent.class);
+    }
+
+    @Override
+    public void execute() {
+        entityStream()
+                .map(this::buildDataObject)
+                .filter(data -> data.pc.position().equals(PositionComponent.ILLEGAL_POSITION))
+                .forEach(this::randomPosition);
+    }
+
+    private void randomPosition(PSData data) {
+        if (Game.currentLevel() != null) data.pc.position(Game.randomTile(LevelElement.FLOOR));
+    }
+
+    private PSData buildDataObject(Entity e) {
+
+        PositionComponent pc =
+                e.fetch(PositionComponent.class)
+                        .orElseThrow(
+                                () -> MissingComponentException.build(e, PositionComponent.class));
+
+        return new PSData(e, pc);
+    }
+
+    private record PSData(Entity e, PositionComponent pc) {}
+}

--- a/game/src/core/utils/Point.java
+++ b/game/src/core/utils/Point.java
@@ -10,6 +10,8 @@ import core.level.utils.Coordinate;
  */
 public class Point {
 
+    private static final float EPSILON = 0.000001f;
+
     public float x;
     public float y;
 
@@ -79,5 +81,15 @@ public class Point {
         float xDiff = p1.x - p2.x;
         float yDiff = p1.y - p2.y;
         return (float) Math.sqrt(xDiff * xDiff + yDiff * yDiff);
+    }
+
+    /**
+     * Two points are equal, if they have the same x and y values.
+     *
+     * @param other Point to compare with
+     * @return if the x and y values of the points are equal.
+     */
+    public boolean equals(Point other) {
+        return Math.abs(x - other.x) < EPSILON && Math.abs(y - other.y) < EPSILON;
     }
 }

--- a/game/test/core/systems/PositionSystemTest.java
+++ b/game/test/core/systems/PositionSystemTest.java
@@ -1,0 +1,64 @@
+package core.systems;
+
+import static org.junit.Assert.*;
+
+import core.Entity;
+import core.Game;
+import core.components.PositionComponent;
+import core.level.Tile;
+import core.level.elements.ILevel;
+import core.level.elements.tile.FloorTile;
+import core.level.utils.LevelElement;
+import core.utils.Point;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class PositionSystemTest {
+
+    private PositionSystem system;
+    private Tile mock = Mockito.mock(FloorTile.class);
+    private Point point = new Point(3, 3);
+    private ILevel level = Mockito.mock(ILevel.class);
+    private Entity entity;
+    private PositionComponent pc;
+
+    @Before
+    public void setup() {
+        pc = new PositionComponent();
+        Game.add(new LevelSystem(null, null, () -> {}));
+        Game.currentLevel(level);
+        system = new PositionSystem();
+        Game.add(system);
+        entity = new Entity();
+        Game.add(entity);
+
+        entity.addComponent(pc);
+
+        Mockito.when(level.randomTile(LevelElement.FLOOR)).thenReturn(mock);
+        Mockito.when(mock.position()).thenReturn(point);
+    }
+
+    @After
+    public void cleanup() {
+        Game.removeAllSystems();
+        Game.removeAllEntities();
+        Game.currentLevel(null);
+    }
+
+    @Test
+    public void test_illegalPosition() {
+        pc.position(PositionComponent.ILLEGAL_POSITION);
+        system.execute();
+        assertTrue(pc.position().equals(point));
+    }
+
+    @Test
+    public void test_legalPosition() {
+        pc.position(new Point(2, 2));
+        system.execute();
+        assertFalse("Nothing should have changed", pc.position().equals(point));
+    }
+}


### PR DESCRIPTION
fixes #959

- Fügt ein konstante `PositionComponent#ILLEGAL_POSITION` ein, welche gesetzt wird, wenn kein level geladen ist
- Fügt das `PositionSystem` ein, welches auf Entitäten mit den `PositionComponent` agiert und deren Illegal-Position auf eine zufällige accessible-position ändert (wenn das level geladen ist).
- Fügt eine gescheite `Point#equals(Point other)` ein
- Tests 