### PR TITLE
[Game] core.level.utils.LevelUtils#tilesInRange findet Kacheln mehrfach

### DIFF
--- a/game/src/core/level/utils/Coordinate.java
+++ b/game/src/core/level/utils/Coordinate.java
@@ -53,7 +53,14 @@ public class Coordinate {
         return new Point(x, y);
     }
 
-    public Coordinate add(Coordinate offset) {
-        return new Coordinate(this.x + offset.x, this.y + offset.y);
+
+    /**
+     * Creates a new Coordinate which has the sum of the Coordinates
+     *
+     * @param other which Coordinate to add
+     * @return Coordinate where the values for x and y are added
+     */
+    public Coordinate add(Coordinate other) {
+        return new Coordinate(this.x + other.x, this.y + other.y);
     }
 }

--- a/game/src/core/level/utils/Coordinate.java
+++ b/game/src/core/level/utils/Coordinate.java
@@ -52,4 +52,8 @@ public class Coordinate {
     public Point toPoint() {
         return new Point(x, y);
     }
+
+    public Coordinate add(Coordinate offset) {
+        return new Coordinate(this.x + offset.x, this.y + offset.y);
+    }
 }

--- a/game/src/core/level/utils/Coordinate.java
+++ b/game/src/core/level/utils/Coordinate.java
@@ -53,7 +53,6 @@ public class Coordinate {
         return new Point(x, y);
     }
 
-
     /**
      * Creates a new Coordinate which has the sum of the Coordinates
      *

--- a/game/src/core/level/utils/LevelUtils.java
+++ b/game/src/core/level/utils/LevelUtils.java
@@ -164,7 +164,8 @@ public class LevelUtils {
 
         Set<Tile> tiles = new HashSet<>();
         Queue<Tile> tileque = new ArrayDeque<>();
-        tileque.add(Game.tileAT(center));
+        Tile start = Game.tileAT(center);
+        if (start != null) tileque.add(start);
         while (tileque.size() > 0) {
             Tile current = tileque.remove();
             boolean added = tiles.add(current);

--- a/game/src/core/level/utils/LevelUtils.java
+++ b/game/src/core/level/utils/LevelUtils.java
@@ -150,6 +150,7 @@ public class LevelUtils {
      * @return List of tiles in the given radius around the center point.
      */
     public static List<Tile> tilesInRange(final Point center, final float radius) {
+        // offset of neighbour Tiles which may not be accessible
         Coordinate[] offsets =
                 new Coordinate[] {
                     new Coordinate(-1, -1),
@@ -161,8 +162,9 @@ public class LevelUtils {
                     new Coordinate(0, 1),
                     new Coordinate(1, 1),
                 };
-
+        // all found tiles
         Set<Tile> tiles = new HashSet<>();
+        // BFS queue
         Queue<Tile> tileque = new ArrayDeque<>();
         Tile start = Game.tileAT(center);
         if (start != null) tileque.add(start);
@@ -182,7 +184,7 @@ public class LevelUtils {
     }
 
     private static boolean isInRange(Point center, float radius, Tile tile) {
-        return isAnyCornerInRadius(center, radius, tile)
+        return isAnyCornerOfTileInRadius(center, radius, tile)
                 || isPointBarelyInTile(center, radius, tile);
     }
 
@@ -216,7 +218,7 @@ public class LevelUtils {
                 && point.y < (tile.coordinate().toPoint().y + 1);
     }
 
-    private static boolean isAnyCornerInRadius(Point center, float radius, Tile x) {
+    private static boolean isAnyCornerOfTileInRadius(Point center, float radius, Tile x) {
         return Point.inRange(center, x.coordinate().toPoint(), radius)
                 || Point.inRange(center, x.coordinate().toPoint(), radius)
                 || Point.inRange(center, x.coordinate().toPoint(), radius)

--- a/game/src/core/level/utils/LevelUtils.java
+++ b/game/src/core/level/utils/LevelUtils.java
@@ -151,9 +151,9 @@ public class LevelUtils {
      */
     public static List<Tile> tilesInRange(final Point center, final float radius) {
         List<Tile> tiles = new ArrayList<>();
-        for (float x = center.x - radius; x <= center.x + radius; x++) {
-            for (float y = center.y - radius; y <= center.y + radius; y++) {
-                tiles.add(Game.tileAT(new Point(x, y)));
+        for (int x = (int) (center.x - radius); x <= center.x + radius; x++) {
+            for (int y = (int) (center.y - radius); y <= center.y + radius; y++) {
+                tiles.add(Game.tileAT(new Coordinate(x, y)));
             }
         }
         tiles.removeIf(Objects::isNull);

--- a/game/src/core/level/utils/LevelUtils.java
+++ b/game/src/core/level/utils/LevelUtils.java
@@ -150,14 +150,76 @@ public class LevelUtils {
      * @return List of tiles in the given radius around the center point.
      */
     public static List<Tile> tilesInRange(final Point center, final float radius) {
-        List<Tile> tiles = new ArrayList<>();
-        for (int x = (int) (center.x - radius); x <= center.x + radius; x++) {
-            for (int y = (int) (center.y - radius); y <= center.y + radius; y++) {
-                tiles.add(Game.tileAT(new Coordinate(x, y)));
+        Coordinate[] offsets =
+                new Coordinate[] {
+                    new Coordinate(-1, -1),
+                    new Coordinate(0, -1),
+                    new Coordinate(1, -1),
+                    new Coordinate(-1, 0),
+                    new Coordinate(1, 0),
+                    new Coordinate(-1, 1),
+                    new Coordinate(0, 1),
+                    new Coordinate(1, 1),
+                };
+
+        Set<Tile> tiles = new HashSet<>();
+        Queue<Tile> tileque = new ArrayDeque<>();
+        tileque.add(Game.tileAT(center));
+        while (tileque.size() > 0) {
+            Tile current = tileque.remove();
+            boolean added = tiles.add(current);
+            if (added) {
+                // Tile is a new Tile so add the neighbours to be checked
+                for (Coordinate offset : offsets) {
+                    Tile tile = current.level().tileAt(current.coordinate().add(offset));
+                    if (tile != null && isInRange(center, radius, tile)) tileque.add(tile);
+                }
             }
         }
         tiles.removeIf(Objects::isNull);
-        return tiles;
+        return new ArrayList<>(tiles);
+    }
+
+    private static boolean isInRange(Point center, float radius, Tile tile) {
+        return isAnyCornerInRadius(center, radius, tile)
+                || isPointBarelyInTile(center, radius, tile);
+    }
+
+    /**
+     * if the radius is barely entering any side it may not touch any of the corners
+     *
+     * @param center
+     * @param radius
+     * @param tile
+     * @return
+     */
+    private static boolean isPointBarelyInTile(Point center, float radius, Tile tile) {
+        // left maxdistance
+        Point xMin = new Point(-radius, 0).add(center);
+        // right maxdistance
+        Point xMax = new Point(radius, 0).add(center);
+        // up maxdistance
+        Point yMin = new Point(0, -radius).add(center);
+        // down maxdistance
+        Point yMax = new Point(0, radius).add(center);
+        return isPointInTile(xMin, tile)
+                || isPointInTile(xMax, tile)
+                || isPointInTile(yMin, tile)
+                || isPointInTile(yMax, tile);
+    }
+
+    private static boolean isPointInTile(Point point, Tile tile) {
+        return tile.coordinate().toPoint().x < point.x
+                && point.x < (tile.coordinate().toPoint().x + 1)
+                && tile.coordinate().toPoint().y < point.y
+                && point.y < (tile.coordinate().toPoint().y + 1);
+    }
+
+    private static boolean isAnyCornerInRadius(Point center, float radius, Tile x) {
+        return Point.inRange(center, x.coordinate().toPoint(), radius)
+                || Point.inRange(center, x.coordinate().toPoint(), radius)
+                || Point.inRange(center, x.coordinate().toPoint(), radius)
+                || Point.inRange(center, x.coordinate().toPoint(), radius);
     }
 
     /**

--- a/game/src/core/utils/Point.java
+++ b/game/src/core/utils/Point.java
@@ -84,6 +84,16 @@ public class Point {
     }
 
     /**
+     * Creates a new Point which has the sum of the Points
+     *
+     * @param other which point to add
+     * @return Point where the values for x and y are added
+     */
+    public Point add(Point other) {
+        return new Point(this.x + other.x, this.y + other.y);
+    }
+
+    /**
      * Two points are equal, if they have the same x and y values.
      *
      * @param other Point to compare with

--- a/game/test/core/level/utils/LevelUtilsTest.java
+++ b/game/test/core/level/utils/LevelUtilsTest.java
@@ -80,6 +80,12 @@ public class LevelUtilsTest {
     }
 
     @Test
+    public void tilesInRangeCenterNotInLevel() {
+        var tiles = LevelUtils.tilesInRange(new Point(-10, -10), 1.1f);
+        assertEquals("should have 3", 0, tiles.size());
+    }
+
+    @Test
     public void tilesInRangeOnlyCorners() {
         var tiles = LevelUtils.tilesInRange(new Point(0, 0), 1.1f);
         assertEquals("should have 3", 3, tiles.size());

--- a/game/test/core/level/utils/LevelUtilsTest.java
+++ b/game/test/core/level/utils/LevelUtilsTest.java
@@ -1,0 +1,117 @@
+package core.level.utils;
+
+import static org.junit.Assert.*;
+
+import core.Game;
+import core.level.TileLevel;
+import core.level.generator.IGenerator;
+import core.systems.LevelSystem;
+import core.utils.IVoidFunction;
+import core.utils.Point;
+import core.utils.components.draw.Painter;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class LevelUtilsTest {
+
+    // default layout is:
+    //
+    // W W W W W
+    // W F F F W
+    // W F E F W
+    // W F F F W
+    // W W W W W
+    @Before
+    public void setup() {
+        Game.add(
+                new LevelSystem(
+                        Mockito.mock(Painter.class),
+                        Mockito.mock(IGenerator.class),
+                        Mockito.mock(IVoidFunction.class)));
+
+        Game.currentLevel(
+                new TileLevel(
+                        new LevelElement[][] {
+                            new LevelElement[] {
+                                LevelElement.WALL,
+                                LevelElement.WALL,
+                                LevelElement.WALL,
+                                LevelElement.WALL,
+                                LevelElement.WALL,
+                            },
+                            new LevelElement[] {
+                                LevelElement.WALL,
+                                LevelElement.FLOOR,
+                                LevelElement.FLOOR,
+                                LevelElement.FLOOR,
+                                LevelElement.WALL,
+                            },
+                            new LevelElement[] {
+                                LevelElement.WALL,
+                                LevelElement.FLOOR,
+                                LevelElement.EXIT,
+                                LevelElement.FLOOR,
+                                LevelElement.WALL,
+                            },
+                            new LevelElement[] {
+                                LevelElement.WALL,
+                                LevelElement.FLOOR,
+                                LevelElement.FLOOR,
+                                LevelElement.FLOOR,
+                                LevelElement.WALL,
+                            },
+                            new LevelElement[] {
+                                LevelElement.WALL,
+                                LevelElement.WALL,
+                                LevelElement.WALL,
+                                LevelElement.WALL,
+                                LevelElement.WALL,
+                            }
+                        },
+                        DesignLabel.randomDesign()));
+    }
+
+    @After
+    public void cleanup() {
+        Game.removeAllSystems();
+    }
+
+    @Test
+    public void tilesInRangeOnlyCorners() {
+        var tiles = LevelUtils.tilesInRange(new Point(0, 0), 1.1f);
+        assertEquals("should have 3", 3, tiles.size());
+        assertTrue(
+                "should contain tile at 0,0 which is the requestPosition",
+                tiles.stream()
+                        .anyMatch(tile -> tile.coordinate().x == 0 && tile.coordinate().y == 0));
+        assertTrue(
+                "should contain tile at 1,0 which is in range",
+                tiles.stream()
+                        .anyMatch(tile -> tile.coordinate().x == 1 && tile.coordinate().y == 0));
+        assertTrue(
+                "should contain tile at 0,1 which is in range",
+                tiles.stream()
+                        .anyMatch(tile -> tile.coordinate().x == 0 && tile.coordinate().y == 1));
+    }
+
+    @Test
+    public void tilesInRangeNotInCorner() {
+        var tiles = LevelUtils.tilesInRange(new Point(0.5f, 0.5f), 0.6f);
+        assertEquals("should have 3", 3, tiles.size());
+        assertTrue(
+                "should contain tile at 0,0 which is the requestPosition",
+                tiles.stream()
+                        .anyMatch(tile -> tile.coordinate().x == 0 && tile.coordinate().y == 0));
+        assertTrue(
+                "should contain tile at 1,0 which is in range",
+                tiles.stream()
+                        .anyMatch(tile -> tile.coordinate().x == 1 && tile.coordinate().y == 0));
+        assertTrue(
+                "should contain tile at 0,1 which is in range",
+                tiles.stream()
+                        .anyMatch(tile -> tile.coordinate().x == 0 && tile.coordinate().y == 1));
+    }
+}

--- a/game/test/core/level/utils/LevelUtilsTest.java
+++ b/game/test/core/level/utils/LevelUtilsTest.java
@@ -82,7 +82,7 @@ public class LevelUtilsTest {
     @Test
     public void tilesInRangeCenterNotInLevel() {
         var tiles = LevelUtils.tilesInRange(new Point(-10, -10), 1.1f);
-        assertEquals("should have 3", 0, tiles.size());
+        assertEquals("tile is outside of the level no Tile should be returned", 0, tiles.size());
     }
 
     @Test


### PR DESCRIPTION
fixes #572 

Umbau von schleife, wo nur direkt auf die untere linke ecke als Kachel Erkennung genutzt wird, so das alle ecken benutzt werden und falls der Radius gerade so in der Kachel endet, ohne eine Ecke zu berühren. (Bild folgt für Darstellung mit allen Fällen)