### PR TITLE
[GAME] fix DrawComponent for Windows

### DIFF
--- a/game/src/core/components/DrawComponent.java
+++ b/game/src/core/components/DrawComponent.java
@@ -288,6 +288,8 @@ public final class DrawComponent implements Component {
     }
 
     private void loadAnimationsFromIDE(String path) {
+        String newPath = File.separator + path;
+        path = path.replace("\\", "/");
         URL url = DrawComponent.class.getResource(File.separator + path);
         if (url != null) {
             try {

--- a/game/src/core/components/DrawComponent.java
+++ b/game/src/core/components/DrawComponent.java
@@ -74,9 +74,12 @@ public final class DrawComponent implements Component {
      * @see Animation
      */
     public DrawComponent(final String path) throws IOException {
+        // for windows
+        String betterPath = path.replace("\\", "/");
+
         // fetch available animations
         try {
-            loadAnimationsFromDirectory(path);
+            loadAnimationsFromDirectory(betterPath);
             currentAnimation(
                     CoreAnimations.IDLE_DOWN,
                     CoreAnimations.IDLE_LEFT,

--- a/game/src/core/components/DrawComponent.java
+++ b/game/src/core/components/DrawComponent.java
@@ -74,12 +74,9 @@ public final class DrawComponent implements Component {
      * @see Animation
      */
     public DrawComponent(final String path) throws IOException {
-        // for windows
-        String betterPath = path.replace("\\", "/");
-
         // fetch available animations
         try {
-            loadAnimationsFromDirectory(betterPath);
+            loadAnimationsFromDirectory(path);
             currentAnimation(
                     CoreAnimations.IDLE_DOWN,
                     CoreAnimations.IDLE_LEFT,
@@ -244,11 +241,11 @@ public final class DrawComponent implements Component {
             // If the entry starts with the path name (character/knight/idle),
             // this is true for entries like (character/knight/idle/idle_knight_1.png) and
             // (character/knight/idle/).
-            if (fileName.startsWith(path + File.separator)) {
+            if (fileName.startsWith(path + "/")) {
 
                 // Get the index of the last FileSeparator; every character after that separator is
                 // part of the filename.
-                int lastSlashIndex = fileName.lastIndexOf(File.separator);
+                int lastSlashIndex = fileName.lastIndexOf("/");
 
                 // Ignore directories, so we only work with strings like
                 // (character/knight/idle/idle_knight_1.png).
@@ -257,8 +254,7 @@ public final class DrawComponent implements Component {
                     // For example, in "character/knight/idle/idle_knight_1.png", this would be the
                     // index of the slash in "/idle".
 
-                    int secondLastSlashIndex =
-                            fileName.lastIndexOf(File.separator, lastSlashIndex - 1);
+                    int secondLastSlashIndex = fileName.lastIndexOf("/", lastSlashIndex - 1);
 
                     // Get the name of the directory. The directory name is between the
                     // second-to-last and the last separator index.
@@ -288,9 +284,7 @@ public final class DrawComponent implements Component {
     }
 
     private void loadAnimationsFromIDE(String path) {
-        String newPath = File.separator + path;
-        path = path.replace("\\", "/");
-        URL url = DrawComponent.class.getResource(File.separator + path);
+        URL url = DrawComponent.class.getResource("/" + path);
         if (url != null) {
             try {
                 File apps = new File(url.toURI());

--- a/game/test/core/components/DrawComponentTest.java
+++ b/game/test/core/components/DrawComponentTest.java
@@ -65,4 +65,6 @@ public class DrawComponentTest {
         assertTrue(animationComponent.hasAnimation(CoreAnimations.RUN_LEFT));
         assertFalse(animationComponent.hasAnimation(() -> "DUMMY"));
     }
+
+    // Test to trigger Matrix
 }

--- a/game/test/core/components/DrawComponentTest.java
+++ b/game/test/core/components/DrawComponentTest.java
@@ -65,6 +65,4 @@ public class DrawComponentTest {
         assertTrue(animationComponent.hasAnimation(CoreAnimations.RUN_LEFT));
         assertFalse(animationComponent.hasAnimation(() -> "DUMMY"));
     }
-
-    // Test to trigger Matrix
 }


### PR DESCRIPTION
Unter Windows können die assets nicht geladen werden (seit der Änderung #953)

Dieser PR behebt dieses verhalten, scheinbar muss intern vollständig mit `/` als Fileseprator gearbeitet werden.

Danke @Lena241 für die schnelle Unterstützung. Bitte nochmal testen

Frage: Wie konnte das in den master gelangen? Vermutlich spielen da mehrere PRs eine Rolle, welche alleine zwar Lauffähig waren aber kombiniert nicht. Vielleicht müssen wir in GitHub einen rebase Forcen. 

Edit: Vermutlich ist es durch gekommen, weil die Tests nicht verändert wurden und somit nur Junit auf Linux lief