### PR TITLE
[GAME] fix Crafting in jar vor mac/unix

### DIFF
--- a/game/src/contrib/crafting/Crafting.java
+++ b/game/src/contrib/crafting/Crafting.java
@@ -105,7 +105,10 @@ public class Crafting {
             String path =
                     new File(Main.class.getResource("").getPath())
                             .getParent()
-                            .replaceAll("(!|file:\\\\)", "");
+                            // for windows
+                            .replaceAll("(!|file:\\\\)", "")
+                            // for unix/macos
+                            .replaceAll("(!|file:)", "");
             JarFile jar = new JarFile(path);
             Enumeration<JarEntry> entries = jar.entries();
             while (entries.hasMoreElements()) {


### PR DESCRIPTION
fixes #967 

Unter Windows war der kram eh schon in einer jar lauffähig (scheinbar war der in #967 befürchtete Fehler nicht aufgetreten)
Under Mac (und ich denke auch Unix) war das Crafting nicht in der Jar lauffähig, da dass Pfad-Replacement per Regex nur den windows typischen Pfad ersetzt hat.
Ich habe das nun angepasst