### PR TITLE
[GAME] add feature to open and close door-tiles

### DIFF
--- a/game/src/core/level/elements/tile/DoorTile.java
+++ b/game/src/core/level/elements/tile/DoorTile.java
@@ -20,8 +20,12 @@ public class DoorTile extends Tile {
     private DoorTile otherDoor;
     private Tile doorstep;
 
+    private boolean open;
+
     /**
      * Creates a new Tile.
+     *
+     * <p>The door will be open.
      *
      * @param texturePath Path to the texture of the tile.
      * @param globalPosition Position of the tile in the global system.
@@ -32,6 +36,7 @@ public class DoorTile extends Tile {
             String texturePath, Coordinate globalPosition, DesignLabel designLabel, ILevel level) {
         super(texturePath, globalPosition, designLabel, level);
         levelElement = LevelElement.DOOR;
+        open = true;
     }
 
     @Override
@@ -101,5 +106,32 @@ public class DoorTile extends Tile {
             }
             texturePath = textureBuilder.toString();
         } // TODO else { error }
+    }
+
+    /**
+     * Open the door.
+     *
+     * <p>The player can use the door to enter the next room.
+     */
+    public void open() {
+        open = true;
+    }
+
+    /**
+     * Close the door.
+     *
+     * <p>The player cant use the door to enter the next room.
+     */
+    public void close() {
+        open = false;
+    }
+
+    /**
+     * Check if the door is open.
+     *
+     * @return true if the door is open, false if not.
+     */
+    public boolean isOpen() {
+        return open;
     }
 }

--- a/game/src/core/systems/LevelSystem.java
+++ b/game/src/core/systems/LevelSystem.java
@@ -225,7 +225,7 @@ public final class LevelSystem extends System {
                                         MissingComponentException.build(
                                                 entity, PositionComponent.class));
         for (DoorTile door : currentLevel.doorTiles()) {
-            if (door.equals(Game.tileAT(pc.position()))) {
+            if (door.isOpen() && door.equals(Game.tileAT(pc.position()))) {
                 door.onEntering(entity);
                 nextLevel = door.getOtherDoor().level();
             }


### PR DESCRIPTION
fixes #975 

- fügt den `DoorTile` einen boolean `open` und entsprechende getter/setter hinzu.
- Das `LevelSystem` prüft ob die Tür offen ist. bevor der Spieler durch sie hindurch gehen kann.

- Es fehlen noch entsprechenden Grafiken (eigenes Issue)