### PR TITLE
[DSL] Variablendeklaration implementieren

### DIFF
--- a/dsl/src/antlr/DungeonDSL.g4
+++ b/dsl/src/antlr/DungeonDSL.g4
@@ -45,13 +45,7 @@ fragment STRING_ESCAPE_SEQ
 /*
  * Parser rules
  */
-
-// TODO:
-// - expression grammar
-// - proper stmt =efinition
-
 program : definition* EOF
-        //| stmt
         ;
 
 definition
@@ -93,7 +87,6 @@ assignee
     ;
 
 logic_or
-
     : logic_or ( or='or' logic_and )
     | logic_and
     ;

--- a/dsl/src/antlr/DungeonDSL.g4
+++ b/dsl/src/antlr/DungeonDSL.g4
@@ -61,9 +61,15 @@ fn_def
 
 stmt
     : expression ';'
+    | var_decl
     | stmt_block
     | conditional_stmt
     | return_stmt
+    ;
+
+var_decl
+    : 'var' id=ID '=' expression ';'   #var_decl_assignment
+    | 'var' id=ID ':' type_decl ';'    #var_decl_type_decl
     ;
 
 expression

--- a/dsl/src/interpreter/DSLInterpreter.java
+++ b/dsl/src/interpreter/DSLInterpreter.java
@@ -120,7 +120,12 @@ public class DSLInterpreter implements AstVisitor<Object> {
             var propertyName = propertyDefNode.getIdName();
             Symbol propertySymbol = prototypesType.resolve(propertyName);
             if (propertySymbol.equals(Symbol.NULL)) {
-                throw new RuntimeException("Property of name '" + propertyName + "' cannot be resolved in type '" + prototypesType.getName() + "'");
+                throw new RuntimeException(
+                        "Property of name '"
+                                + propertyName
+                                + "' cannot be resolved in type '"
+                                + prototypesType.getName()
+                                + "'");
             }
             var propertiesType = propertySymbol.getDataType();
 
@@ -616,7 +621,7 @@ public class DSLInterpreter implements AstVisitor<Object> {
 
     @Override
     public Object visit(VarDeclNode node) {
-        String variableName = ((IdNode)node.getIdentifier()).getName();
+        String variableName = ((IdNode) node.getIdentifier()).getName();
 
         // check, if the current memory space already contains a value of the same name
         Value value = getCurrentMemorySpace().resolve(variableName, false);
@@ -627,7 +632,8 @@ public class DSLInterpreter implements AstVisitor<Object> {
 
         // create new Value in memory space (overwrite existing one)
         if (node.getDeclType().equals(VarDeclNode.DeclType.assignmentDecl)) {
-            throw new UnsupportedOperationException("Assignment declaration currently not supported");
+            throw new UnsupportedOperationException(
+                    "Assignment declaration currently not supported");
         } else {
             // get datatype
             Symbol variableSymbol = symbolTable().getSymbolsForAstNode(node).get(0);

--- a/dsl/src/interpreter/DSLInterpreter.java
+++ b/dsl/src/interpreter/DSLInterpreter.java
@@ -615,6 +615,28 @@ public class DSLInterpreter implements AstVisitor<Object> {
     }
 
     @Override
+    public Object visit(VarDeclNode node) {
+        String variableName = ((IdNode)node.getIdentifier()).getName();
+
+        // check, if the current memory space already contains a value of the same name
+        Value value = getCurrentMemorySpace().resolve(variableName, false);
+        if (!value.equals(Value.NONE)) {
+            getCurrentMemorySpace().delete(variableName);
+            value = Value.NONE;
+        }
+
+        // create new Value in memory space (overwrite existing one)
+        if (node.getDeclType().equals(VarDeclNode.DeclType.assignmentDecl)) {
+            throw new UnsupportedOperationException("Assignment declaration currently not supported");
+        } else {
+            // get datatype
+            Symbol variableSymbol = symbolTable().getSymbolsForAstNode(node).get(0);
+            value = bindFromSymbol(variableSymbol, this.getCurrentMemorySpace());
+        }
+        return value;
+    }
+
+    @Override
     public Object visit(LogicOrNode node) {
         // TODO: implement
         throw new UnsupportedOperationException();

--- a/dsl/src/interpreter/DSLInterpreter.java
+++ b/dsl/src/interpreter/DSLInterpreter.java
@@ -117,8 +117,12 @@ public class DSLInterpreter implements AstVisitor<Object> {
             var rhsValue = (Value) propertyDefNode.getStmtNode().accept(this);
 
             // get type of lhs (the assignee)
-            var propName = propertyDefNode.getIdName();
-            var propertiesType = prototypesType.resolve(propName).getDataType();
+            var propertyName = propertyDefNode.getIdName();
+            Symbol propertySymbol = prototypesType.resolve(propertyName);
+            if (propertySymbol.equals(Symbol.NULL)) {
+                throw new RuntimeException("Property of name '" + propertyName + "' cannot be resolved in type '" + prototypesType.getName() + "'");
+            }
+            var propertiesType = propertySymbol.getDataType();
 
             // clone value
             Value value = (Value) rhsValue.clone();

--- a/dsl/src/parser/DungeonASTConverter.java
+++ b/dsl/src/parser/DungeonASTConverter.java
@@ -136,7 +136,12 @@ public class DungeonASTConverter implements antlr.main.DungeonDSLListener {
 
     @Override
     public void exitVar_decl_assignment(DungeonDSLParser.Var_decl_assignmentContext ctx) {
-        throw new UnsupportedOperationException();
+        Node expression = astStack.pop();
+        Node identifier = astStack.pop();
+        assert identifier.type == Node.Type.Identifier;
+
+        Node varDeclNode = new VarDeclNode(VarDeclNode.DeclType.assignmentDecl, identifier, expression);
+        astStack.push(varDeclNode);
     }
 
     @Override
@@ -146,7 +151,12 @@ public class DungeonASTConverter implements antlr.main.DungeonDSLListener {
 
     @Override
     public void exitVar_decl_type_decl(DungeonDSLParser.Var_decl_type_declContext ctx) {
-        throw new UnsupportedOperationException();
+        Node typeDecl = astStack.pop();
+        Node identifier = astStack.pop();
+        assert identifier.type == Node.Type.Identifier;
+
+        Node varDeclNode = new VarDeclNode(VarDeclNode.DeclType.typeDecl, identifier, typeDecl);
+        astStack.push(varDeclNode);
     }
 
     @Override

--- a/dsl/src/parser/DungeonASTConverter.java
+++ b/dsl/src/parser/DungeonASTConverter.java
@@ -130,6 +130,26 @@ public class DungeonASTConverter implements antlr.main.DungeonDSLListener {
     }
 
     @Override
+    public void enterVar_decl_assignment(DungeonDSLParser.Var_decl_assignmentContext ctx) {
+
+    }
+
+    @Override
+    public void exitVar_decl_assignment(DungeonDSLParser.Var_decl_assignmentContext ctx) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void enterVar_decl_type_decl(DungeonDSLParser.Var_decl_type_declContext ctx) {
+
+    }
+
+    @Override
+    public void exitVar_decl_type_decl(DungeonDSLParser.Var_decl_type_declContext ctx) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public void enterExpression(DungeonDSLParser.ExpressionContext ctx) {}
 
     @Override

--- a/dsl/src/parser/DungeonASTConverter.java
+++ b/dsl/src/parser/DungeonASTConverter.java
@@ -130,9 +130,7 @@ public class DungeonASTConverter implements antlr.main.DungeonDSLListener {
     }
 
     @Override
-    public void enterVar_decl_assignment(DungeonDSLParser.Var_decl_assignmentContext ctx) {
-
-    }
+    public void enterVar_decl_assignment(DungeonDSLParser.Var_decl_assignmentContext ctx) {}
 
     @Override
     public void exitVar_decl_assignment(DungeonDSLParser.Var_decl_assignmentContext ctx) {
@@ -140,14 +138,13 @@ public class DungeonASTConverter implements antlr.main.DungeonDSLListener {
         Node identifier = astStack.pop();
         assert identifier.type == Node.Type.Identifier;
 
-        Node varDeclNode = new VarDeclNode(VarDeclNode.DeclType.assignmentDecl, identifier, expression);
+        Node varDeclNode =
+                new VarDeclNode(VarDeclNode.DeclType.assignmentDecl, identifier, expression);
         astStack.push(varDeclNode);
     }
 
     @Override
-    public void enterVar_decl_type_decl(DungeonDSLParser.Var_decl_type_declContext ctx) {
-
-    }
+    public void enterVar_decl_type_decl(DungeonDSLParser.Var_decl_type_declContext ctx) {}
 
     @Override
     public void exitVar_decl_type_decl(DungeonDSLParser.Var_decl_type_declContext ctx) {

--- a/dsl/src/parser/ast/AstVisitor.java
+++ b/dsl/src/parser/ast/AstVisitor.java
@@ -356,6 +356,16 @@ public interface AstVisitor<T> {
     }
 
     /**
+     * Visitor method for VarDeclNodes
+     *
+     * @param node Node to visit
+     * @return T
+     */
+    default T visit(VarDeclNode node) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
      * Visit all children of the passed node
      *
      * @param node The node to visit all children of

--- a/dsl/src/parser/ast/Node.java
+++ b/dsl/src/parser/ast/Node.java
@@ -52,6 +52,7 @@ public class Node {
         Bool,
         ConditionalStmtIfElse,
         ReturnMark,
+        ScopeExitMark,
         Assignment,
         LogicOr,
         LogicAnd,

--- a/dsl/src/parser/ast/Node.java
+++ b/dsl/src/parser/ast/Node.java
@@ -65,7 +65,8 @@ public class Node {
         ListDefinitionNode,
         SetDefinitionNode,
         ListTypeIdentifierNode,
-        SetTypeIdentifierNode
+        SetTypeIdentifierNode,
+        VarDeclNode
     }
 
     public static Node NONE = new Node(Type.NONE, new ArrayList<>());

--- a/dsl/src/parser/ast/VarDeclNode.java
+++ b/dsl/src/parser/ast/VarDeclNode.java
@@ -1,0 +1,8 @@
+package parser.ast;
+
+public class VarDeclNode extends BinaryNode {
+
+    public VarDeclNode(Node identifier, Node rhs) {
+        super (Type.VarDeclNode, identifier, rhs);
+    }
+}

--- a/dsl/src/parser/ast/VarDeclNode.java
+++ b/dsl/src/parser/ast/VarDeclNode.java
@@ -1,8 +1,28 @@
 package parser.ast;
 
 public class VarDeclNode extends BinaryNode {
+    public enum DeclType {
+        assignmentDecl,
+        typeDecl
+    }
 
-    public VarDeclNode(Node identifier, Node rhs) {
-        super (Type.VarDeclNode, identifier, rhs);
+    private final VarDeclNode.DeclType declType;
+
+    public Node getIdentifier() {
+        return this.getLhs();
+    }
+
+    public VarDeclNode.DeclType getDeclType() {
+        return declType;
+    }
+
+    public VarDeclNode(VarDeclNode.DeclType type, Node identifier, Node rhs) {
+        super(Type.VarDeclNode, identifier, rhs);
+        this.declType = type;
+    }
+
+    @Override
+    public <T> T accept(AstVisitor<T> visitor) {
+        return visitor.visit(this);
     }
 }

--- a/dsl/src/runtime/EncapsulatedObject.java
+++ b/dsl/src/runtime/EncapsulatedObject.java
@@ -149,7 +149,8 @@ public class EncapsulatedObject extends Value implements IMemorySpace {
 
     @Override
     public void delete(String name) {
-        throw new UnsupportedOperationException("Deleting a value from an Encapsulated Object is not supported!");
+        throw new UnsupportedOperationException(
+                "Deleting a value from an Encapsulated Object is not supported!");
     }
 
     // TODO: define the semantics for this based on, if the value is a POD type or

--- a/dsl/src/runtime/EncapsulatedObject.java
+++ b/dsl/src/runtime/EncapsulatedObject.java
@@ -147,6 +147,11 @@ public class EncapsulatedObject extends Value implements IMemorySpace {
         return resolve(name);
     }
 
+    @Override
+    public void delete(String name) {
+        throw new UnsupportedOperationException("Deleting a value from an Encapsulated Object is not supported!");
+    }
+
     // TODO: define the semantics for this based on, if the value is a POD type or
     //  a complex type -> what happens, if we want to set a component of an
     //  entity or a complex datatype of a component (e.g. Point)?!

--- a/dsl/src/runtime/FunctionValue.java
+++ b/dsl/src/runtime/FunctionValue.java
@@ -22,7 +22,7 @@ public class FunctionValue extends Value {
      * @param callable the callable represented by this value
      */
     public FunctionValue(IType functionReturnValue, ICallable callable) {
-        super(functionReturnValue, null);
+        super(functionReturnValue, callable);
         this.callable = callable;
     }
 

--- a/dsl/src/runtime/IMemorySpace.java
+++ b/dsl/src/runtime/IMemorySpace.java
@@ -31,6 +31,13 @@ public interface IMemorySpace {
     Value resolve(String name, boolean resolveInParent);
 
     /**
+     * Delete a {@link Value} of given name from this IMemorySpace
+     *
+     * @param name the name of the value to delete
+     */
+    void delete(String name);
+
+    /**
      * Set the value specified by the name
      *
      * @param name name of the value to set

--- a/dsl/src/runtime/MemorySpace.java
+++ b/dsl/src/runtime/MemorySpace.java
@@ -78,6 +78,11 @@ public class MemorySpace implements IMemorySpace {
     }
 
     @Override
+    public void delete(String name) {
+        this.values.remove(name);
+    }
+
+    @Override
     public boolean setValue(String name, Value value) {
         var resolved = resolve(name, false);
         if (resolved.equals(Value.NONE)) {

--- a/dsl/src/semanticanalysis/SemanticAnalyzer.java
+++ b/dsl/src/semanticanalysis/SemanticAnalyzer.java
@@ -387,13 +387,46 @@ public class SemanticAnalyzer implements AstVisitor<Void> {
 
     @Override
     public Void visit(ConditionalStmtNodeIf node) {
-        visitChildren(node);
+        node.getCondition().accept(this);
+
+        // if the statement is not a block (i.e. there is only one statement in the if-statements body),
+        // we need to create a new scope here (because it won't be created in a block-statement)
+        if (!node.getIfStmt().type.equals(Node.Type.Block)) {
+            var scope = new Scope(scopeStack.peek());
+            scopeStack.push(scope);
+            node.getIfStmt().accept(this);
+            scopeStack.pop();
+        } else {
+            node.getIfStmt().accept(this);
+        }
+
         return null;
     }
 
     @Override
     public Void visit(ConditionalStmtNodeIfElse node) {
-        visitChildren(node);
+        node.getCondition().accept(this);
+
+        // if the statements are not blocks (i.e. there is only one statement in the if-statements body),
+        // we need to create new scopes here (because it won't be created in block-statements)
+        if (!node.getIfStmt().type.equals(Node.Type.Block)) {
+            var ifScope = new Scope(scopeStack.peek());
+            scopeStack.push(ifScope);
+            node.getIfStmt().accept(this);
+            scopeStack.pop();
+        } else {
+            node.getIfStmt().accept(this);
+        }
+
+        if (!node.getElseStmt().type.equals(Node.Type.Block)) {
+            var elseScope = new Scope(scopeStack.peek());
+            scopeStack.push(elseScope);
+            node.getElseStmt().accept(this);
+            scopeStack.pop();
+        } else {
+            node.getElseStmt().accept(this);
+        }
+
         return null;
     }
 

--- a/dsl/src/semanticanalysis/SemanticAnalyzer.java
+++ b/dsl/src/semanticanalysis/SemanticAnalyzer.java
@@ -389,7 +389,8 @@ public class SemanticAnalyzer implements AstVisitor<Void> {
     public Void visit(ConditionalStmtNodeIf node) {
         node.getCondition().accept(this);
 
-        // if the statement is not a block (i.e. there is only one statement in the if-statements body),
+        // if the statement is not a block (i.e. there is only one statement in the if-statements
+        // body),
         // we need to create a new scope here (because it won't be created in a block-statement)
         if (!node.getIfStmt().type.equals(Node.Type.Block)) {
             var scope = new Scope(scopeStack.peek());
@@ -407,7 +408,8 @@ public class SemanticAnalyzer implements AstVisitor<Void> {
     public Void visit(ConditionalStmtNodeIfElse node) {
         node.getCondition().accept(this);
 
-        // if the statements are not blocks (i.e. there is only one statement in the if-statements body),
+        // if the statements are not blocks (i.e. there is only one statement in the if-statements
+        // body),
         // we need to create new scopes here (because it won't be created in block-statements)
         if (!node.getIfStmt().type.equals(Node.Type.Block)) {
             var ifScope = new Scope(scopeStack.peek());

--- a/dsl/src/semanticanalysis/SemanticAnalyzer.java
+++ b/dsl/src/semanticanalysis/SemanticAnalyzer.java
@@ -356,10 +356,8 @@ public class SemanticAnalyzer implements AstVisitor<Void> {
             FunctionSymbol funcSymbol = (FunctionSymbol) resolved;
             scopeStack.push(funcSymbol);
 
-            // visit all stmts
-            for (var stmt : node.getStmts()) {
-                stmt.accept(this);
-            }
+            // visit statements
+            node.getStmtBlock().accept(this);
 
             // create symbol table entry
             symbolTable.addSymbolNodeRelation(funcSymbol, node, false);

--- a/dsl/src/semanticanalysis/SemanticAnalyzer.java
+++ b/dsl/src/semanticanalysis/SemanticAnalyzer.java
@@ -542,12 +542,12 @@ public class SemanticAnalyzer implements AstVisitor<Void> {
 
     @Override
     public Void visit(VarDeclNode node) {
-        String name = ((IdNode)node.getIdentifier()).getName();
+        String name = ((IdNode) node.getIdentifier()).getName();
 
         // check if a variable is already defined in the current scope
         Symbol resolvedName = this.currentScope().resolve(name, false);
         if (!resolvedName.equals(Symbol.NULL)) {
-            throw new RuntimeException("Redefinition of variable '" + name +"'");
+            throw new RuntimeException("Redefinition of variable '" + name + "'");
         }
 
         // create new symbol for the variable
@@ -557,7 +557,7 @@ public class SemanticAnalyzer implements AstVisitor<Void> {
         }
 
         // resolve the type name
-        IdNode typeDeclNode = (IdNode)node.getRhs();
+        IdNode typeDeclNode = (IdNode) node.getRhs();
         String typeName = typeDeclNode.getName();
         if (!typeDeclNode.type.equals(Node.Type.Identifier)) {
             // list or set type -> create type

--- a/dsl/src/semanticanalysis/VariableBinder.java
+++ b/dsl/src/semanticanalysis/VariableBinder.java
@@ -32,6 +32,7 @@ import semanticanalysis.types.IType;
 // TODO: handle scoped Variables in stmt Blocks correctly, once
 //  variable definitions are implemented
 
+// TODO: rename this to ObjectBinder (only handles global definitions)
 /** Creates symbols for definition nodes (graph, object) and binds these nodes to those symbols */
 public class VariableBinder implements AstVisitor<Void> {
     SymbolTable symbolTable;
@@ -279,6 +280,11 @@ public class VariableBinder implements AstVisitor<Void> {
 
     @Override
     public Void visit(SetDefinitionNode node) {
+        return null;
+    }
+
+    @Override
+    public Void visit(VarDeclNode node) {
         return null;
     }
 

--- a/dsl/test/interpreter/TestDSLInterpreter.java
+++ b/dsl/test/interpreter/TestDSLInterpreter.java
@@ -1936,7 +1936,8 @@ public class TestDSLInterpreter {
 
         componentWithConsumer.executeCallbackWithText("hello");
 
-        // the output stream should only contain the default value for a string variable ("") and the
+        // the output stream should only contain the default value for a string variable ("") and
+        // the
         // line separator from the print-call
         String output = outputStream.toString();
         assertEquals(output, System.lineSeparator());
@@ -1945,7 +1946,7 @@ public class TestDSLInterpreter {
     @Test
     public void testVariableCreationAndAssignment() {
         String program =
-            """
+                """
             entity_type my_type {
                 test_component_with_string_consumer_callback {
                     on_interaction: get_property
@@ -1972,34 +1973,35 @@ public class TestDSLInterpreter {
         DSLInterpreter interpreter = new DSLInterpreter();
         env.getTypeBuilder().createDSLTypeForJavaTypeInScope(env.getGlobalScope(), Entity.class);
         env.getTypeBuilder()
-            .createDSLTypeForJavaTypeInScope(
-                env.getGlobalScope(), TestComponentWithStringConsumerCallback.class);
+                .createDSLTypeForJavaTypeInScope(
+                        env.getGlobalScope(), TestComponentWithStringConsumerCallback.class);
 
         var config =
-            (CustomQuestConfig)
-                Helpers.generateQuestConfigWithCustomTypes(program, env, interpreter);
+                (CustomQuestConfig)
+                        Helpers.generateQuestConfigWithCustomTypes(program, env, interpreter);
 
         var entity = config.entity();
 
         TestComponentWithStringConsumerCallback componentWithConsumer =
-            (TestComponentWithStringConsumerCallback)
-                entity.components.stream()
-                    .filter(c -> c instanceof TestComponentWithStringConsumerCallback)
-                    .toList()
-                    .get(0);
+                (TestComponentWithStringConsumerCallback)
+                        entity.components.stream()
+                                .filter(c -> c instanceof TestComponentWithStringConsumerCallback)
+                                .toList()
+                                .get(0);
 
         componentWithConsumer.executeCallbackWithText("hello");
 
-        // the output stream should only contain the default value for a string variable ("") and the
+        // the output stream should only contain the default value for a string variable ("") and
+        // the
         // line separator from the print-call
         String output = outputStream.toString();
-        assertEquals(output, "Hello, World!"+System.lineSeparator());
+        assertEquals(output, "Hello, World!" + System.lineSeparator());
     }
 
     @Test
     public void testVariableCreationAndAssignmentEntity() {
         String program =
-            """
+                """
             entity_type my_type {
                 test_component2 {
                     member1: "Hello, World!"
@@ -2029,31 +2031,32 @@ public class TestDSLInterpreter {
         DSLInterpreter interpreter = new DSLInterpreter();
         env.getTypeBuilder().createDSLTypeForJavaTypeInScope(env.getGlobalScope(), Entity.class);
         env.getTypeBuilder()
-            .createDSLTypeForJavaTypeInScope(env.getGlobalScope(), TestComponent2.class);
+                .createDSLTypeForJavaTypeInScope(env.getGlobalScope(), TestComponent2.class);
         env.getTypeBuilder()
-            .createDSLTypeForJavaTypeInScope(
-                env.getGlobalScope(), TestComponentEntityConsumerCallback.class);
+                .createDSLTypeForJavaTypeInScope(
+                        env.getGlobalScope(), TestComponentEntityConsumerCallback.class);
         env.getTypeBuilder()
-            .registerProperty(env.getGlobalScope(), Entity.TestComponent2Property.instance);
+                .registerProperty(env.getGlobalScope(), Entity.TestComponent2Property.instance);
 
         var config =
-            (CustomQuestConfig)
-                Helpers.generateQuestConfigWithCustomTypes(program, env, interpreter);
+                (CustomQuestConfig)
+                        Helpers.generateQuestConfigWithCustomTypes(program, env, interpreter);
 
         var entity = config.entity();
 
         TestComponentEntityConsumerCallback componentWithConsumer =
-            (TestComponentEntityConsumerCallback)
-                entity.components.stream()
-                    .filter(c -> c instanceof TestComponentEntityConsumerCallback)
-                    .toList()
-                    .get(0);
+                (TestComponentEntityConsumerCallback)
+                        entity.components.stream()
+                                .filter(c -> c instanceof TestComponentEntityConsumerCallback)
+                                .toList()
+                                .get(0);
 
         componentWithConsumer.consumer.accept(entity);
 
-        // the output stream should only contain the default value for a string variable ("") and the
+        // the output stream should only contain the default value for a string variable ("") and
+        // the
         // line separator from the print-call
         String output = outputStream.toString();
-        assertEquals(output, "Hello, World!"+System.lineSeparator());
+        assertEquals(output, "Hello, World!" + System.lineSeparator());
     }
 }

--- a/dsl/test/interpreter/TestDSLInterpreter.java
+++ b/dsl/test/interpreter/TestDSLInterpreter.java
@@ -1901,6 +1901,7 @@ public class TestDSLInterpreter {
 
                 fn get_property(string param) {
                     var test : string;
+                    print(test);
                 }
 
                 quest_config c {
@@ -1935,9 +1936,9 @@ public class TestDSLInterpreter {
 
         componentWithConsumer.executeCallbackWithText("hello");
 
+        // the output stream should only contain the default value for a string variable ("") and the
+        // line separator from the print-call
         String output = outputStream.toString();
-        Assert.assertTrue(
-                output.equals(
-                        "hello" + System.lineSeparator() + "my text" + System.lineSeparator()));
+        assertEquals(output, System.lineSeparator());
     }
 }

--- a/dsl/test/interpreter/TestDSLInterpreter.java
+++ b/dsl/test/interpreter/TestDSLInterpreter.java
@@ -156,14 +156,14 @@ public class TestDSLInterpreter {
     public void funcCallReturnUserFunc() {
         String program =
                 """
-            fn ret_string() -> string {
-                return "Hello, World!";
-            }
+                    fn ret_string() -> string {
+                        return "Hello, World!";
+                    }
 
-            quest_config c {
-                test: print(ret_string())
-            }
-        """;
+                    quest_config c {
+                        test: print(ret_string())
+                    }
+                """;
 
         // print currently just prints to system.out, so we need to
         // check the contents for the printed string
@@ -182,18 +182,18 @@ public class TestDSLInterpreter {
     public void funcCallReturnUserFuncNestedBlock() {
         String program =
                 """
-            fn ret_string() -> string {
-                {
-                    {
-                        return "Hello, World!";
+                    fn ret_string() -> string {
+                        {
+                            {
+                                return "Hello, World!";
+                            }
+                        }
                     }
-                }
-            }
 
-            quest_config c {
-                test: print(ret_string())
-            }
-        """;
+                    quest_config c {
+                        test: print(ret_string())
+                    }
+                """;
 
         // print currently just prints to system.out, so we need to
         // check the contents for the printed string
@@ -211,18 +211,18 @@ public class TestDSLInterpreter {
     public void funcCallNestedStmtBlock() {
         String program =
                 """
-                fn print_string() {
-                    {
+                    fn print_string() {
                         {
-                            print("Hello, World!");
+                            {
+                                print("Hello, World!");
+                            }
                         }
                     }
-                }
 
-                quest_config c {
-                    test: print_string()
-                }
-            """;
+                    quest_config c {
+                        test: print_string()
+                    }
+                """;
 
         // print currently just prints to system.out, so we need to
         // check the contents for the printed string
@@ -241,14 +241,14 @@ public class TestDSLInterpreter {
     public void funcCallReturnUserFuncWithoutReturnType() {
         String program =
                 """
-                    fn ret_string() {
-                        return "Hello, World!";
-                    }
+                        fn ret_string() {
+                            return "Hello, World!";
+                        }
 
-                quest_config c {
-                    test: print(ret_string())
-                }
-            """;
+                    quest_config c {
+                        test: print(ret_string())
+                    }
+                """;
 
         // print currently just prints to system.out, so we need to
         // check the contents for the printed string
@@ -496,22 +496,22 @@ public class TestDSLInterpreter {
     public void objectEncapsulation() {
         String program =
                 """
-            entity_type my_obj {
-                test_component1 {
-                    member1: 42,
-                    member2: 12.34
-                },
-                test_component2 {
-                    member1: "Hallo",
-                    member2: 123
+                entity_type my_obj {
+                    test_component1 {
+                        member1: 42,
+                        member2: 12.34
+                    },
+                    test_component2 {
+                        member1: "Hallo",
+                        member2: 123
+                    }
                 }
-            }
 
-            quest_config config {
-                entity: instantiate(my_obj),
-                second_entity: instantiate(my_obj)
-            }
-            """;
+                quest_config config {
+                    entity: instantiate(my_obj),
+                    second_entity: instantiate(my_obj)
+                }
+                """;
 
         var env = new TestEnvironment();
         env.getTypeBuilder()
@@ -558,14 +558,14 @@ public class TestDSLInterpreter {
     public void aggregateTypeInstancingNonSupportedExternalType() {
         String program =
                 """
-            entity_type my_obj {
-                component_with_external_type_member { }
-            }
+                entity_type my_obj {
+                    component_with_external_type_member { }
+                }
 
-            quest_config config {
-                entity: instantiate(my_obj)
-            }
-            """;
+                quest_config config {
+                    entity: instantiate(my_obj)
+                }
+                """;
 
         var env = new TestEnvironment();
         env.getTypeBuilder()
@@ -747,14 +747,14 @@ public class TestDSLInterpreter {
     public void testIfStmtFalse() {
         String program =
                 """
-            fn test_func() {
-                if 0 print("Hello, World!");
-            }
+                fn test_func() {
+                    if 0 print("Hello, World!");
+                }
 
-            quest_config c {
-                test: test_func()
-            }
-                """;
+                quest_config c {
+                    test: test_func()
+                }
+                    """;
 
         // print currently just prints to system.out, so we need to
         // check the contents for the printed string
@@ -772,14 +772,14 @@ public class TestDSLInterpreter {
     public void testIfStmtTrue() {
         String program =
                 """
-            fn test_func() {
-                if 1 print("Hello, World!");
-            }
+                fn test_func() {
+                    if 1 print("Hello, World!");
+                }
 
-            quest_config c {
-                test: test_func()
-            }
-                """;
+                quest_config c {
+                    test: test_func()
+                }
+                    """;
 
         // print currently just prints to system.out, so we need to
         // check the contents for the printed string
@@ -797,15 +797,15 @@ public class TestDSLInterpreter {
     public void testElseStmt() {
         String program =
                 """
-            fn test_func() {
-                if 0 print("Hello");
-                else print ("World");
-            }
+                fn test_func() {
+                    if 0 print("Hello");
+                    else print ("World");
+                }
 
-            quest_config c {
-                test: test_func()
-            }
-                """;
+                quest_config c {
+                    test: test_func()
+                }
+                    """;
 
         // print currently just prints to system.out, so we need to
         // check the contents for the printed string
@@ -823,16 +823,16 @@ public class TestDSLInterpreter {
     public void testIfElseStmt() {
         String program =
                 """
-            fn test_func() {
-                if 0 print("Hello");
-                else if 0 print ("World");
-                else print("!");
-            }
+                fn test_func() {
+                    if 0 print("Hello");
+                    else if 0 print ("World");
+                    else print("!");
+                }
 
-            quest_config c {
-                test: test_func()
-            }
-                """;
+                quest_config c {
+                    test: test_func()
+                }
+                    """;
 
         // print currently just prints to system.out, so we need to
         // check the contents for the printed string
@@ -850,16 +850,16 @@ public class TestDSLInterpreter {
     public void testIfElseStmtSecondIf() {
         String program =
                 """
-            fn test_func() {
-                if false print("Hello");
-                else if true print ("World");
-                else print("!");
-            }
+                fn test_func() {
+                    if false print("Hello");
+                    else if true print ("World");
+                    else print("!");
+                }
 
-            quest_config c {
-                test: test_func()
-            }
-                """;
+                quest_config c {
+                    test: test_func()
+                }
+                    """;
 
         // print currently just prints to system.out, so we need to
         // check the contents for the printed string
@@ -878,21 +878,21 @@ public class TestDSLInterpreter {
     public void testBranchingReturn() {
         String program =
                 """
-        fn test_func() {
-            if false {
-                print("branch1");
-            } else {
-                print("branch2 stmt1");
-                print("branch2 stmt2");
-                return;
-                print("after return stmt");
-            }
-        }
+                fn test_func() {
+                    if false {
+                        print("branch1");
+                    } else {
+                        print("branch2 stmt1");
+                        print("branch2 stmt2");
+                        return;
+                        print("after return stmt");
+                    }
+                }
 
-        quest_config c {
-            test: test_func()
-        }
-            """;
+                quest_config c {
+                    test: test_func()
+                }
+                    """;
 
         // print currently just prints to system.out, so we need to
         // check the contents for the printed string
@@ -913,28 +913,28 @@ public class TestDSLInterpreter {
     public void testBranchingReturnNested() {
         String program =
                 """
-        fn other_func() -> string {
-            print("other_func stmt1");
-            print("other_func stmt2");
-            return "hello" ;
-            print("other_func stmt3");
-        }
+                fn other_func() -> string {
+                    print("other_func stmt1");
+                    print("other_func stmt2");
+                    return "hello" ;
+                    print("other_func stmt3");
+                }
 
-        fn test_func() {
-            if false {
-                print("branch1");
-            } else {
-                print("branch2 stmt1");
-                print(other_func());
-                return;
-                print("after return stmt");
-            }
-        }
+                fn test_func() {
+                    if false {
+                        print("branch1");
+                    } else {
+                        print("branch2 stmt1");
+                        print(other_func());
+                        return;
+                        print("after return stmt");
+                    }
+                }
 
-        quest_config c {
-            test: test_func()
-        }
-            """;
+                quest_config c {
+                    test: test_func()
+                }
+                    """;
 
         // print currently just prints to system.out, so we need to
         // check the contents for the printed string
@@ -961,20 +961,20 @@ public class TestDSLInterpreter {
     public void testFuncRefValue() {
         String program =
                 """
-            entity_type my_type {
-                test_component_with_callback {
-                    on_interaction: other_func
-                }
-            }
+                    entity_type my_type {
+                        test_component_with_callback {
+                            on_interaction: other_func
+                        }
+                    }
 
-            fn other_func(entity my_entity) {
-                print("Hello, World!");
-            }
+                    fn other_func(entity my_entity) {
+                        print("Hello, World!");
+                    }
 
-            quest_config c {
-                entity: instantiate(my_type)
-            }
-        """;
+                    quest_config c {
+                        entity: instantiate(my_type)
+                    }
+                """;
 
         // print currently just prints to system.out, so we need to
         // check the contents for the printed string
@@ -994,20 +994,20 @@ public class TestDSLInterpreter {
     public void testFuncRefValueCall() {
         String program =
                 """
-            entity_type my_type {
-                test_component_with_string_consumer_callback {
-                    on_interaction: other_func
-                }
-            }
+                    entity_type my_type {
+                        test_component_with_string_consumer_callback {
+                            on_interaction: other_func
+                        }
+                    }
 
-            fn other_func(string text) {
-                print(text);
-            }
+                    fn other_func(string text) {
+                        print(text);
+                    }
 
-            quest_config c {
-                entity: instantiate(my_type)
-            }
-        """;
+                    quest_config c {
+                        entity: instantiate(my_type)
+                    }
+                """;
 
         // print currently just prints to system.out, so we need to
         // check the contents for the printed string
@@ -1039,20 +1039,20 @@ public class TestDSLInterpreter {
     public void testFuncRefValueCallReturn() {
         String program =
                 """
-            entity_type my_type {
-                test_component_with_string_function_callback {
-                    on_interaction: other_func
-                }
-            }
+                    entity_type my_type {
+                        test_component_with_string_function_callback {
+                            on_interaction: other_func
+                        }
+                    }
 
-            fn other_func(string text) -> string {
-                return text;
-            }
+                    fn other_func(string text) -> string {
+                        return text;
+                    }
 
-            quest_config c {
-                entity: instantiate(my_type)
-            }
-        """;
+                    quest_config c {
+                        entity: instantiate(my_type)
+                    }
+                """;
 
         // print currently just prints to system.out, so we need to
         // check the contents for the printed string
@@ -1081,11 +1081,11 @@ public class TestDSLInterpreter {
     public void registerListAndSetTypesInEnvironment() {
         String program =
                 """
-                quest_config c {
-                    int_list: [1,2,3],
-                    string_list: ["Hello", "World", "!"]
-                }
-            """;
+                    quest_config c {
+                        int_list: [1,2,3],
+                        string_list: ["Hello", "World", "!"]
+                    }
+                """;
 
         // print currently just prints to system.out, so we need to
         // check the contents for the printed string
@@ -1115,11 +1115,11 @@ public class TestDSLInterpreter {
     public void setListValues() {
         String program =
                 """
-                quest_config c {
-                    int_list: [1,2,3],
-                    string_list: ["Hello", "World", "!"]
-                }
-            """;
+                    quest_config c {
+                        int_list: [1,2,3],
+                        string_list: ["Hello", "World", "!"]
+                    }
+                """;
 
         // print currently just prints to system.out, so we need to
         // check the contents for the printed string
@@ -1147,11 +1147,11 @@ public class TestDSLInterpreter {
     public void setSetValues() {
         String program =
                 """
-                quest_config c {
-                    float_set: <1.2,2.3,3.0,3.0>,
-                    string_set: <"Hello", "Hello", "World", "!">
-                }
-            """;
+                    quest_config c {
+                        float_set: <1.2,2.3,3.0,3.0>,
+                        string_set: <"Hello", "Hello", "World", "!">
+                    }
+                """;
 
         // print currently just prints to system.out, so we need to
         // check the contents for the printed string
@@ -1182,20 +1182,20 @@ public class TestDSLInterpreter {
     public void passListValueToFunc() {
         String program =
                 """
-                fn test_func(entity[] my_entities) -> bool {
-                    return true;
-                }
-
-                entity_type my_type{
-                    test_component_list_callback{
-                        on_interaction: test_func
+                    fn test_func(entity[] my_entities) -> bool {
+                        return true;
                     }
-                }
 
-                quest_config c {
-                    entity: instantiate(my_type)
-                }
-            """;
+                    entity_type my_type{
+                        test_component_list_callback{
+                            on_interaction: test_func
+                        }
+                    }
+
+                    quest_config c {
+                        entity: instantiate(my_type)
+                    }
+                """;
 
         // print currently just prints to system.out, so we need to
         // check the contents for the printed string
@@ -1230,20 +1230,20 @@ public class TestDSLInterpreter {
     public void passListValueThroughFunc() {
         String program =
                 """
-                fn test_func(entity[] my_entities) -> entity[] {
-                    return my_entities;
-                }
-
-                entity_type my_type{
-                    test_component_list_pass_through_callback{
-                        on_interaction: test_func
+                    fn test_func(entity[] my_entities) -> entity[] {
+                        return my_entities;
                     }
-                }
 
-                quest_config c {
-                    entity: instantiate(my_type)
-                }
-            """;
+                    entity_type my_type{
+                        test_component_list_pass_through_callback{
+                            on_interaction: test_func
+                        }
+                    }
+
+                    quest_config c {
+                        entity: instantiate(my_type)
+                    }
+                """;
 
         // print currently just prints to system.out, so we need to
         // check the contents for the printed string
@@ -1280,20 +1280,20 @@ public class TestDSLInterpreter {
     public void passSetValueThroughFunc() {
         String program =
                 """
-                fn test_func(entity<> my_entities) -> entity<> {
-                    return my_entities;
-                }
-
-                entity_type my_type{
-                    test_component_set_pass_through_callback{
-                        on_interaction: test_func
+                    fn test_func(entity<> my_entities) -> entity<> {
+                        return my_entities;
                     }
-                }
 
-                quest_config c {
-                    entity: instantiate(my_type)
-                }
-            """;
+                    entity_type my_type{
+                        test_component_set_pass_through_callback{
+                            on_interaction: test_func
+                        }
+                    }
+
+                    quest_config c {
+                        entity: instantiate(my_type)
+                    }
+                """;
 
         // print currently just prints to system.out, so we need to
         // check the contents for the printed string
@@ -1330,22 +1330,22 @@ public class TestDSLInterpreter {
     public void taskDefinition() {
         String program =
                 """
-            single_choice_task my_single_choice_task {
-                description: "Hello",
-                answers: ["1", "2", "3"],
-                correct_answer_index: 1
-            }
+                    single_choice_task my_single_choice_task {
+                        description: "Hello",
+                        answers: ["1", "2", "3"],
+                        correct_answer_index: 1
+                    }
 
-            multiple_choice_task my_multiple_choice_task {
-                description: "Tschüss",
-                answers: ["4", "5", "6"],
-                correct_answer_index: [0,1]
-            }
+                    multiple_choice_task my_multiple_choice_task {
+                        description: "Tschüss",
+                        answers: ["4", "5", "6"],
+                        correct_answer_index: [0,1]
+                    }
 
-            quest_config c {
-                tasks: [my_single_choice_task, my_multiple_choice_task]
-            }
-        """;
+                    quest_config c {
+                        tasks: [my_single_choice_task, my_multiple_choice_task]
+                    }
+                """;
 
         DSLInterpreter interpreter = new DSLInterpreter();
         var config = (QuestConfig) interpreter.getQuestConfig(program);
@@ -1373,23 +1373,23 @@ public class TestDSLInterpreter {
     public void testMemberAccess() {
         String program =
                 """
-            fn test_func(test_component2 component) {
-                print(component.member1);
-            }
+                    fn test_func(test_component2 component) {
+                        print(component.member1);
+                    }
 
-            entity_type my_type{
-                test_component_string_member_and_callback{
-                    consumer: test_func
-                },
-                test_component2 {
-                    member1: "Hello, World!"
-                }
-            }
+                    entity_type my_type{
+                        test_component_string_member_and_callback{
+                            consumer: test_func
+                        },
+                        test_component2 {
+                            member1: "Hello, World!"
+                        }
+                    }
 
-            quest_config c {
-                entity: instantiate(my_type)
-            }
-        """;
+                    quest_config c {
+                        entity: instantiate(my_type)
+                    }
+                """;
 
         // print currently just prints to system.out, so we need to
         // check the contents for the printed string
@@ -1422,28 +1422,28 @@ public class TestDSLInterpreter {
     public void testMemberAccessFuncCall() {
         String program =
                 """
-            fn return_component(test_component2 component) -> test_component2 {
-                return component;
-            }
+                    fn return_component(test_component2 component) -> test_component2 {
+                        return component;
+                    }
 
-            fn use_function(test_component2 component) {
-                // setting of the component parameter does not work!
-                print(return_component(component).member1);
-            }
+                    fn use_function(test_component2 component) {
+                        // setting of the component parameter does not work!
+                        print(return_component(component).member1);
+                    }
 
-            entity_type my_type{
-                test_component_string_member_and_callback{
-                    consumer: use_function
-                },
-                test_component2 {
-                    member1: "Hello, World!"
-                }
-            }
+                    entity_type my_type{
+                        test_component_string_member_and_callback{
+                            consumer: use_function
+                        },
+                        test_component2 {
+                            member1: "Hello, World!"
+                        }
+                    }
 
-            quest_config c {
-                entity: instantiate(my_type)
-            }
-        """;
+                    quest_config c {
+                        entity: instantiate(my_type)
+                    }
+                """;
 
         // print currently just prints to system.out, so we need to
         // check the contents for the printed string
@@ -1475,24 +1475,24 @@ public class TestDSLInterpreter {
     public void testProperty() {
         String program =
                 """
-            entity_type my_type {
-                test_component2 {
-                    member2: 42,
-                    this_is_a_float: 3.14
-                },
-                test_component_with_callback {
-                    consumer: get_property
+                entity_type my_type {
+                    test_component2 {
+                        member2: 42,
+                        this_is_a_float: 3.14
+                    },
+                    test_component_with_callback {
+                        consumer: get_property
+                    }
                 }
-            }
 
-            fn get_property(test_component2 comp) {
-                print(comp.this_is_a_float);
-            }
+                fn get_property(test_component2 comp) {
+                    print(comp.this_is_a_float);
+                }
 
-            quest_config c {
-                entity: instantiate(my_type)
-            }
-            """;
+                quest_config c {
+                    entity: instantiate(my_type)
+                }
+                """;
 
         // print currently just prints to system.out, so we need to
         // check the contents for the printed string
@@ -1529,25 +1529,25 @@ public class TestDSLInterpreter {
     public void testPropertyOfComplexType() {
         String program =
                 """
-        entity_type my_type {
-            test_component2 {
-                member2: 42,
-                this_is_complex: complex_type { member1: 42 }
-            },
-            test_component_with_callback {
-                consumer: get_property
-            }
-        }
+                entity_type my_type {
+                    test_component2 {
+                        member2: 42,
+                        this_is_complex: complex_type { member1: 42 }
+                    },
+                    test_component_with_callback {
+                        consumer: get_property
+                    }
+                }
 
-        fn get_property(test_component2 comp) {
-            print(comp.this_is_complex.member1);
-            print(comp.this_is_complex.member3);
-        }
+                fn get_property(test_component2 comp) {
+                    print(comp.this_is_complex.member1);
+                    print(comp.this_is_complex.member3);
+                }
 
-        quest_config c {
-            entity: instantiate(my_type)
-        }
-        """;
+                quest_config c {
+                    entity: instantiate(my_type)
+                }
+                """;
 
         // print currently just prints to system.out, so we need to
         // check the contents for the printed string
@@ -1585,24 +1585,24 @@ public class TestDSLInterpreter {
     public void testComponentPropertyOfEntity() {
         String program =
                 """
-            entity_type my_type {
-                test_component2 {
-                    member2: 42
-                },
-                test_component_with_callback {
-                    consumer: get_property
+                entity_type my_type {
+                    test_component2 {
+                        member2: 42
+                    },
+                    test_component_with_callback {
+                        consumer: get_property
+                    }
                 }
-            }
 
-            fn get_property(entity ent) {
-                print(ent.test_component1.member1);
-                print(ent.test_component2.member2);
-            }
+                fn get_property(entity ent) {
+                    print(ent.test_component1.member1);
+                    print(ent.test_component2.member2);
+                }
 
-            quest_config c {
-                entity: instantiate(my_type)
-            }
-            """;
+                quest_config c {
+                    entity: instantiate(my_type)
+                }
+                """;
 
         // print currently just prints to system.out, so we need to
         // check the contents for the printed string
@@ -1638,23 +1638,23 @@ public class TestDSLInterpreter {
     public void testComponentPropertyOfEntityUpdateValue() {
         String program =
                 """
-        entity_type my_type {
-            test_component2 {
-                member2: 42
-            },
-            test_component_with_callback {
-                consumer: get_property
-            }
-        }
+                entity_type my_type {
+                    test_component2 {
+                        member2: 42
+                    },
+                    test_component_with_callback {
+                        consumer: get_property
+                    }
+                }
 
-        fn get_property(entity ent) {
-            print(ent.test_component2.member2);
-        }
+                fn get_property(entity ent) {
+                    print(ent.test_component2.member2);
+                }
 
-        quest_config c {
-            entity: instantiate(my_type)
-        }
-        """;
+                quest_config c {
+                    entity: instantiate(my_type)
+                }
+                """;
 
         // print currently just prints to system.out, so we need to
         // check the contents for the printed string
@@ -1712,26 +1712,26 @@ public class TestDSLInterpreter {
     public void testAssignmentProperty() {
         String program =
                 """
-    entity_type my_type {
-        test_component2 {
-            member1: "ja",
-            member3: "nein"
-        },
-        test_component_with_callback {
-            consumer: get_property
-        }
-    }
+                    entity_type my_type {
+                        test_component2 {
+                            member1: "ja",
+                            member3: "nein"
+                        },
+                        test_component_with_callback {
+                            consumer: get_property
+                        }
+                    }
 
-    fn get_property(entity ent) {
-        ent.test_component2.member3 = ent.test_component2.member1 = "kuckuck";
-        print(ent.test_component2.member1);
-        print(ent.test_component2.member3);
-    }
+                    fn get_property(entity ent) {
+                        ent.test_component2.member3 = ent.test_component2.member1 = "kuckuck";
+                        print(ent.test_component2.member1);
+                        print(ent.test_component2.member3);
+                    }
 
-    quest_config c {
-        entity: instantiate(my_type)
-    }
-    """;
+                    quest_config c {
+                        entity: instantiate(my_type)
+                    }
+                """;
 
         // print currently just prints to system.out, so we need to
         // check the contents for the printed string
@@ -1754,7 +1754,6 @@ public class TestDSLInterpreter {
         var config =
                 (CustomQuestConfig)
                         Helpers.generateQuestConfigWithCustomTypes(program, env, interpreter);
-
         var entity = config.entity();
 
         TestComponentEntityConsumerCallback componentWithConsumer =
@@ -1776,27 +1775,27 @@ public class TestDSLInterpreter {
     public void testAssignmentObjectMember() {
         String program =
                 """
-    entity_type my_type {
-        test_component2 {
-            member1: "ja",
-            member3: "nein"
-        },
-        test_component_with_callback {
-            consumer: set_property
-        }
-    }
+                entity_type my_type {
+                    test_component2 {
+                        member1: "ja",
+                        member3: "nein"
+                    },
+                    test_component_with_callback {
+                        consumer: set_property
+                    }
+                }
 
-    fn set_property(entity ent) {
-        c.second_entity = ent;
-        print(c.second_entity.test_component2.member1);
-        ent.test_component2.member1 = "nein";
-        print(c.second_entity.test_component2.member1);
-    }
+                fn set_property(entity ent) {
+                    c.second_entity = ent;
+                    print(c.second_entity.test_component2.member1);
+                    ent.test_component2.member1 = "nein";
+                    print(c.second_entity.test_component2.member1);
+                }
 
-    quest_config c {
-        entity: instantiate(my_type)
-    }
-    """;
+                quest_config c {
+                    entity: instantiate(my_type)
+                }
+                """;
 
         // print currently just prints to system.out, so we need to
         // check the contents for the printed string
@@ -1840,22 +1839,22 @@ public class TestDSLInterpreter {
     public void testAssignmentFuncParam() {
         String program =
                 """
-    entity_type my_type {
-        test_component_with_string_consumer_callback {
-            on_interaction: set_param
-        }
-    }
+                entity_type my_type {
+                    test_component_with_string_consumer_callback {
+                        on_interaction: set_param
+                    }
+                }
 
-    fn set_param(string text) {
-        print(text);
-        text = "my text";
-        print(text);
-    }
+                fn set_param(string text) {
+                    print(text);
+                    text = "my text";
+                    print(text);
+                }
 
-    quest_config c {
-        entity: instantiate(my_type)
-    }
-    """;
+                quest_config c {
+                    entity: instantiate(my_type)
+                }
+                """;
 
         // print currently just prints to system.out, so we need to
         // check the contents for the printed string
@@ -1868,6 +1867,58 @@ public class TestDSLInterpreter {
         env.getTypeBuilder()
                 .createDSLTypeForJavaTypeInScope(
                         env.getGlobalScope(), TestComponentWithStringConsumerCallback.class);
+
+        var config =
+                (CustomQuestConfig)
+                        Helpers.generateQuestConfigWithCustomTypes(program, env, interpreter);
+
+        var entity = config.entity();
+
+        TestComponentWithStringConsumerCallback componentWithConsumer =
+                (TestComponentWithStringConsumerCallback)
+                        entity.components.stream()
+                                .filter(c -> c instanceof TestComponentWithStringConsumerCallback)
+                                .toList()
+                                .get(0);
+
+        componentWithConsumer.executeCallbackWithText("hello");
+
+        String output = outputStream.toString();
+        Assert.assertTrue(
+                output.equals(
+                        "hello" + System.lineSeparator() + "my text" + System.lineSeparator()));
+    }
+
+    @Test
+    public void testVariableCreation() {
+        String program =
+                """
+                entity_type my_type {
+                    test_component_with_callback {
+                        consumer: get_property
+                    }
+                }
+
+                fn get_property(string param) {
+                    var test : string;
+                }
+
+                quest_config c {
+                    entity: instantiate(my_type)
+                }
+                """;
+
+        // print currently just prints to system.out, so we need to
+        // check the contents for the printed string
+        var outputStream = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(outputStream));
+
+        TestEnvironment env = new TestEnvironment();
+        DSLInterpreter interpreter = new DSLInterpreter();
+        env.getTypeBuilder().createDSLTypeForJavaTypeInScope(env.getGlobalScope(), Entity.class);
+        env.getTypeBuilder()
+                .createDSLTypeForJavaTypeInScope(
+                        env.getGlobalScope(), TestComponentWithCallback.class);
 
         var config =
                 (CustomQuestConfig)

--- a/dsl/test/interpreter/TestDSLInterpreter.java
+++ b/dsl/test/interpreter/TestDSLInterpreter.java
@@ -2122,4 +2122,185 @@ public class TestDSLInterpreter {
         String output = outputStream.toString();
         assertEquals(output, "Hello, World!" + System.lineSeparator());
     }
+
+    @Test
+    public void testVariableCreationIfStmtBlock() {
+        String program =
+                """
+        entity_type my_type {
+            test_component_with_callback {
+                consumer: func
+            }
+        }
+
+        fn func(entity ent) {
+            var test : string;
+            if true {
+                var test : int;
+                test = 42;
+            }
+            print(test);
+        }
+
+        quest_config c {
+            entity: instantiate(my_type)
+        }
+        """;
+
+        // print currently just prints to system.out, so we need to
+        // check the contents for the printed string
+        var outputStream = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(outputStream));
+
+        TestEnvironment env = new TestEnvironment();
+        DSLInterpreter interpreter = new DSLInterpreter();
+        env.getTypeBuilder().createDSLTypeForJavaTypeInScope(env.getGlobalScope(), Entity.class);
+        env.getTypeBuilder()
+                .createDSLTypeForJavaTypeInScope(
+                        env.getGlobalScope(), TestComponentEntityConsumerCallback.class);
+
+        var config =
+                (CustomQuestConfig)
+                        Helpers.generateQuestConfigWithCustomTypes(program, env, interpreter);
+
+        var entity = config.entity();
+
+        TestComponentEntityConsumerCallback componentWithConsumer =
+                (TestComponentEntityConsumerCallback)
+                        entity.components.stream()
+                                .filter(c -> c instanceof TestComponentEntityConsumerCallback)
+                                .toList()
+                                .get(0);
+
+        componentWithConsumer.consumer.accept(entity);
+
+        // the output stream should only contain the default value for a string variable ("") and
+        // the line separator from the print-call; if the variable definition in the if-stmt-body
+        // "escapes" the output will contain "42\n"
+        String output = outputStream.toString();
+        assertEquals(System.lineSeparator(), output);
+    }
+
+    @Test
+    public void testVariableCreationIfStmtSingleStmt() {
+        String program =
+                """
+            entity_type my_type {
+                test_component_with_callback {
+                    consumer: func
+                }
+            }
+
+            fn func(entity ent) {
+                var test : string;
+                if true
+                    var test : int;
+                print(test);
+            }
+
+            quest_config c {
+                entity: instantiate(my_type)
+            }
+            """;
+
+        // print currently just prints to system.out, so we need to
+        // check the contents for the printed string
+        var outputStream = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(outputStream));
+
+        TestEnvironment env = new TestEnvironment();
+        DSLInterpreter interpreter = new DSLInterpreter();
+        env.getTypeBuilder().createDSLTypeForJavaTypeInScope(env.getGlobalScope(), Entity.class);
+        env.getTypeBuilder()
+                .createDSLTypeForJavaTypeInScope(
+                        env.getGlobalScope(), TestComponentEntityConsumerCallback.class);
+
+        var config =
+                (CustomQuestConfig)
+                        Helpers.generateQuestConfigWithCustomTypes(program, env, interpreter);
+
+        var entity = config.entity();
+
+        TestComponentEntityConsumerCallback componentWithConsumer =
+                (TestComponentEntityConsumerCallback)
+                        entity.components.stream()
+                                .filter(c -> c instanceof TestComponentEntityConsumerCallback)
+                                .toList()
+                                .get(0);
+
+        componentWithConsumer.consumer.accept(entity);
+
+        // the output stream should only contain the default value for a string variable ("") and
+        // the line separator from the print-call; if the variable definition in the if-stmt-body
+        // "escapes" the output will contain "0\n", as the new 'test'-variable will be initialized
+        // with 0
+        String output = outputStream.toString();
+        assertEquals(System.lineSeparator(), output);
+    }
+
+    @Test
+    public void testVariableCreationIfElseStmtSingleStmt() {
+        String program =
+                """
+            entity_type my_type {
+                test_component_with_callback {
+                    consumer: func
+                }
+            }
+
+            fn func(entity ent) {
+                var test : string;
+
+                if true
+                    var test : int;
+                else
+                    var test : int;
+                print(test);
+
+                if false
+                    var test : int;
+                else
+                    var test : int;
+                print(test);
+            }
+
+            quest_config c {
+                entity: instantiate(my_type)
+            }
+            """;
+
+        // print currently just prints to system.out, so we need to
+        // check the contents for the printed string
+        var outputStream = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(outputStream));
+
+        TestEnvironment env = new TestEnvironment();
+        DSLInterpreter interpreter = new DSLInterpreter();
+        env.getTypeBuilder().createDSLTypeForJavaTypeInScope(env.getGlobalScope(), Entity.class);
+        env.getTypeBuilder()
+                .createDSLTypeForJavaTypeInScope(
+                        env.getGlobalScope(), TestComponentEntityConsumerCallback.class);
+
+        var config =
+                (CustomQuestConfig)
+                        Helpers.generateQuestConfigWithCustomTypes(program, env, interpreter);
+
+        var entity = config.entity();
+
+        TestComponentEntityConsumerCallback componentWithConsumer =
+                (TestComponentEntityConsumerCallback)
+                        entity.components.stream()
+                                .filter(c -> c instanceof TestComponentEntityConsumerCallback)
+                                .toList()
+                                .get(0);
+
+        componentWithConsumer.consumer.accept(entity);
+
+        // the output stream should only contain the default value for a string variable ("") and
+        // the line separator from the print-call; if the variable definitions in the
+        // if-else=stmt-body "escapes" the output will contain '0', as the new 'test'-variable
+        // will be initialized with 0
+        String output = outputStream.toString();
+        assertEquals(System.lineSeparator() + System.lineSeparator(), output);
+    }
 }

--- a/dsl/test/interpreter/TestDSLInterpreter.java
+++ b/dsl/test/interpreter/TestDSLInterpreter.java
@@ -2059,4 +2059,67 @@ public class TestDSLInterpreter {
         String output = outputStream.toString();
         assertEquals(output, "Hello, World!" + System.lineSeparator());
     }
+
+    @Test
+    public void testVariableCreationList() {
+        String program =
+                """
+        entity_type my_type {
+            test_component2 {
+                member1: "Hello, World!"
+            },
+            test_component_with_callback {
+                consumer: func
+            }
+        }
+
+        fn func(entity ent) {
+            var test : entity[];
+            if test {
+                print("Hello, World!");
+            }
+        }
+
+        quest_config c {
+            entity: instantiate(my_type)
+        }
+        """;
+
+        // print currently just prints to system.out, so we need to
+        // check the contents for the printed string
+        var outputStream = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(outputStream));
+
+        TestEnvironment env = new TestEnvironment();
+        DSLInterpreter interpreter = new DSLInterpreter();
+        env.getTypeBuilder().createDSLTypeForJavaTypeInScope(env.getGlobalScope(), Entity.class);
+        env.getTypeBuilder()
+                .createDSLTypeForJavaTypeInScope(env.getGlobalScope(), TestComponent2.class);
+        env.getTypeBuilder()
+                .createDSLTypeForJavaTypeInScope(
+                        env.getGlobalScope(), TestComponentEntityConsumerCallback.class);
+        env.getTypeBuilder()
+                .registerProperty(env.getGlobalScope(), Entity.TestComponent2Property.instance);
+
+        var config =
+                (CustomQuestConfig)
+                        Helpers.generateQuestConfigWithCustomTypes(program, env, interpreter);
+
+        var entity = config.entity();
+
+        TestComponentEntityConsumerCallback componentWithConsumer =
+                (TestComponentEntityConsumerCallback)
+                        entity.components.stream()
+                                .filter(c -> c instanceof TestComponentEntityConsumerCallback)
+                                .toList()
+                                .get(0);
+
+        componentWithConsumer.consumer.accept(entity);
+
+        // the output stream should only contain the default value for a string variable ("") and
+        // the
+        // line separator from the print-call
+        String output = outputStream.toString();
+        assertEquals(output, "Hello, World!" + System.lineSeparator());
+    }
 }

--- a/dsl/test/interpreter/TestDSLInterpreter.java
+++ b/dsl/test/interpreter/TestDSLInterpreter.java
@@ -1894,8 +1894,8 @@ public class TestDSLInterpreter {
         String program =
                 """
                 entity_type my_type {
-                    test_component_with_callback {
-                        consumer: get_property
+                    test_component_with_string_consumer_callback {
+                        on_interaction: get_property
                     }
                 }
 
@@ -1918,7 +1918,7 @@ public class TestDSLInterpreter {
         env.getTypeBuilder().createDSLTypeForJavaTypeInScope(env.getGlobalScope(), Entity.class);
         env.getTypeBuilder()
                 .createDSLTypeForJavaTypeInScope(
-                        env.getGlobalScope(), TestComponentWithCallback.class);
+                        env.getGlobalScope(), TestComponentWithStringConsumerCallback.class);
 
         var config =
                 (CustomQuestConfig)

--- a/dsl/test/semanticanalysis/TestSemanticAnalyzer.java
+++ b/dsl/test/semanticanalysis/TestSemanticAnalyzer.java
@@ -9,8 +9,8 @@ import interpreter.TestEnvironment;
 import interpreter.mockecs.Entity;
 import interpreter.mockecs.TestComponent2;
 import interpreter.mockecs.TestComponentEntityConsumerCallback;
-
 import interpreter.mockecs.TestComponentWithStringConsumerCallback;
+
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -635,10 +635,11 @@ public class TestSemanticAnalyzer {
         Assert.assertNotEquals(Symbol.NULL, testVariableSymbol);
         Assert.assertEquals(BuiltInType.stringType, testVariableSymbol.dataType);
     }
+
     @Test
     public void testVariableCreationIfStmt() {
         String program =
-            """
+                """
             entity_type my_type {
                 test_component_with_string_consumer_callback {
                     on_interaction: callback
@@ -665,18 +666,18 @@ public class TestSemanticAnalyzer {
         TestEnvironment env = new TestEnvironment();
         env.getTypeBuilder().createDSLTypeForJavaTypeInScope(env.getGlobalScope(), Entity.class);
         env.getTypeBuilder()
-            .createDSLTypeForJavaTypeInScope(
-                env.getGlobalScope(), TestComponentWithStringConsumerCallback.class);
+                .createDSLTypeForJavaTypeInScope(
+                        env.getGlobalScope(), TestComponentWithStringConsumerCallback.class);
 
         var ast = Helpers.getASTFromString(program);
         var result = Helpers.getSymtableForASTWithCustomEnvironment(ast, env);
         var symbolTable = result.symbolTable;
 
-        FunctionSymbol funcSymbol =
-            (FunctionSymbol) symbolTable.globalScope.resolve("callback");
+        FunctionSymbol funcSymbol = (FunctionSymbol) symbolTable.globalScope.resolve("callback");
 
         FuncDefNode funcDefNode = (FuncDefNode) symbolTable.getCreationAstNode(funcSymbol);
-        ConditionalStmtNodeIfElse conditional = (ConditionalStmtNodeIfElse) funcDefNode.getStmtBlock().getChild(0).getChild(0);
+        ConditionalStmtNodeIfElse conditional =
+                (ConditionalStmtNodeIfElse) funcDefNode.getStmtBlock().getChild(0).getChild(0);
         VarDeclNode ifStmtDeclNode = (VarDeclNode) conditional.getIfStmt();
         VarDeclNode elseStmtDeclNode = (VarDeclNode) conditional.getElseStmt();
 

--- a/dsl/test/semanticanalysis/TestSemanticAnalyzer.java
+++ b/dsl/test/semanticanalysis/TestSemanticAnalyzer.java
@@ -627,7 +627,10 @@ public class TestSemanticAnalyzer {
 
         FunctionSymbol funcSymbol =
                 (FunctionSymbol) symbolTable.globalScope.resolve("get_property");
-        Symbol testVariableSymbol = funcSymbol.resolve("test");
+        FuncDefNode funcDefNode = (FuncDefNode) symbolTable.getCreationAstNode(funcSymbol);
+        VarDeclNode declNode = (VarDeclNode) funcDefNode.getStmtBlock().getChild(0).getChild(0);
+        Symbol testVariableSymbol = symbolTable.getSymbolsForAstNode(declNode).get(0);
+
         Assert.assertNotEquals(Symbol.NULL, testVariableSymbol);
         Assert.assertEquals(BuiltInType.stringType, testVariableSymbol.dataType);
     }

--- a/dsl/test/semanticanalysis/TestSemanticAnalyzer.java
+++ b/dsl/test/semanticanalysis/TestSemanticAnalyzer.java
@@ -4,14 +4,12 @@ import dslToGame.graph.Graph;
 
 import helpers.Helpers;
 
-import interpreter.CustomQuestConfig;
-import interpreter.DSLInterpreter;
 import interpreter.DummyNativeFunction;
 import interpreter.TestEnvironment;
 import interpreter.mockecs.Entity;
 import interpreter.mockecs.TestComponent2;
-
 import interpreter.mockecs.TestComponentEntityConsumerCallback;
+
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -596,7 +594,7 @@ public class TestSemanticAnalyzer {
     @Test
     public void testVariableCreation() {
         String program =
-            """
+                """
     entity_type my_type {
         test_component_with_callback {
             consumer: get_property
@@ -620,14 +618,15 @@ public class TestSemanticAnalyzer {
         TestEnvironment env = new TestEnvironment();
         env.getTypeBuilder().createDSLTypeForJavaTypeInScope(env.getGlobalScope(), Entity.class);
         env.getTypeBuilder()
-            .createDSLTypeForJavaTypeInScope(
-                env.getGlobalScope(), TestComponentEntityConsumerCallback.class);
+                .createDSLTypeForJavaTypeInScope(
+                        env.getGlobalScope(), TestComponentEntityConsumerCallback.class);
 
         var ast = Helpers.getASTFromString(program);
         var result = Helpers.getSymtableForASTWithCustomEnvironment(ast, env);
         var symbolTable = result.symbolTable;
 
-        FunctionSymbol funcSymbol = (FunctionSymbol)symbolTable.globalScope.resolve("get_property");
+        FunctionSymbol funcSymbol =
+                (FunctionSymbol) symbolTable.globalScope.resolve("get_property");
         Symbol testVariableSymbol = funcSymbol.resolve("test");
         Assert.assertNotEquals(Symbol.NULL, testVariableSymbol);
         Assert.assertEquals(BuiltInType.stringType, testVariableSymbol.dataType);


### PR DESCRIPTION
Implementiert Variablen-Definition.

Erweitert Grammatik für Variablendeklaration.
Implementiert AST-Konvertierung für Variablendeklaration.
Implementiert semantische Analyse für Variablendeklaration (wobei allerdings aktuell nur die `identifier : datentyp` Variante unterstützt wird, die `identifier = expression` Variante erfordert Typechecking).
Fügt Sonderfall-Behandlung für if-else-Statement mit nur einem Statement im Rumpf hinzu, um evtl. darin erfolgte Variablendeklarationen nicht in den umliegenden Scope zu lassen (TODO: das in der Interpretation berücksichtigen oder festlegen, dass im Rumpf von if-else-Statements immer ein Block verwendet werden muss).
Fügt Tests hinzu.

TODO:
- [x] Sonderbehandlung if-else-Statement Interpretation (siehe Text oben)
- [x] StmtBlock muss neuen MemorySpace erzeugen