### PR TITLE
[GAME] renamed PatrouilleWalk to PatrolWalk

### DIFF
--- a/game/src/contrib/components/AIComponent.java
+++ b/game/src/contrib/components/AIComponent.java
@@ -2,6 +2,7 @@ package contrib.components;
 
 import contrib.systems.AISystem;
 import contrib.utils.components.ai.fight.CollideAI;
+import contrib.utils.components.ai.idle.PatrolWalk;
 import contrib.utils.components.ai.idle.RadiusWalk;
 import contrib.utils.components.ai.transition.RangeTransition;
 
@@ -23,7 +24,7 @@ import java.util.function.Function;
  * to check if the idle or combat behaviour should be executed.
  *
  * <p>The {@link #idleBehavior} defines the behaviour in idle state, e.g. walking on a specific path
- * {@link contrib.utils.components.ai.idle.PatrouilleWalk}.
+ * {@link PatrolWalk}.
  *
  * <p>The {@link #fightBehavior} defines the combat behaviour, e.g. attacking with a fireball skill
  * {@link contrib.utils.components.ai.fight.RangeAI}.

--- a/game/src/contrib/entities/AIFactory.java
+++ b/game/src/contrib/entities/AIFactory.java
@@ -4,7 +4,7 @@ import contrib.components.AIComponent;
 import contrib.components.HealthComponent;
 import contrib.utils.components.ai.fight.CollideAI;
 import contrib.utils.components.ai.fight.RangeAI;
-import contrib.utils.components.ai.idle.PatrouilleWalk;
+import contrib.utils.components.ai.idle.PatrolWalk;
 import contrib.utils.components.ai.idle.RadiusWalk;
 import contrib.utils.components.ai.idle.StaticRadiusWalk;
 import contrib.utils.components.ai.transition.ProtectOnApproach;
@@ -116,8 +116,8 @@ public class AIFactory {
 
         switch (index) {
             case 0 -> {
-                PatrouilleWalk.MODE[] modes = PatrouilleWalk.MODE.values();
-                return new PatrouilleWalk(
+                PatrolWalk.MODE[] modes = PatrolWalk.MODE.values();
+                return new PatrolWalk(
                         RANDOM.nextFloat(PATROUILLE_RADIUS_LOW, PATROUILLE_RADIUS_HIGH),
                         RANDOM.nextInt(CHECKPOINTS_LOW, CHECKPOINTS_HIGH + 1),
                         RANDOM.nextInt(PAUSE_TIME_LOW, PAUSE_TIME_HIGH + 1),

--- a/game/src/contrib/utils/components/ai/idle/PatrolWalk.java
+++ b/game/src/contrib/utils/components/ai/idle/PatrolWalk.java
@@ -17,7 +17,7 @@ import java.util.List;
 import java.util.Random;
 import java.util.function.Consumer;
 
-public class PatrouilleWalk implements Consumer<Entity> {
+public class PatrolWalk implements Consumer<Entity> {
 
     private static final Random random = new Random();
 
@@ -53,7 +53,7 @@ public class PatrouilleWalk implements Consumer<Entity> {
      * @param pauseTime Max time in milliseconds to wait on a checkpoint. The actual time is a
      *     random number between 0 and this value
      */
-    public PatrouilleWalk(
+    public PatrolWalk(
             final float radius, final int numberCheckpoints, final int pauseTime, final MODE mode) {
         this.radius = radius;
         this.numberCheckpoints = numberCheckpoints;


### PR DESCRIPTION
fixes #983

Patrouille ist kein englisches Wort. PatrouilleWalk wurde dementsprechend in PatrolWalk umbenannt.