### PR TITLE
[GAME] make room size base on entities in room

### DIFF
--- a/game/src/core/level/generator/graphBased/RoombasedLevelGenerator.java
+++ b/game/src/core/level/generator/graphBased/RoombasedLevelGenerator.java
@@ -41,6 +41,11 @@ import java.util.logging.Logger;
  */
 public class RoombasedLevelGenerator {
 
+    /** Rooms with this amount or fewer entities will be generated small. */
+    private static final int MAX_ENTITIES_FOR_SMALL_ROOMS = 2;
+    /** Rooms with this amount or more entities will be generated large. */
+    private static final int MIN_ENTITIES_FOR_BIG_ROOM = 5;
+
     private static final Logger LOGGER = Logger.getLogger(RoombasedLevelGenerator.class.getName());
 
     /**
@@ -63,8 +68,7 @@ public class RoombasedLevelGenerator {
                         node ->
                                 node.level(
                                         new TileLevel(
-                                                roomG.layout(
-                                                        LevelSize.randomSize(), node.neighbours()),
+                                                roomG.layout(sizeFor(node), node.neighbours()),
                                                 designLabel)));
 
         for (Node node : graph.nodes()) {
@@ -76,6 +80,12 @@ public class RoombasedLevelGenerator {
             node.level().onFirstLoad(() -> node.entities().forEach(Game::add));
         }
         return graph.root().level();
+    }
+
+    private static LevelSize sizeFor(Node node) {
+        if (node.entities().size() <= MAX_ENTITIES_FOR_SMALL_ROOMS) return LevelSize.SMALL;
+        else if (node.entities().size() >= MIN_ENTITIES_FOR_BIG_ROOM) return LevelSize.LARGE;
+        else return LevelSize.MEDIUM;
     }
 
     /**

--- a/game/src/core/level/generator/graphBased/RoombasedLevelGenerator.java
+++ b/game/src/core/level/generator/graphBased/RoombasedLevelGenerator.java
@@ -2,6 +2,8 @@ package core.level.generator.graphBased;
 
 import core.Entity;
 import core.Game;
+import core.components.DrawComponent;
+import core.components.PositionComponent;
 import core.level.Tile;
 import core.level.TileLevel;
 import core.level.elements.ILevel;
@@ -16,6 +18,7 @@ import core.utils.IVoidFunction;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Logger;
 
 /**
@@ -83,8 +86,16 @@ public class RoombasedLevelGenerator {
     }
 
     private static LevelSize sizeFor(Node node) {
-        if (node.entities().size() <= MAX_ENTITIES_FOR_SMALL_ROOMS) return LevelSize.SMALL;
-        else if (node.entities().size() >= MIN_ENTITIES_FOR_BIG_ROOM) return LevelSize.LARGE;
+        AtomicInteger count = new AtomicInteger();
+        node.entities()
+                .forEach(
+                        e -> {
+                            if (e.isPresent(PositionComponent.class)
+                                    && e.isPresent(DrawComponent.class)) count.getAndIncrement();
+                        });
+
+        if (count.get() <= MAX_ENTITIES_FOR_SMALL_ROOMS) return LevelSize.SMALL;
+        else if (count.get() >= MIN_ENTITIES_FOR_BIG_ROOM) return LevelSize.LARGE;
         else return LevelSize.MEDIUM;
     }
 


### PR DESCRIPTION
fixes #982 

- Die Raumgröße wird jetzt beim generieren davon abhängig gemacht, wie viele Entitäten initial darin enthalten sein sollen (dabei zählen nur Entitäten mit einen PositionComponent und DrawComponent (also quasi nur Sachen die man auch sieht) 
- Konstanten sind nach etwas hin und her testen festgelegt worden. Für meinen Geschmack war das ganz gut. 