### PR TITLE
[DSL] Methoden implementieren

### DIFF
--- a/dsl/src/interpreter/DSLInterpreter.java
+++ b/dsl/src/interpreter/DSLInterpreter.java
@@ -534,9 +534,6 @@ public class DSLInterpreter implements AstVisitor<Object> {
     public Object visit(FuncCallNode node) {
         var funcName = node.getIdName();
 
-        // TODO: resolve in current memory-space / in datatype of "this"
-        //  this resolving will likely be more complex and should be refactored into it's own method
-
         var symbol = this.symbolTable().getSymbolsForAstNode(node).get(0);
 
         if (!(symbol instanceof ICallable callable)) {

--- a/dsl/src/interpreter/DSLInterpreter.java
+++ b/dsl/src/interpreter/DSLInterpreter.java
@@ -488,7 +488,8 @@ public class DSLInterpreter implements AstVisitor<Object> {
     public Object visit(IdNode node) {
         var symbol = this.symbolTable().getSymbolsForAstNode(node).get(0);
         if (symbol instanceof FunctionSymbol functionSymbol) {
-            return new FunctionValue(functionSymbol.getFunctionType().getReturnType(), functionSymbol);
+            return new FunctionValue(
+                    functionSymbol.getFunctionType().getReturnType(), functionSymbol);
         }
 
         return this.getCurrentMemorySpace().resolve(node.getName(), true);
@@ -535,7 +536,9 @@ public class DSLInterpreter implements AstVisitor<Object> {
 
         // TODO: resolve in current memory-space / in datatype of "this"
         //  this resolving will likely be more complex and should be refactored into it's own method
-        var symbol = this.symbolTable().getGlobalScope().resolve(funcName);
+
+        var symbol = this.symbolTable().getSymbolsForAstNode(node).get(0);
+
         if (!(symbol instanceof ICallable callable)) {
             throw new RuntimeException("Symbol for name '" + funcName + "' is not callable!");
         } else {
@@ -553,7 +556,7 @@ public class DSLInterpreter implements AstVisitor<Object> {
                 var dslType = this.environment.getDSLTypeForClass(valueClass);
                 if (dslType == null) {
                     throw new RuntimeException(
-                        "No DSL Type representation for java type '" + valueClass + "'");
+                            "No DSL Type representation for java type '" + valueClass + "'");
                 }
                 returnValue = new Value(dslType, returnValue);
             }
@@ -643,10 +646,7 @@ public class DSLInterpreter implements AstVisitor<Object> {
     public Object visit(MemberAccessNode node) {
         Value lhs = (Value) node.getLhs().accept(this);
 
-        assert lhs instanceof AggregateValue;
-
-        AggregateValue lhsAggregateValue = (AggregateValue) lhs;
-        this.memoryStack.push(lhsAggregateValue.getMemorySpace());
+        this.memoryStack.push(lhs.getMemorySpace());
         Value rhsValue = (Value) node.getRhs().accept(this);
         this.memoryStack.pop();
 

--- a/dsl/src/runtime/AggregateValue.java
+++ b/dsl/src/runtime/AggregateValue.java
@@ -47,7 +47,6 @@ public class AggregateValue extends Value {
      * @param ms the {@link IMemorySpace} to set as the memory space of this AggregateValue
      */
     public void setMemorySpace(IMemorySpace ms) {
-        // TODO: test this
         ms.delete(THIS_NAME);
         ms.bindValue(THIS_NAME, this);
         this.memorySpace = ms;

--- a/dsl/src/runtime/AggregateValue.java
+++ b/dsl/src/runtime/AggregateValue.java
@@ -6,13 +6,13 @@ import java.util.Map;
 import java.util.Set;
 
 public class AggregateValue extends Value {
-    protected IMemorySpace ms;
 
     /**
      * @return {@link IMemorySpace} holding the values of this AggregateValue
      */
+    @Override
     public IMemorySpace getMemorySpace() {
-        return ms;
+        return memorySpace;
     }
 
     /**
@@ -23,7 +23,7 @@ public class AggregateValue extends Value {
      */
     public AggregateValue(IType datatype, IMemorySpace parentSpace) {
         super(datatype, null);
-        this.ms = new MemorySpace(parentSpace);
+        initializeMemorySpace(parentSpace);
     }
 
     /**
@@ -35,14 +35,22 @@ public class AggregateValue extends Value {
      */
     public AggregateValue(IType datatype, IMemorySpace parentSpace, Object internalValue) {
         super(datatype, internalValue);
-        this.ms = new MemorySpace(parentSpace);
+        initializeMemorySpace(parentSpace);
+    }
+
+    private void initializeMemorySpace(IMemorySpace parentSpace) {
+        this.memorySpace = new MemorySpace(parentSpace);
+        this.memorySpace.bindValue(THIS_NAME, this);
     }
 
     /**
      * @param ms the {@link IMemorySpace} to set as the memory space of this AggregateValue
      */
     public void setMemorySpace(IMemorySpace ms) {
-        this.ms = ms;
+        // TODO: test this
+        ms.delete(THIS_NAME);
+        ms.bindValue(THIS_NAME, this);
+        this.memorySpace = ms;
     }
 
     /**

--- a/dsl/src/runtime/EncapsulatedObject.java
+++ b/dsl/src/runtime/EncapsulatedObject.java
@@ -163,7 +163,7 @@ public class EncapsulatedObject extends Value implements IMemorySpace {
             thisValue = Value.NONE;
         } else {
             throw new UnsupportedOperationException(
-                "Deleting a value from an Encapsulated Object is not supported!");
+                    "Deleting a value from an Encapsulated Object is not supported!");
         }
     }
 

--- a/dsl/src/runtime/EncapsulatedObject.java
+++ b/dsl/src/runtime/EncapsulatedObject.java
@@ -76,6 +76,10 @@ public class EncapsulatedObject extends Value implements IMemorySpace {
             return objectCache.get(name);
         }
 
+        if (name.equals(THIS_NAME)) {
+            return thisValue;
+        }
+
         // lookup name
         Field correspondingField = this.typeMemberToField.getOrDefault(name, null);
         if (correspondingField != null) {

--- a/dsl/src/runtime/EncapsulatedObject.java
+++ b/dsl/src/runtime/EncapsulatedObject.java
@@ -12,6 +12,7 @@ import java.util.Set;
 public class EncapsulatedObject extends Value implements IMemorySpace {
     private IMemorySpace parent;
     private AggregateType type;
+    private Value thisValue = Value.NONE;
 
     // TODO: this should be static for one aggregateType and not instanced for each new instance of
     //  the same type;
@@ -60,7 +61,12 @@ public class EncapsulatedObject extends Value implements IMemorySpace {
 
     @Override
     public boolean bindValue(String name, Value value) {
-        return false;
+        if (name.equals(THIS_NAME)) {
+            thisValue = value;
+            return true;
+        } else {
+            return false;
+        }
     }
 
     @Override
@@ -149,8 +155,12 @@ public class EncapsulatedObject extends Value implements IMemorySpace {
 
     @Override
     public void delete(String name) {
-        throw new UnsupportedOperationException(
+        if (name.equals(THIS_NAME)) {
+            thisValue = Value.NONE;
+        } else {
+            throw new UnsupportedOperationException(
                 "Deleting a value from an Encapsulated Object is not supported!");
+        }
     }
 
     // TODO: define the semantics for this based on, if the value is a POD type or
@@ -159,6 +169,11 @@ public class EncapsulatedObject extends Value implements IMemorySpace {
     //  (will be done in https://github.com/Programmiermethoden/Dungeon/issues/156)
     @Override
     public boolean setValue(String name, Value value) {
+        // handle this value
+        if (name.equals(THIS_NAME)) {
+            thisValue = value;
+        }
+
         Field correspondingField = this.typeMemberToField.getOrDefault(name, null);
         if (correspondingField == null) {
             return false;

--- a/dsl/src/runtime/GameEnvironment.java
+++ b/dsl/src/runtime/GameEnvironment.java
@@ -199,7 +199,7 @@ public class GameEnvironment implements IEvironment {
 
     protected void bindBuiltInProperties() {
         for (IDSLTypeProperty<?, ?> property : getBuiltInProperties()) {
-            this.typeBuilder.registerProperty(this.globalScope, property);
+            this.typeBuilder.bindProperty(this.globalScope, property);
         }
     }
 

--- a/dsl/src/runtime/ListValue.java
+++ b/dsl/src/runtime/ListValue.java
@@ -61,6 +61,7 @@ public class ListValue extends Value {
         list().clear();
     }
 
+    // region native_methods
     public static class AddMethod implements IInstanceCallable {
 
         public static AddMethod instance = new AddMethod();
@@ -113,4 +114,5 @@ public class ListValue extends Value {
             }
         }
     }
+    // endregion
 }

--- a/dsl/src/runtime/ListValue.java
+++ b/dsl/src/runtime/ListValue.java
@@ -77,4 +77,18 @@ public class ListValue extends Value {
             return null;
         }
     }
+
+    public static class SizeMethod implements IInstanceCallable {
+
+        public static SizeMethod instance = new SizeMethod();
+
+        private SizeMethod() {}
+
+        @Override
+        public Object call(DSLInterpreter interpreter, Object instance, List<Node> parameters) {
+            ListValue listValue = (ListValue) instance;
+
+            return listValue.list().size();
+        }
+    }
 }

--- a/dsl/src/runtime/ListValue.java
+++ b/dsl/src/runtime/ListValue.java
@@ -91,4 +91,26 @@ public class ListValue extends Value {
             return listValue.list().size();
         }
     }
+
+    public static class GetMethod implements IInstanceCallable {
+
+        public static GetMethod instance = new GetMethod();
+
+        private GetMethod() {}
+
+        @Override
+        public Object call(DSLInterpreter interpreter, Object instance, List<Node> parameters) {
+            ListValue listValue = (ListValue) instance;
+
+            Node indexParameterNode = parameters.get(0);
+            Value indexValue = (Value) indexParameterNode.accept(interpreter);
+            int index = (int) indexValue.getInternalValue();
+
+            if (index >= listValue.list().size()) {
+                return Value.NONE;
+            } else {
+                return listValue.list().get(index);
+            }
+        }
+    }
 }

--- a/dsl/src/runtime/ListValue.java
+++ b/dsl/src/runtime/ListValue.java
@@ -64,8 +64,8 @@ public class ListValue extends Value {
     // region native_methods
 
     /**
-     * Native method, which implements adding a Value to the internal {@link List}
-     * of a {@link ListValue}.
+     * Native method, which implements adding a Value to the internal {@link List} of a {@link
+     * ListValue}.
      */
     public static class AddMethod implements IInstanceCallable {
 
@@ -85,8 +85,8 @@ public class ListValue extends Value {
     }
 
     /**
-     * Native method, which implements calculating the size (i.e. the number of stored elements
-     * of a {@link ListValue}.
+     * Native method, which implements calculating the size (i.e. the number of stored elements of a
+     * {@link ListValue}.
      */
     public static class SizeMethod implements IInstanceCallable {
 
@@ -103,9 +103,9 @@ public class ListValue extends Value {
     }
 
     /**
-     * Native method, which implements the access to one element of a {@link ListValue} by index.
-     * If the index is out of range of the internal {@link List} of the {@link ListValue},
-     * {@link Value#NONE} is returned.
+     * Native method, which implements the access to one element of a {@link ListValue} by index. If
+     * the index is out of range of the internal {@link List} of the {@link ListValue}, {@link
+     * Value#NONE} is returned.
      */
     public static class GetMethod implements IInstanceCallable {
 

--- a/dsl/src/runtime/ListValue.java
+++ b/dsl/src/runtime/ListValue.java
@@ -62,6 +62,11 @@ public class ListValue extends Value {
     }
 
     // region native_methods
+
+    /**
+     * Native method, which implements adding a Value to the internal {@link List}
+     * of a {@link ListValue}.
+     */
     public static class AddMethod implements IInstanceCallable {
 
         public static AddMethod instance = new AddMethod();
@@ -79,6 +84,10 @@ public class ListValue extends Value {
         }
     }
 
+    /**
+     * Native method, which implements calculating the size (i.e. the number of stored elements
+     * of a {@link ListValue}.
+     */
     public static class SizeMethod implements IInstanceCallable {
 
         public static SizeMethod instance = new SizeMethod();
@@ -93,6 +102,11 @@ public class ListValue extends Value {
         }
     }
 
+    /**
+     * Native method, which implements the access to one element of a {@link ListValue} by index.
+     * If the index is out of range of the internal {@link List} of the {@link ListValue},
+     * {@link Value#NONE} is returned.
+     */
     public static class GetMethod implements IInstanceCallable {
 
         public static GetMethod instance = new GetMethod();

--- a/dsl/src/runtime/ListValue.java
+++ b/dsl/src/runtime/ListValue.java
@@ -1,6 +1,11 @@
 package runtime;
 
-import semanticanalysis.types.ListType;
+import interpreter.DSLInterpreter;
+
+import parser.ast.Node;
+
+import semanticanalysis.IInstanceCallable;
+import semanticanalysis.types.*;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -20,13 +25,17 @@ public class ListValue extends Value {
         return (ListType) this.dataType;
     }
 
+    protected ArrayList<Value> list() {
+        return (ArrayList<Value>) this.object;
+    }
+
     /**
      * Add a Value to the list
      *
      * @param value the value to add
      */
     public void addValue(Value value) {
-        ((ArrayList<Value>) this.object).add(value);
+        list().add(value);
     }
 
     /**
@@ -36,7 +45,7 @@ public class ListValue extends Value {
      * @return the Value at specified index
      */
     public Value getValue(int index) {
-        return ((ArrayList<Value>) this.object).get(index);
+        return list().get(index);
     }
 
     /**
@@ -45,11 +54,27 @@ public class ListValue extends Value {
      * @return the stored Values
      */
     public List<Value> getValues() {
-        return (List<Value>) this.object;
+        return list();
     }
 
     public void clearList() {
-        ((List<Value>) this.object).clear();
-        ;
+        list().clear();
+    }
+
+    public static class AddMethod implements IInstanceCallable {
+
+        public static AddMethod instance = new AddMethod();
+
+        private AddMethod() {}
+
+        @Override
+        public Object call(DSLInterpreter interpreter, Object instance, List<Node> parameters) {
+            ListValue listValue = (ListValue) instance;
+            Node paramNode = parameters.get(0);
+            Value paramValue = (Value) paramNode.accept(interpreter);
+
+            listValue.list().add(paramValue);
+            return null;
+        }
     }
 }

--- a/dsl/src/runtime/SetValue.java
+++ b/dsl/src/runtime/SetValue.java
@@ -42,7 +42,7 @@ public class SetValue extends Value {
         if (internalValueSet.contains(internalValue)) {
             return false;
         }
-        internalValueSet.add(object);
+        internalValueSet.add(internalValue);
         set().add(value);
         return true;
     }

--- a/dsl/src/runtime/SetValue.java
+++ b/dsl/src/runtime/SetValue.java
@@ -1,7 +1,9 @@
 package runtime;
 
 import interpreter.DSLInterpreter;
+
 import parser.ast.Node;
+
 import semanticanalysis.IInstanceCallable;
 import semanticanalysis.types.SetType;
 
@@ -29,7 +31,9 @@ public class SetValue extends Value {
         return (SetType) this.dataType;
     }
 
-    protected HashSet<Value> set() { return ((HashSet<Value>) this.object); }
+    protected HashSet<Value> set() {
+        return ((HashSet<Value>) this.object);
+    }
     /**
      * Add a Value to the set. The Value will only be added to the set, if no other Value with the
      * same internal value of the passed Value is already stored in this set.
@@ -57,7 +61,6 @@ public class SetValue extends Value {
     public void clearSet() {
         set().clear();
     }
-
 
     // region native_methods
     public static class AddMethod implements IInstanceCallable {

--- a/dsl/src/runtime/SetValue.java
+++ b/dsl/src/runtime/SetValue.java
@@ -63,6 +63,10 @@ public class SetValue extends Value {
     }
 
     // region native_methods
+    /**
+     * Native method, which implements adding a Value to the internal {@link Set}
+     * of a {@link SetValue}.
+     */
     public static class AddMethod implements IInstanceCallable {
 
         public static SetValue.AddMethod instance = new SetValue.AddMethod();
@@ -79,6 +83,10 @@ public class SetValue extends Value {
         }
     }
 
+    /**
+     * Native method, which implements calculating the size (i.e. the number of stored elements
+     * of a {@link SetValue}.
+     */
     public static class SizeMethod implements IInstanceCallable {
 
         public static SetValue.SizeMethod instance = new SetValue.SizeMethod();
@@ -93,6 +101,12 @@ public class SetValue extends Value {
         }
     }
 
+    /**
+     * Native method, which checks whether a given Value is present in the
+     * internal value set of a {@link SetValue}.
+     * Because different instances of {@link Value} can refer to the same internal value,
+     * the internal values are used for the lookup.
+     */
     public static class ContainsMethod implements IInstanceCallable {
 
         public static SetValue.ContainsMethod instance = new SetValue.ContainsMethod();

--- a/dsl/src/runtime/SetValue.java
+++ b/dsl/src/runtime/SetValue.java
@@ -1,8 +1,12 @@
 package runtime;
 
+import interpreter.DSLInterpreter;
+import parser.ast.Node;
+import semanticanalysis.IInstanceCallable;
 import semanticanalysis.types.SetType;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 /** Implements a set value */
@@ -25,6 +29,7 @@ public class SetValue extends Value {
         return (SetType) this.dataType;
     }
 
+    protected HashSet<Value> set() { return ((HashSet<Value>) this.object); }
     /**
      * Add a Value to the set. The Value will only be added to the set, if no other Value with the
      * same internal value of the passed Value is already stored in this set.
@@ -38,7 +43,7 @@ public class SetValue extends Value {
             return false;
         }
         internalValueSet.add(object);
-        ((HashSet<Value>) this.object).add(value);
+        set().add(value);
         return true;
     }
 
@@ -46,10 +51,61 @@ public class SetValue extends Value {
      * @return all stored values
      */
     public Set<Value> getValues() {
-        return (Set<Value>) this.object;
+        return set();
     }
 
     public void clearSet() {
-        ((Set<Value>) this.object).clear();
+        set().clear();
     }
+
+
+    // region native_methods
+    public static class AddMethod implements IInstanceCallable {
+
+        public static SetValue.AddMethod instance = new SetValue.AddMethod();
+
+        private AddMethod() {}
+
+        @Override
+        public Object call(DSLInterpreter interpreter, Object instance, List<Node> parameters) {
+            SetValue setValue = (SetValue) instance;
+            Node paramNode = parameters.get(0);
+            Value paramValue = (Value) paramNode.accept(interpreter);
+
+            return setValue.addValue(paramValue);
+        }
+    }
+
+    public static class SizeMethod implements IInstanceCallable {
+
+        public static SetValue.SizeMethod instance = new SetValue.SizeMethod();
+
+        private SizeMethod() {}
+
+        @Override
+        public Object call(DSLInterpreter interpreter, Object instance, List<Node> parameters) {
+            SetValue setValue = (SetValue) instance;
+
+            return setValue.set().size();
+        }
+    }
+
+    public static class ContainsMethod implements IInstanceCallable {
+
+        public static SetValue.ContainsMethod instance = new SetValue.ContainsMethod();
+
+        private ContainsMethod() {}
+
+        @Override
+        public Object call(DSLInterpreter interpreter, Object instance, List<Node> parameters) {
+            SetValue setValue = (SetValue) instance;
+
+            Node valueToCheckNode = parameters.get(0);
+            Value valueToCheck = (Value) valueToCheckNode.accept(interpreter);
+
+            return setValue.internalValueSet.contains(valueToCheck.getInternalValue());
+        }
+    }
+    // endregion
+
 }

--- a/dsl/src/runtime/SetValue.java
+++ b/dsl/src/runtime/SetValue.java
@@ -64,8 +64,8 @@ public class SetValue extends Value {
 
     // region native_methods
     /**
-     * Native method, which implements adding a Value to the internal {@link Set}
-     * of a {@link SetValue}.
+     * Native method, which implements adding a Value to the internal {@link Set} of a {@link
+     * SetValue}.
      */
     public static class AddMethod implements IInstanceCallable {
 
@@ -84,8 +84,8 @@ public class SetValue extends Value {
     }
 
     /**
-     * Native method, which implements calculating the size (i.e. the number of stored elements
-     * of a {@link SetValue}.
+     * Native method, which implements calculating the size (i.e. the number of stored elements of a
+     * {@link SetValue}.
      */
     public static class SizeMethod implements IInstanceCallable {
 
@@ -102,10 +102,9 @@ public class SetValue extends Value {
     }
 
     /**
-     * Native method, which checks whether a given Value is present in the
-     * internal value set of a {@link SetValue}.
-     * Because different instances of {@link Value} can refer to the same internal value,
-     * the internal values are used for the lookup.
+     * Native method, which checks whether a given Value is present in the internal value set of a
+     * {@link SetValue}. Because different instances of {@link Value} can refer to the same internal
+     * value, the internal values are used for the lookup.
      */
     public static class ContainsMethod implements IInstanceCallable {
 

--- a/dsl/src/runtime/Value.java
+++ b/dsl/src/runtime/Value.java
@@ -58,7 +58,6 @@ public class Value implements IClonable {
         this.dataType = type;
     }
 
-
     public IMemorySpace getMemorySpace() {
         if (this.memorySpace == null) {
             this.memorySpace = new MemorySpace();

--- a/dsl/src/runtime/Value.java
+++ b/dsl/src/runtime/Value.java
@@ -13,11 +13,13 @@ import semanticanalysis.types.IType;
  */
 public class Value implements IClonable {
     public static Value NONE = new Value(BuiltInType.noType, null, false);
+    public static String THIS_NAME = "$THIS$";
 
     protected IType dataType;
     protected Object object;
     protected final boolean isMutable;
     protected boolean dirty;
+    protected IMemorySpace memorySpace;
 
     /**
      * Indicates, if the internal value of this {@link Value} was set explicitly (e.g. in a
@@ -54,6 +56,15 @@ public class Value implements IClonable {
 
     public void setDataType(IType type) {
         this.dataType = type;
+    }
+
+
+    public IMemorySpace getMemorySpace() {
+        if (this.memorySpace == null) {
+            this.memorySpace = new MemorySpace();
+            this.memorySpace.bindValue(THIS_NAME, this);
+        }
+        return this.memorySpace;
     }
 
     /**

--- a/dsl/src/runtime/Value.java
+++ b/dsl/src/runtime/Value.java
@@ -59,9 +59,8 @@ public class Value implements IClonable {
     }
 
     /**
-     * Return the {@link IMemorySpace} associated with this Value.
-     * Basic Values only store a reference to themselves in this
-     * IMemorySpace. Therefore, it is only created on demand.
+     * Return the {@link IMemorySpace} associated with this Value. Basic Values only store a
+     * reference to themselves in this IMemorySpace. Therefore, it is only created on demand.
      *
      * @return the IMemorySpace associated with this Value
      */

--- a/dsl/src/runtime/Value.java
+++ b/dsl/src/runtime/Value.java
@@ -58,6 +58,13 @@ public class Value implements IClonable {
         this.dataType = type;
     }
 
+    /**
+     * Return the {@link IMemorySpace} associated with this Value.
+     * Basic Values only store a reference to themselves in this
+     * IMemorySpace. Therefore, it is only created on demand.
+     *
+     * @return the IMemorySpace associated with this Value
+     */
     public IMemorySpace getMemorySpace() {
         if (this.memorySpace == null) {
             this.memorySpace = new MemorySpace();

--- a/dsl/src/runtime/nativefunctions/ExtensionMethod.java
+++ b/dsl/src/runtime/nativefunctions/ExtensionMethod.java
@@ -15,13 +15,13 @@ import semanticanalysis.types.IDSLExtensionMethod;
 import java.util.List;
 
 public class ExtensionMethod extends Symbol implements ICallable {
-    private final IDSLExtensionMethod<Object> extensionMethod;
+    private final IDSLExtensionMethod<Object, Object> extensionMethod;
 
     public ExtensionMethod(
             String name,
             IScope parentScope,
             FunctionType functionType,
-            IDSLExtensionMethod<Object> callable) {
+            IDSLExtensionMethod<Object, Object> callable) {
         super(name, parentScope, functionType);
         this.extensionMethod = callable;
     }

--- a/dsl/src/runtime/nativefunctions/ExtensionMethod.java
+++ b/dsl/src/runtime/nativefunctions/ExtensionMethod.java
@@ -1,0 +1,54 @@
+package runtime.nativefunctions;
+
+import interpreter.DSLInterpreter;
+
+import parser.ast.Node;
+
+import runtime.Value;
+
+import semanticanalysis.ICallable;
+import semanticanalysis.IScope;
+import semanticanalysis.Symbol;
+import semanticanalysis.types.FunctionType;
+import semanticanalysis.types.IDSLExtensionMethod;
+
+import java.util.List;
+
+public class ExtensionMethod extends Symbol implements ICallable {
+    private final IDSLExtensionMethod<Object> extensionMethod;
+
+    public ExtensionMethod(
+            String name,
+            IScope parentScope,
+            FunctionType functionType,
+            IDSLExtensionMethod<Object> callable) {
+        super(name, parentScope, functionType);
+        this.extensionMethod = callable;
+    }
+
+    @Override
+    public Object call(DSLInterpreter interperter, List<Node> parameters) {
+        // resolve "THIS_VALUE"
+        Value instance = interperter.getCurrentMemorySpace().resolve(Value.THIS_NAME);
+        Object instanceObject = instance.getInternalValue();
+
+        // interpret parameters and extract internal values
+        List<Object> parameterObjects =
+                parameters.stream()
+                        .map(p -> p.accept(interperter))
+                        .map(o -> ((Value) o).getInternalValue())
+                        .toList();
+
+        return this.extensionMethod.call(interperter, instanceObject, parameterObjects);
+    }
+
+    @Override
+    public ICallable.Type getCallableType() {
+        return null;
+    }
+
+    @Override
+    public FunctionType getFunctionType() {
+        return null;
+    }
+}

--- a/dsl/src/runtime/nativefunctions/ExtensionMethod.java
+++ b/dsl/src/runtime/nativefunctions/ExtensionMethod.java
@@ -52,7 +52,7 @@ public class ExtensionMethod extends Symbol implements ICallable {
                         .map(o -> ((Value) o).getInternalValue())
                         .toList();
 
-        return this.extensionMethod.call(interperter, instanceObject, parameterObjects);
+        return this.extensionMethod.call(instanceObject, parameterObjects);
     }
 
     @Override

--- a/dsl/src/runtime/nativefunctions/ExtensionMethod.java
+++ b/dsl/src/runtime/nativefunctions/ExtensionMethod.java
@@ -15,9 +15,9 @@ import semanticanalysis.types.IDSLExtensionMethod;
 import java.util.List;
 
 /**
- * {@link ICallable} implementation for an {@link IDSLExtensionMethod}.
- * It is used for binding {@link IDSLExtensionMethod} implementations as symbols in a
- * DSL data type, which is created from a java class.
+ * {@link ICallable} implementation for an {@link IDSLExtensionMethod}. It is used for binding
+ * {@link IDSLExtensionMethod} implementations as symbols in a DSL data type, which is created from
+ * a java class.
  */
 public class ExtensionMethod extends Symbol implements ICallable {
     private final IDSLExtensionMethod<Object, Object> extensionMethod;
@@ -27,8 +27,10 @@ public class ExtensionMethod extends Symbol implements ICallable {
      *
      * @param name The name of the method
      * @param parentScope The parent scope of this symbol
-     * @param functionType The {@link FunctionType} containing the signature information of the method
-     * @param callable The {@link IDSLExtensionMethod}, which contains the actual implementation of the method's logic
+     * @param functionType The {@link FunctionType} containing the signature information of the
+     *     method
+     * @param callable The {@link IDSLExtensionMethod}, which contains the actual implementation of
+     *     the method's logic
      */
     public ExtensionMethod(
             String name,

--- a/dsl/src/runtime/nativefunctions/ExtensionMethod.java
+++ b/dsl/src/runtime/nativefunctions/ExtensionMethod.java
@@ -14,9 +14,22 @@ import semanticanalysis.types.IDSLExtensionMethod;
 
 import java.util.List;
 
+/**
+ * {@link ICallable} implementation for an {@link IDSLExtensionMethod}.
+ * It is used for binding {@link IDSLExtensionMethod} implementations as symbols in a
+ * DSL data type, which is created from a java class.
+ */
 public class ExtensionMethod extends Symbol implements ICallable {
     private final IDSLExtensionMethod<Object, Object> extensionMethod;
 
+    /**
+     * Constructor.
+     *
+     * @param name The name of the method
+     * @param parentScope The parent scope of this symbol
+     * @param functionType The {@link FunctionType} containing the signature information of the method
+     * @param callable The {@link IDSLExtensionMethod}, which contains the actual implementation of the method's logic
+     */
     public ExtensionMethod(
             String name,
             IScope parentScope,

--- a/dsl/src/runtime/nativefunctions/NativeMethod.java
+++ b/dsl/src/runtime/nativefunctions/NativeMethod.java
@@ -1,0 +1,44 @@
+package runtime.nativefunctions;
+
+import interpreter.DSLInterpreter;
+
+import parser.ast.Node;
+
+import runtime.Value;
+import semanticanalysis.ICallable;
+import semanticanalysis.IInstanceCallable;
+import semanticanalysis.IScope;
+import semanticanalysis.Symbol;
+import semanticanalysis.types.FunctionType;
+
+import java.util.List;
+
+public class NativeMethod extends Symbol implements ICallable {
+    private final IInstanceCallable instanceCallable;
+
+    public NativeMethod(
+            String name,
+            IScope parentScope,
+            FunctionType functionType,
+            IInstanceCallable callable) {
+        super(name, parentScope, functionType);
+        this.instanceCallable = callable;
+    }
+
+    @Override
+    public Object call(DSLInterpreter interperter, List<Node> parameters) {
+        // resolve "THIS_VALUE"
+        Value instance = interperter.getCurrentMemorySpace().resolve(Value.THIS_NAME);
+        return this.instanceCallable.call(interperter, instance, parameters);
+    }
+
+    @Override
+    public ICallable.Type getCallableType() {
+        return null;
+    }
+
+    @Override
+    public FunctionType getFunctionType() {
+        return null;
+    }
+}

--- a/dsl/src/runtime/nativefunctions/NativeMethod.java
+++ b/dsl/src/runtime/nativefunctions/NativeMethod.java
@@ -5,6 +5,7 @@ import interpreter.DSLInterpreter;
 import parser.ast.Node;
 
 import runtime.Value;
+
 import semanticanalysis.ICallable;
 import semanticanalysis.IInstanceCallable;
 import semanticanalysis.IScope;

--- a/dsl/src/runtime/nativefunctions/NativeMethod.java
+++ b/dsl/src/runtime/nativefunctions/NativeMethod.java
@@ -11,12 +11,27 @@ import semanticanalysis.IInstanceCallable;
 import semanticanalysis.IScope;
 import semanticanalysis.Symbol;
 import semanticanalysis.types.FunctionType;
+import semanticanalysis.types.IDSLExtensionMethod;
 
 import java.util.List;
 
+ /**
+  * {@link ICallable} implementation for native methods, which are an integral built-in
+  * part of the DungeonDSL.
+  * It is used for binding {@link IInstanceCallable} implementations as symbols in a
+  * DSL data type.
+  */
 public class NativeMethod extends Symbol implements ICallable {
     private final IInstanceCallable instanceCallable;
 
+     /**
+      * Constructor.
+      *
+      * @param name The name of the method
+      * @param parentScope The parent scope of this symbol
+      * @param functionType The {@link FunctionType} containing the signature information of the method
+      * @param callable The {@link IInstanceCallable}, which contains the actual implementation of the method's logic
+      */
     public NativeMethod(
             String name,
             IScope parentScope,

--- a/dsl/src/runtime/nativefunctions/NativeMethod.java
+++ b/dsl/src/runtime/nativefunctions/NativeMethod.java
@@ -11,27 +11,27 @@ import semanticanalysis.IInstanceCallable;
 import semanticanalysis.IScope;
 import semanticanalysis.Symbol;
 import semanticanalysis.types.FunctionType;
-import semanticanalysis.types.IDSLExtensionMethod;
 
 import java.util.List;
 
- /**
-  * {@link ICallable} implementation for native methods, which are an integral built-in
-  * part of the DungeonDSL.
-  * It is used for binding {@link IInstanceCallable} implementations as symbols in a
-  * DSL data type.
-  */
+/**
+ * {@link ICallable} implementation for native methods, which are an integral built-in part of the
+ * DungeonDSL. It is used for binding {@link IInstanceCallable} implementations as symbols in a DSL
+ * data type.
+ */
 public class NativeMethod extends Symbol implements ICallable {
     private final IInstanceCallable instanceCallable;
 
-     /**
-      * Constructor.
-      *
-      * @param name The name of the method
-      * @param parentScope The parent scope of this symbol
-      * @param functionType The {@link FunctionType} containing the signature information of the method
-      * @param callable The {@link IInstanceCallable}, which contains the actual implementation of the method's logic
-      */
+    /**
+     * Constructor.
+     *
+     * @param name The name of the method
+     * @param parentScope The parent scope of this symbol
+     * @param functionType The {@link FunctionType} containing the signature information of the
+     *     method
+     * @param callable The {@link IInstanceCallable}, which contains the actual implementation of
+     *     the method's logic
+     */
     public NativeMethod(
             String name,
             IScope parentScope,

--- a/dsl/src/semanticanalysis/IInstanceCallable.java
+++ b/dsl/src/semanticanalysis/IInstanceCallable.java
@@ -7,9 +7,9 @@ import parser.ast.Node;
 import java.util.List;
 
 /**
- * Simple interface for methods, which require an instance for context.
- * This interface is used for built-in native methods only, for external methods,
- * use {@link semanticanalysis.types.IDSLExtensionMethod}!
+ * Simple interface for methods, which require an instance for context. This interface is used for
+ * built-in native methods only, for external methods, use {@link
+ * semanticanalysis.types.IDSLExtensionMethod}!
  */
 public interface IInstanceCallable {
     Object call(DSLInterpreter interpreter, Object instance, List<Node> parameters);

--- a/dsl/src/semanticanalysis/IInstanceCallable.java
+++ b/dsl/src/semanticanalysis/IInstanceCallable.java
@@ -6,6 +6,11 @@ import parser.ast.Node;
 
 import java.util.List;
 
+/**
+ * Simple interface for methods, which require an instance for context.
+ * This interface is used for built-in native methods only, for external methods,
+ * use {@link semanticanalysis.types.IDSLExtensionMethod}!
+ */
 public interface IInstanceCallable {
     Object call(DSLInterpreter interpreter, Object instance, List<Node> parameters);
 }

--- a/dsl/src/semanticanalysis/IInstanceCallable.java
+++ b/dsl/src/semanticanalysis/IInstanceCallable.java
@@ -1,0 +1,11 @@
+package semanticanalysis;
+
+import interpreter.DSLInterpreter;
+
+import parser.ast.Node;
+
+import java.util.List;
+
+public interface IInstanceCallable {
+    Object call(DSLInterpreter interpreter, Object instance, List<Node> parameters);
+}

--- a/dsl/src/semanticanalysis/SemanticAnalyzer.java
+++ b/dsl/src/semanticanalysis/SemanticAnalyzer.java
@@ -338,8 +338,7 @@ public class SemanticAnalyzer implements AstVisitor<Void> {
         }
 
         if (!(funcSymbol instanceof ICallable)) {
-            throw new RuntimeException(
-                "Symbol with name " + funcName + " is not callable!");
+            throw new RuntimeException("Symbol with name " + funcName + " is not callable!");
         }
 
         this.symbolTable.addSymbolNodeRelation(funcSymbol, node, false);
@@ -445,6 +444,9 @@ public class SemanticAnalyzer implements AstVisitor<Void> {
         IType lhsDataType = BuiltInType.noType;
         if (lhs.type.equals(Node.Type.Identifier)) {
             String nameToResolve = ((IdNode) lhs).getName();
+            if (nameToResolve.equals("ent")) {
+                boolean b = true;
+            }
             Symbol symbol = this.currentScope().resolve(nameToResolve);
             lhsDataType = symbol.getDataType();
 

--- a/dsl/src/semanticanalysis/SemanticAnalyzer.java
+++ b/dsl/src/semanticanalysis/SemanticAnalyzer.java
@@ -444,9 +444,6 @@ public class SemanticAnalyzer implements AstVisitor<Void> {
         IType lhsDataType = BuiltInType.noType;
         if (lhs.type.equals(Node.Type.Identifier)) {
             String nameToResolve = ((IdNode) lhs).getName();
-            if (nameToResolve.equals("ent")) {
-                boolean b = true;
-            }
             Symbol symbol = this.currentScope().resolve(nameToResolve);
             lhsDataType = symbol.getDataType();
 

--- a/dsl/src/semanticanalysis/SemanticAnalyzer.java
+++ b/dsl/src/semanticanalysis/SemanticAnalyzer.java
@@ -330,13 +330,18 @@ public class SemanticAnalyzer implements AstVisitor<Void> {
     public Void visit(FuncCallNode node) {
         // resolve function definition in global scope
         String funcName = node.getIdName();
-        var funcSymbol = this.symbolTable.globalScope.resolve(funcName);
+
+        var funcSymbol = currentScope().resolve(funcName, true);
         if (funcSymbol.equals(Symbol.NULL)) {
             throw new RuntimeException(
-                    "Function with name " + funcName + " could not be resolved in global scope");
+                    "Function with name " + funcName + " could not be resolved!");
         }
 
-        assert funcSymbol.getSymbolType() == Symbol.Type.Scoped;
+        if (!(funcSymbol instanceof ICallable)) {
+            throw new RuntimeException(
+                "Symbol with name " + funcName + " is not callable!");
+        }
+
         this.symbolTable.addSymbolNodeRelation(funcSymbol, node, false);
 
         for (var parameter : node.getParameters()) {

--- a/dsl/src/semanticanalysis/types/DSLExtensionMethod.java
+++ b/dsl/src/semanticanalysis/types/DSLExtensionMethod.java
@@ -5,9 +5,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-/**
- * Annotation to mark an {@link IDSLExtensionMethod} implementation.
- */
+/** Annotation to mark an {@link IDSLExtensionMethod} implementation. */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE})
 public @interface DSLExtensionMethod {

--- a/dsl/src/semanticanalysis/types/DSLExtensionMethod.java
+++ b/dsl/src/semanticanalysis/types/DSLExtensionMethod.java
@@ -1,0 +1,26 @@
+package semanticanalysis.types;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE})
+public @interface DSLExtensionMethod {
+    /**
+     * The name of the property, by which it should be accessible in a DSL program.
+     *
+     * @return the name.
+     */
+    String name();
+
+    /**
+     * The Java-Class corresponding to the the dsl type, which should be extended by this property.
+     *
+     * <p>For {@link AggregateTypeAdapter} instances, this should be the adapter-class.
+     *
+     * @return
+     */
+    Class<?> extendedType();
+}

--- a/dsl/src/semanticanalysis/types/DSLExtensionMethod.java
+++ b/dsl/src/semanticanalysis/types/DSLExtensionMethod.java
@@ -5,22 +5,23 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * Annotation to mark an {@link IDSLExtensionMethod} implementation.
+ */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE})
 public @interface DSLExtensionMethod {
     /**
-     * The name of the property, by which it should be accessible in a DSL program.
+     * The name of the extension method, by which it should be accessible in a DSL program.
      *
      * @return the name.
      */
     String name();
 
     /**
-     * The Java-Class corresponding to the the dsl type, which should be extended by this property.
+     * The Java-Class corresponding to the dsl type, which should be extended by this method.
      *
      * <p>For {@link AggregateTypeAdapter} instances, this should be the adapter-class.
-     *
-     * @return
      */
     Class<?> extendedType();
 }

--- a/dsl/src/semanticanalysis/types/FunctionType.java
+++ b/dsl/src/semanticanalysis/types/FunctionType.java
@@ -6,6 +6,7 @@ import semanticanalysis.Symbol;
 import java.util.ArrayList;
 import java.util.List;
 
+// TODO: extend this for named parameters
 public class FunctionType extends Symbol implements IType {
     private final IType returnType;
     private final ArrayList<IType> parameterTypes;
@@ -42,13 +43,13 @@ public class FunctionType extends Symbol implements IType {
         this.parameterTypes = new ArrayList<>(List.of(parameterTypes));
     }
 
-    public FunctionType(IType returnType, ArrayList<IType> parameterTypes) {
+    public FunctionType(IType returnType, List<IType> parameterTypes) {
         super(calculateTypeName(returnType, parameterTypes), Scope.NULL, null);
         this.returnType = returnType;
-        this.parameterTypes = parameterTypes;
+        this.parameterTypes = new ArrayList<>(parameterTypes);
     }
 
-    public static String calculateTypeName(IType returnType, ArrayList<IType> parameterTypes) {
+    public static String calculateTypeName(IType returnType, List<IType> parameterTypes) {
         StringBuilder nameBuilder = new StringBuilder();
         nameBuilder.append("$fn(");
         for (int i = 0; i < parameterTypes.size(); i++) {

--- a/dsl/src/semanticanalysis/types/IDSLExtensionMethod.java
+++ b/dsl/src/semanticanalysis/types/IDSLExtensionMethod.java
@@ -19,12 +19,11 @@ public interface IDSLExtensionMethod<T, R> {
     /**
      * Implementation of the method's logic.
      *
-     * @param interpreter DSLInterpreter to use for interpretation (TODO: remove)
      * @param instance the object, which provides the context for the method execution
-     * @param params the List of parameters for the method call.
+     * @param params   the List of parameters for the method call.
      * @return The return value of the method call.
      */
-    R call(DSLInterpreter interpreter, T instance, List<Object> params);
+    R call(T instance, List<Object> params);
 
     /**
      * Should return an in-order list of the classes, which will be used for the parameters.

--- a/dsl/src/semanticanalysis/types/IDSLExtensionMethod.java
+++ b/dsl/src/semanticanalysis/types/IDSLExtensionMethod.java
@@ -1,0 +1,19 @@
+package semanticanalysis.types;
+
+import interpreter.DSLInterpreter;
+
+import java.util.List;
+
+/**
+ * A {@link IDSLExtensionMethod}
+ *
+ * @param <T> type of the instance in which to access the method
+ */
+public interface IDSLExtensionMethod<T> {
+    // TODO: generify return value
+    Object call(DSLInterpreter interpreter, T instance, List<Object> params);
+
+    List<Class<?>> getParameterTypes();
+
+    Class<?> getReturnType();
+}

--- a/dsl/src/semanticanalysis/types/IDSLExtensionMethod.java
+++ b/dsl/src/semanticanalysis/types/IDSLExtensionMethod.java
@@ -5,12 +5,29 @@ import interpreter.DSLInterpreter;
 import java.util.List;
 
 /**
- * A {@link IDSLExtensionMethod}
+ * A {@link IDSLExtensionMethod} is used to implement a method (instance-function) of
+ * a DSL data type created from a java class annotated by {@link DSLType}. It differs from
+ * {@link semanticanalysis.IInstanceCallable} in the aspect, that the parameters are passed
+ * to the method as objects, which do not need to be interpreted by a {@link DSLInterpreter}.
+ * The parameters are passed as a {@link List}.
  *
- * @param <T> type of the instance in which to access the method
+ * @param <T> type of the instance in which to access the method.
+ * @param <R> type of the return value of the method
  */
 public interface IDSLExtensionMethod<T, R> {
+
+    /**
+     * Implementation of the method's logic.
+     *
+     * @param interpreter DSLInterpreter to use for interpretation (TODO: remove)
+     * @param instance the object, which provides the context for the method execution
+     * @param params the List of parameters for the method call.
+     * @return The return value of the method call.
+     */
     R call(DSLInterpreter interpreter, T instance, List<Object> params);
 
+    /**
+     * Should return an in-order list of the classes, which will be used for the parameters.
+     */
     List<Class<?>> getParameterTypes();
 }

--- a/dsl/src/semanticanalysis/types/IDSLExtensionMethod.java
+++ b/dsl/src/semanticanalysis/types/IDSLExtensionMethod.java
@@ -9,11 +9,8 @@ import java.util.List;
  *
  * @param <T> type of the instance in which to access the method
  */
-public interface IDSLExtensionMethod<T> {
-    // TODO: generify return value
-    Object call(DSLInterpreter interpreter, T instance, List<Object> params);
+public interface IDSLExtensionMethod<T, R> {
+    R call(DSLInterpreter interpreter, T instance, List<Object> params);
 
     List<Class<?>> getParameterTypes();
-
-    Class<?> getReturnType();
 }

--- a/dsl/src/semanticanalysis/types/IDSLExtensionMethod.java
+++ b/dsl/src/semanticanalysis/types/IDSLExtensionMethod.java
@@ -5,11 +5,11 @@ import interpreter.DSLInterpreter;
 import java.util.List;
 
 /**
- * A {@link IDSLExtensionMethod} is used to implement a method (instance-function) of
- * a DSL data type created from a java class annotated by {@link DSLType}. It differs from
- * {@link semanticanalysis.IInstanceCallable} in the aspect, that the parameters are passed
- * to the method as objects, which do not need to be interpreted by a {@link DSLInterpreter}.
- * The parameters are passed as a {@link List}.
+ * A {@link IDSLExtensionMethod} is used to implement a method (instance-function) of a DSL data
+ * type created from a java class annotated by {@link DSLType}. It differs from {@link
+ * semanticanalysis.IInstanceCallable} in the aspect, that the parameters are passed to the method
+ * as objects, which do not need to be interpreted by a {@link DSLInterpreter}. The parameters are
+ * passed as a {@link List}.
  *
  * @param <T> type of the instance in which to access the method.
  * @param <R> type of the return value of the method
@@ -20,13 +20,11 @@ public interface IDSLExtensionMethod<T, R> {
      * Implementation of the method's logic.
      *
      * @param instance the object, which provides the context for the method execution
-     * @param params   the List of parameters for the method call.
+     * @param params the List of parameters for the method call.
      * @return The return value of the method call.
      */
     R call(T instance, List<Object> params);
 
-    /**
-     * Should return an in-order list of the classes, which will be used for the parameters.
-     */
+    /** Should return an in-order list of the classes, which will be used for the parameters. */
     List<Class<?>> getParameterTypes();
 }

--- a/dsl/src/semanticanalysis/types/ListType.java
+++ b/dsl/src/semanticanalysis/types/ListType.java
@@ -35,11 +35,11 @@ public class ListType extends ScopedSymbol implements IType {
         this.bind(sizeMethod);
 
         NativeMethod getMethod =
-            new NativeMethod(
-                "get",
-                this,
-                new FunctionType(elementType, BuiltInType.intType),
-                ListValue.GetMethod.instance);
+                new NativeMethod(
+                        "get",
+                        this,
+                        new FunctionType(elementType, BuiltInType.intType),
+                        ListValue.GetMethod.instance);
         this.bind(getMethod);
     }
 

--- a/dsl/src/semanticanalysis/types/ListType.java
+++ b/dsl/src/semanticanalysis/types/ListType.java
@@ -27,12 +27,20 @@ public class ListType extends ScopedSymbol implements IType {
         this.bind(addMethod);
 
         NativeMethod sizeMethod =
-            new NativeMethod(
-                "size",
-                this,
-                new FunctionType(BuiltInType.intType, BuiltInType.noType),
-                ListValue.SizeMethod.instance);
+                new NativeMethod(
+                        "size",
+                        this,
+                        new FunctionType(BuiltInType.intType, BuiltInType.noType),
+                        ListValue.SizeMethod.instance);
         this.bind(sizeMethod);
+
+        NativeMethod getMethod =
+            new NativeMethod(
+                "get",
+                this,
+                new FunctionType(elementType, BuiltInType.intType),
+                ListValue.GetMethod.instance);
+        this.bind(getMethod);
     }
 
     @Override

--- a/dsl/src/semanticanalysis/types/ListType.java
+++ b/dsl/src/semanticanalysis/types/ListType.java
@@ -1,10 +1,12 @@
 package semanticanalysis.types;
 
-import semanticanalysis.IScope;
-import semanticanalysis.Symbol;
+import runtime.ListValue;
+import runtime.nativefunctions.NativeMethod;
 
-public class ListType extends Symbol implements IType {
-    // private final IType elementType;
+import semanticanalysis.IScope;
+import semanticanalysis.ScopedSymbol;
+
+public class ListType extends ScopedSymbol implements IType {
     public IType getElementType() {
         return this.dataType;
     }
@@ -14,9 +16,15 @@ public class ListType extends Symbol implements IType {
     }
 
     public ListType(IType elementType, IScope parentScope) {
-        this.name = getListTypeName(elementType);
-        this.dataType = elementType;
-        this.scope = parentScope;
+        super(getListTypeName(elementType), parentScope, elementType);
+
+        NativeMethod addMehod =
+                new NativeMethod(
+                        "add",
+                        this,
+                        new FunctionType(BuiltInType.noType, elementType),
+                        ListValue.AddMethod.instance);
+        this.bind(addMehod);
     }
 
     @Override

--- a/dsl/src/semanticanalysis/types/ListType.java
+++ b/dsl/src/semanticanalysis/types/ListType.java
@@ -18,13 +18,21 @@ public class ListType extends ScopedSymbol implements IType {
     public ListType(IType elementType, IScope parentScope) {
         super(getListTypeName(elementType), parentScope, elementType);
 
-        NativeMethod addMehod =
+        NativeMethod addMethod =
                 new NativeMethod(
                         "add",
                         this,
                         new FunctionType(BuiltInType.noType, elementType),
                         ListValue.AddMethod.instance);
-        this.bind(addMehod);
+        this.bind(addMethod);
+
+        NativeMethod sizeMethod =
+            new NativeMethod(
+                "size",
+                this,
+                new FunctionType(BuiltInType.intType, BuiltInType.noType),
+                ListValue.SizeMethod.instance);
+        this.bind(sizeMethod);
     }
 
     @Override

--- a/dsl/src/semanticanalysis/types/SetType.java
+++ b/dsl/src/semanticanalysis/types/SetType.java
@@ -1,9 +1,11 @@
 package semanticanalysis.types;
 
+import runtime.SetValue;
+import runtime.nativefunctions.NativeMethod;
 import semanticanalysis.IScope;
-import semanticanalysis.Symbol;
+import semanticanalysis.ScopedSymbol;
 
-public class SetType extends Symbol implements IType {
+public class SetType extends ScopedSymbol implements IType {
     // private final IType elementType;
     public IType getElementType() {
         return this.dataType;
@@ -14,9 +16,31 @@ public class SetType extends Symbol implements IType {
     }
 
     public SetType(IType elementType, IScope parentScope) {
-        this.name = getSetTypeName(elementType);
-        this.dataType = elementType;
-        this.scope = parentScope;
+        super(getSetTypeName(elementType), parentScope, elementType);
+
+        NativeMethod addMethod =
+            new NativeMethod(
+                "add",
+                this,
+                new FunctionType(BuiltInType.boolType, elementType),
+                SetValue.AddMethod.instance);
+        this.bind(addMethod);
+
+        NativeMethod sizeMethod =
+            new NativeMethod(
+                "size",
+                this,
+                new FunctionType(BuiltInType.intType, BuiltInType.noType),
+                SetValue.SizeMethod.instance);
+        this.bind(sizeMethod);
+
+        NativeMethod getMethod =
+            new NativeMethod(
+                "contains",
+                this,
+                new FunctionType(BuiltInType.boolType, elementType),
+                SetValue.ContainsMethod.instance);
+        this.bind(getMethod);
     }
 
     @Override

--- a/dsl/src/semanticanalysis/types/SetType.java
+++ b/dsl/src/semanticanalysis/types/SetType.java
@@ -2,6 +2,7 @@ package semanticanalysis.types;
 
 import runtime.SetValue;
 import runtime.nativefunctions.NativeMethod;
+
 import semanticanalysis.IScope;
 import semanticanalysis.ScopedSymbol;
 
@@ -19,27 +20,27 @@ public class SetType extends ScopedSymbol implements IType {
         super(getSetTypeName(elementType), parentScope, elementType);
 
         NativeMethod addMethod =
-            new NativeMethod(
-                "add",
-                this,
-                new FunctionType(BuiltInType.boolType, elementType),
-                SetValue.AddMethod.instance);
+                new NativeMethod(
+                        "add",
+                        this,
+                        new FunctionType(BuiltInType.boolType, elementType),
+                        SetValue.AddMethod.instance);
         this.bind(addMethod);
 
         NativeMethod sizeMethod =
-            new NativeMethod(
-                "size",
-                this,
-                new FunctionType(BuiltInType.intType, BuiltInType.noType),
-                SetValue.SizeMethod.instance);
+                new NativeMethod(
+                        "size",
+                        this,
+                        new FunctionType(BuiltInType.intType, BuiltInType.noType),
+                        SetValue.SizeMethod.instance);
         this.bind(sizeMethod);
 
         NativeMethod getMethod =
-            new NativeMethod(
-                "contains",
-                this,
-                new FunctionType(BuiltInType.boolType, elementType),
-                SetValue.ContainsMethod.instance);
+                new NativeMethod(
+                        "contains",
+                        this,
+                        new FunctionType(BuiltInType.boolType, elementType),
+                        SetValue.ContainsMethod.instance);
         this.bind(getMethod);
     }
 

--- a/dsl/src/semanticanalysis/types/TypeBuilder.java
+++ b/dsl/src/semanticanalysis/types/TypeBuilder.java
@@ -406,7 +406,10 @@ public class TypeBuilder {
      * @param type the java {@link Type} to create a DSL {@link IType} from
      */
     public IType createDSLTypeForJavaTypeInScope(IScope globalScope, Type type) {
-        // TODO: test for type = null
+        if (type == null) {
+            return BuiltInType.noType;
+        }
+
         // catch recursion
         if (this.currentLookedUpTypes.contains(type)) {
             throw new RuntimeException("RECURSIVE TYPE DEF");

--- a/dsl/src/semanticanalysis/types/TypeBuilder.java
+++ b/dsl/src/semanticanalysis/types/TypeBuilder.java
@@ -492,7 +492,14 @@ public class TypeBuilder {
         return aggregateType;
     }
 
-    public void registerProperty(IScope globalScope, IDSLTypeProperty<?, ?> property) {
+    /**
+     * Bind a {@link IDSLTypeProperty} as an {@link PropertySymbol} in the DSL
+     * datatype corresponding to the {@link DSLTypeProperty#extendedType()} field.
+     *
+     * @param globalScope the global scope to use for resolving data types
+     * @param property the {@link IDSLTypeProperty} to bind
+     */
+    public void bindProperty(IScope globalScope, IDSLTypeProperty<?, ?> property) {
         // get extended type
         Class<?> propertyClass = property.getClass();
         if (propertyClass.isAnnotationPresent(DSLTypeProperty.class)) {
@@ -517,7 +524,14 @@ public class TypeBuilder {
         }
     }
 
-    public void registerMethod(IScope globalScope, IDSLExtensionMethod<?, ?> method) {
+    /**
+     * Bind a {@link IDSLExtensionMethod} as an {@link ExtensionMethod} symbol in the DSL
+     * datatype corresponding to the {@link DSLExtensionMethod#extendedType()} field.
+     *
+     * @param globalScope the global scope to use for resolving data types
+     * @param method the {@link IDSLExtensionMethod} to bind
+     */
+    public void bindMethod(IScope globalScope, IDSLExtensionMethod<?, ?> method) {
         // get extended type
         Class<?> methodClass = method.getClass();
         if (methodClass.isAnnotationPresent(DSLExtensionMethod.class)) {

--- a/dsl/src/semanticanalysis/types/TypeBuilder.java
+++ b/dsl/src/semanticanalysis/types/TypeBuilder.java
@@ -493,8 +493,8 @@ public class TypeBuilder {
     }
 
     /**
-     * Bind a {@link IDSLTypeProperty} as an {@link PropertySymbol} in the DSL
-     * datatype corresponding to the {@link DSLTypeProperty#extendedType()} field.
+     * Bind a {@link IDSLTypeProperty} as an {@link PropertySymbol} in the DSL datatype
+     * corresponding to the {@link DSLTypeProperty#extendedType()} field.
      *
      * @param globalScope the global scope to use for resolving data types
      * @param property the {@link IDSLTypeProperty} to bind
@@ -525,8 +525,8 @@ public class TypeBuilder {
     }
 
     /**
-     * Bind a {@link IDSLExtensionMethod} as an {@link ExtensionMethod} symbol in the DSL
-     * datatype corresponding to the {@link DSLExtensionMethod#extendedType()} field.
+     * Bind a {@link IDSLExtensionMethod} as an {@link ExtensionMethod} symbol in the DSL datatype
+     * corresponding to the {@link DSLExtensionMethod#extendedType()} field.
      *
      * @param globalScope the global scope to use for resolving data types
      * @param method the {@link IDSLExtensionMethod} to bind

--- a/dsl/src/semanticanalysis/types/TypeBuilder.java
+++ b/dsl/src/semanticanalysis/types/TypeBuilder.java
@@ -406,6 +406,7 @@ public class TypeBuilder {
      * @param type the java {@link Type} to create a DSL {@link IType} from
      */
     public IType createDSLTypeForJavaTypeInScope(IScope globalScope, Type type) {
+        // TODO: test for type = null
         // catch recursion
         if (this.currentLookedUpTypes.contains(type)) {
             throw new RuntimeException("RECURSIVE TYPE DEF");

--- a/dsl/src/semanticanalysis/types/TypeBuilder.java
+++ b/dsl/src/semanticanalysis/types/TypeBuilder.java
@@ -525,7 +525,7 @@ public class TypeBuilder {
         }
     }
 
-    public void registerMethod(IScope globalScope, IDSLExtensionMethod<?> method) {
+    public void registerMethod(IScope globalScope, IDSLExtensionMethod<?, ?> method) {
         // get extended type
         Class<?> methodClass = method.getClass();
         if (methodClass.isAnnotationPresent(DSLExtensionMethod.class)) {
@@ -550,7 +550,7 @@ public class TypeBuilder {
                 IType instanceDSLType = createDSLTypeForJavaTypeInScope(globalScope, instanceType);
 
                 // create FunctionType
-                Class<?> returnType = method.getReturnType();
+                Type returnType = parameterizedType.getActualTypeArguments()[1];
                 IType returnDSLType = createDSLTypeForJavaTypeInScope(globalScope, returnType);
 
                 var parameterTypes = method.getParameterTypes();
@@ -566,7 +566,7 @@ public class TypeBuilder {
                                 annotation.name(),
                                 aggregateExtendedType,
                                 functionType,
-                                (IDSLExtensionMethod<Object>) method);
+                                (IDSLExtensionMethod<Object, Object>) method);
                 aggregateExtendedType.bind(nativeMethodSymbol);
             }
         }

--- a/dsl/test/interpreter/TestDSLInterpreter.java
+++ b/dsl/test/interpreter/TestDSLInterpreter.java
@@ -433,9 +433,9 @@ public class TestDSLInterpreter {
 
         var env = new TestEnvironment();
         env.getTypeBuilder()
-                .registerProperty(env.getGlobalScope(), Entity.TestComponent1Property.instance);
+                .bindProperty(env.getGlobalScope(), Entity.TestComponent1Property.instance);
         env.getTypeBuilder()
-                .registerProperty(env.getGlobalScope(), Entity.TestComponent2Property.instance);
+                .bindProperty(env.getGlobalScope(), Entity.TestComponent2Property.instance);
 
         var interpreter = new DSLInterpreter();
         var questConfig =
@@ -515,9 +515,9 @@ public class TestDSLInterpreter {
 
         var env = new TestEnvironment();
         env.getTypeBuilder()
-                .registerProperty(env.getGlobalScope(), Entity.TestComponent1Property.instance);
+                .bindProperty(env.getGlobalScope(), Entity.TestComponent1Property.instance);
         env.getTypeBuilder()
-                .registerProperty(env.getGlobalScope(), Entity.TestComponent2Property.instance);
+                .bindProperty(env.getGlobalScope(), Entity.TestComponent2Property.instance);
 
         var interpreter = new DSLInterpreter();
         var questConfig =
@@ -572,7 +572,7 @@ public class TestDSLInterpreter {
                 .createDSLTypeForJavaTypeInScope(
                         env.getGlobalScope(), ComponentWithExternalTypeMember.class);
         env.getTypeBuilder()
-                .registerProperty(
+                .bindProperty(
                         env.getGlobalScope(),
                         Entity.ComponentWithExternalTypeMemberProperty.instance);
 
@@ -628,7 +628,7 @@ public class TestDSLInterpreter {
                 .createDSLTypeForJavaTypeInScope(
                         env.getGlobalScope(), TestComponentWithExternalType.class);
         env.getTypeBuilder()
-                .registerProperty(
+                .bindProperty(
                         env.getGlobalScope(),
                         Entity.TestComponentWithExternalTypeProperty.instance);
 
@@ -680,7 +680,7 @@ public class TestDSLInterpreter {
                 .createDSLTypeForJavaTypeInScope(
                         env.getGlobalScope(), TestComponentWithExternalType.class);
         env.getTypeBuilder()
-                .registerProperty(
+                .bindProperty(
                         env.getGlobalScope(),
                         Entity.TestComponentWithExternalTypeProperty.instance);
         DSLInterpreter interpreter = new DSLInterpreter();
@@ -1508,7 +1508,7 @@ public class TestDSLInterpreter {
                 .createDSLTypeForJavaTypeInScope(
                         env.getGlobalScope(), TestComponentTestComponent2ConsumerCallback.class);
         env.getTypeBuilder()
-                .registerProperty(
+                .bindProperty(
                         env.getGlobalScope(), TestComponent2.TestComponentPseudoProperty.instance);
 
         var config =
@@ -1563,7 +1563,7 @@ public class TestDSLInterpreter {
                 .createDSLTypeForJavaTypeInScope(
                         env.getGlobalScope(), TestComponentTestComponent2ConsumerCallback.class);
         env.getTypeBuilder()
-                .registerProperty(
+                .bindProperty(
                         env.getGlobalScope(),
                         TestComponent2.TestComponentPseudoPropertyComplexType.instance);
 
@@ -1618,9 +1618,9 @@ public class TestDSLInterpreter {
                 .createDSLTypeForJavaTypeInScope(
                         env.getGlobalScope(), TestComponentEntityConsumerCallback.class);
         env.getTypeBuilder()
-                .registerProperty(env.getGlobalScope(), Entity.TestComponent2Property.instance);
+                .bindProperty(env.getGlobalScope(), Entity.TestComponent2Property.instance);
         env.getTypeBuilder()
-                .registerProperty(env.getGlobalScope(), Entity.TestComponent1Property.instance);
+                .bindProperty(env.getGlobalScope(), Entity.TestComponent1Property.instance);
 
         var config =
                 (CustomQuestConfig)
@@ -1670,9 +1670,9 @@ public class TestDSLInterpreter {
                 .createDSLTypeForJavaTypeInScope(
                         env.getGlobalScope(), TestComponentEntityConsumerCallback.class);
         env.getTypeBuilder()
-                .registerProperty(env.getGlobalScope(), Entity.TestComponent2Property.instance);
+                .bindProperty(env.getGlobalScope(), Entity.TestComponent2Property.instance);
         env.getTypeBuilder()
-                .registerProperty(env.getGlobalScope(), Entity.TestComponent1Property.instance);
+                .bindProperty(env.getGlobalScope(), Entity.TestComponent1Property.instance);
 
         var config =
                 (CustomQuestConfig)
@@ -1747,9 +1747,9 @@ public class TestDSLInterpreter {
                 .createDSLTypeForJavaTypeInScope(
                         env.getGlobalScope(), TestComponentEntityConsumerCallback.class);
         env.getTypeBuilder()
-                .registerProperty(env.getGlobalScope(), Entity.TestComponent2Property.instance);
+                .bindProperty(env.getGlobalScope(), Entity.TestComponent2Property.instance);
         env.getTypeBuilder()
-                .registerProperty(env.getGlobalScope(), Entity.TestComponent1Property.instance);
+                .bindProperty(env.getGlobalScope(), Entity.TestComponent1Property.instance);
 
         var config =
                 (CustomQuestConfig)
@@ -1811,9 +1811,9 @@ public class TestDSLInterpreter {
                 .createDSLTypeForJavaTypeInScope(
                         env.getGlobalScope(), TestComponentEntityConsumerCallback.class);
         env.getTypeBuilder()
-                .registerProperty(env.getGlobalScope(), Entity.TestComponent2Property.instance);
+                .bindProperty(env.getGlobalScope(), Entity.TestComponent2Property.instance);
         env.getTypeBuilder()
-                .registerProperty(env.getGlobalScope(), Entity.TestComponent1Property.instance);
+                .bindProperty(env.getGlobalScope(), Entity.TestComponent1Property.instance);
 
         var config =
                 (CustomQuestConfig)
@@ -2036,7 +2036,7 @@ public class TestDSLInterpreter {
                 .createDSLTypeForJavaTypeInScope(
                         env.getGlobalScope(), TestComponentEntityConsumerCallback.class);
         env.getTypeBuilder()
-                .registerProperty(env.getGlobalScope(), Entity.TestComponent2Property.instance);
+                .bindProperty(env.getGlobalScope(), Entity.TestComponent2Property.instance);
 
         var config =
                 (CustomQuestConfig)
@@ -2099,7 +2099,7 @@ public class TestDSLInterpreter {
                 .createDSLTypeForJavaTypeInScope(
                         env.getGlobalScope(), TestComponentEntityConsumerCallback.class);
         env.getTypeBuilder()
-                .registerProperty(env.getGlobalScope(), Entity.TestComponent2Property.instance);
+                .bindProperty(env.getGlobalScope(), Entity.TestComponent2Property.instance);
 
         var config =
                 (CustomQuestConfig)
@@ -2479,10 +2479,10 @@ public class TestDSLInterpreter {
         env.getTypeBuilder()
                 .createDSLTypeForJavaTypeInScope(env.getGlobalScope(), TestComponent2.class);
         env.getTypeBuilder()
-                .registerProperty(env.getGlobalScope(), Entity.TestComponent1Property.instance);
+                .bindProperty(env.getGlobalScope(), Entity.TestComponent1Property.instance);
         env.getTypeBuilder()
-                .registerProperty(env.getGlobalScope(), Entity.TestComponent2Property.instance);
-        env.getTypeBuilder().registerMethod(env.getGlobalScope(), TestComponent2.MyMethod.instance);
+                .bindProperty(env.getGlobalScope(), Entity.TestComponent2Property.instance);
+        env.getTypeBuilder().bindMethod(env.getGlobalScope(), TestComponent2.MyMethod.instance);
 
         var config =
                 (CustomQuestConfig)

--- a/dsl/test/interpreter/TestDSLInterpreter.java
+++ b/dsl/test/interpreter/TestDSLInterpreter.java
@@ -2303,4 +2303,63 @@ public class TestDSLInterpreter {
         String output = outputStream.toString();
         assertEquals(System.lineSeparator() + System.lineSeparator(), output);
     }
+
+    @Test
+    public void testNativeMethodCall() {
+        String program =
+                """
+        entity_type my_type {
+            test_component_with_callback {
+                consumer: func
+            }
+        }
+
+        fn func(entity ent) {
+            var test : string[];
+            {
+                test.add("hello");
+                test.add("world");
+            }
+            print(test);
+        }
+
+        quest_config c {
+            entity: instantiate(my_type)
+        }
+        """;
+
+        // print currently just prints to system.out, so we need to
+        // check the contents for the printed string
+        var outputStream = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(outputStream));
+
+        TestEnvironment env = new TestEnvironment();
+        DSLInterpreter interpreter = new DSLInterpreter();
+        env.getTypeBuilder().createDSLTypeForJavaTypeInScope(env.getGlobalScope(), Entity.class);
+        env.getTypeBuilder()
+                .createDSLTypeForJavaTypeInScope(
+                        env.getGlobalScope(), TestComponentEntityConsumerCallback.class);
+
+        var config =
+                (CustomQuestConfig)
+                        Helpers.generateQuestConfigWithCustomTypes(program, env, interpreter);
+
+        var entity = config.entity();
+
+        TestComponentEntityConsumerCallback componentWithConsumer =
+                (TestComponentEntityConsumerCallback)
+                        entity.components.stream()
+                                .filter(c -> c instanceof TestComponentEntityConsumerCallback)
+                                .toList()
+                                .get(0);
+
+        componentWithConsumer.consumer.accept(entity);
+
+        // the output stream should only contain the default value for a string variable ("") and
+        // the line separator from the print-call; if the variable definitions in the
+        // if-else=stmt-body "escapes" the output will contain '0', as the new 'test'-variable
+        // will be initialized with 0
+        String output = outputStream.toString();
+        assertEquals("[hello, world]" + System.lineSeparator(), output);
+    }
 }

--- a/dsl/test/interpreter/TestDSLInterpreter.java
+++ b/dsl/test/interpreter/TestDSLInterpreter.java
@@ -2425,10 +2425,6 @@ public class TestDSLInterpreter {
 
         componentWithConsumer.consumer.accept(entity);
 
-        // the output stream should only contain the default value for a string variable ("") and
-        // the line separator from the print-call; if the variable definitions in the
-        // if-else=stmt-body "escapes" the output will contain '0', as the new 'test'-variable
-        // will be initialized with 0
         String output = outputStream.toString();
         assertEquals(
                 "2"
@@ -2457,10 +2453,7 @@ public class TestDSLInterpreter {
         }
 
         fn func(entity ent) {
-            // here, the second "ent" can't be resolved, because test_component2 is still on top of scope stack..
-            // should first resolve all member accesses and after that the parameters
-            // or create dedicated scope stack for member access..
-            //ent.test_component2.my_method(ent.test_component1);
+            // in test_component2.my_method, `member` of the instance will be set to the first parameter
             ent.test_component2.my_method("Hello, World!", 42, "Nope");
             print(ent.test_component2.member1);
         }
@@ -2506,10 +2499,6 @@ public class TestDSLInterpreter {
 
         componentWithConsumer.consumer.accept(entity);
 
-        // the output stream should only contain the default value for a string variable ("") and
-        // the line separator from the print-call; if the variable definitions in the
-        // if-else=stmt-body "escapes" the output will contain '0', as the new 'test'-variable
-        // will be initialized with 0
         String output = outputStream.toString();
         assertEquals("Hello, World!" + System.lineSeparator(), output);
     }

--- a/dsl/test/interpreter/TestDSLInterpreter.java
+++ b/dsl/test/interpreter/TestDSLInterpreter.java
@@ -2321,6 +2321,7 @@ public class TestDSLInterpreter {
                 test.add("world");
             }
             print(test);
+            print(test.size());
         }
 
         quest_config c {
@@ -2360,6 +2361,6 @@ public class TestDSLInterpreter {
         // if-else=stmt-body "escapes" the output will contain '0', as the new 'test'-variable
         // will be initialized with 0
         String output = outputStream.toString();
-        assertEquals("[hello, world]" + System.lineSeparator(), output);
+        assertEquals("[hello, world]" + System.lineSeparator() + "2" + System.lineSeparator(), output);
     }
 }

--- a/dsl/test/interpreter/TestDSLInterpreter.java
+++ b/dsl/test/interpreter/TestDSLInterpreter.java
@@ -2443,7 +2443,7 @@ public class TestDSLInterpreter {
     @Test
     public void testExtensionMethodCall() {
         String program =
-            """
+                """
         entity_type my_type {
             test_component1 {
                 member1: 42,
@@ -2479,30 +2479,30 @@ public class TestDSLInterpreter {
         DSLInterpreter interpreter = new DSLInterpreter();
         env.getTypeBuilder().createDSLTypeForJavaTypeInScope(env.getGlobalScope(), Entity.class);
         env.getTypeBuilder()
-            .createDSLTypeForJavaTypeInScope(
-                env.getGlobalScope(), TestComponentEntityConsumerCallback.class);
+                .createDSLTypeForJavaTypeInScope(
+                        env.getGlobalScope(), TestComponentEntityConsumerCallback.class);
         env.getTypeBuilder()
-            .createDSLTypeForJavaTypeInScope(
-                env.getGlobalScope(), TestComponent1.class);
+                .createDSLTypeForJavaTypeInScope(env.getGlobalScope(), TestComponent1.class);
         env.getTypeBuilder()
-            .createDSLTypeForJavaTypeInScope(
-                env.getGlobalScope(), TestComponent2.class);
-        env.getTypeBuilder().registerProperty(env.getGlobalScope(), Entity.TestComponent1Property.instance);
-        env.getTypeBuilder().registerProperty(env.getGlobalScope(), Entity.TestComponent2Property.instance);
+                .createDSLTypeForJavaTypeInScope(env.getGlobalScope(), TestComponent2.class);
+        env.getTypeBuilder()
+                .registerProperty(env.getGlobalScope(), Entity.TestComponent1Property.instance);
+        env.getTypeBuilder()
+                .registerProperty(env.getGlobalScope(), Entity.TestComponent2Property.instance);
         env.getTypeBuilder().registerMethod(env.getGlobalScope(), TestComponent2.MyMethod.instance);
 
         var config =
-            (CustomQuestConfig)
-                Helpers.generateQuestConfigWithCustomTypes(program, env, interpreter);
+                (CustomQuestConfig)
+                        Helpers.generateQuestConfigWithCustomTypes(program, env, interpreter);
 
         var entity = config.entity();
 
         TestComponentEntityConsumerCallback componentWithConsumer =
-            (TestComponentEntityConsumerCallback)
-                entity.components.stream()
-                    .filter(c -> c instanceof TestComponentEntityConsumerCallback)
-                    .toList()
-                    .get(0);
+                (TestComponentEntityConsumerCallback)
+                        entity.components.stream()
+                                .filter(c -> c instanceof TestComponentEntityConsumerCallback)
+                                .toList()
+                                .get(0);
 
         componentWithConsumer.consumer.accept(entity);
 
@@ -2511,6 +2511,6 @@ public class TestDSLInterpreter {
         // if-else=stmt-body "escapes" the output will contain '0', as the new 'test'-variable
         // will be initialized with 0
         String output = outputStream.toString();
-        assertEquals( "Hello, World!" + System.lineSeparator(), output);
+        assertEquals("Hello, World!" + System.lineSeparator(), output);
     }
 }

--- a/dsl/test/interpreter/TestDSLInterpreter.java
+++ b/dsl/test/interpreter/TestDSLInterpreter.java
@@ -2322,6 +2322,7 @@ public class TestDSLInterpreter {
             }
             print(test);
             print(test.size());
+            print(test.get(1));
         }
 
         quest_config c {
@@ -2361,6 +2362,13 @@ public class TestDSLInterpreter {
         // if-else=stmt-body "escapes" the output will contain '0', as the new 'test'-variable
         // will be initialized with 0
         String output = outputStream.toString();
-        assertEquals("[hello, world]" + System.lineSeparator() + "2" + System.lineSeparator(), output);
+        assertEquals(
+                "[hello, world]"
+                        + System.lineSeparator()
+                        + "2"
+                        + System.lineSeparator()
+                        + "world"
+                        + System.lineSeparator(),
+                output);
     }
 }

--- a/dsl/test/interpreter/mockecs/TestComponent2.java
+++ b/dsl/test/interpreter/mockecs/TestComponent2.java
@@ -1,6 +1,11 @@
 package interpreter.mockecs;
 
+import interpreter.DSLInterpreter;
+
 import semanticanalysis.types.*;
+
+import java.util.Arrays;
+import java.util.List;
 
 @DSLType
 public class TestComponent2 extends Component {
@@ -39,6 +44,37 @@ public class TestComponent2 extends Component {
         @Override
         public ComplexType get(TestComponent2 instance) {
             return instance.hiddenComplexMember;
+        }
+    }
+
+    @DSLExtensionMethod(name = "my_method", extendedType = TestComponent2.class)
+    public static class MyMethod implements IDSLExtensionMethod<TestComponent2> {
+        public static MyMethod instance = new MyMethod();
+
+        @Override
+        public Object call(DSLInterpreter interpreter, TestComponent2 instance, List<Object> params) {
+            //TestComponent1 param1 = (TestComponent1) params[0];
+            String param1 = (String) params.get(0);
+            Integer param2 = (Integer) params.get(1);
+            String param3 = (String) params.get(2);
+
+            instance.member1 = param1;
+            instance.member2 = param2;
+            instance.member3 = param3;
+
+            return this;
+        }
+
+        @Override
+        public List<Class<?>> getParameterTypes() {
+            //var arr = new Class<?>[] {TestComponent1.class, Integer.class, String.class};
+            var arr = new Class<?>[] {String.class, Integer.class, String.class};
+            return Arrays.stream(arr).toList();
+        }
+
+        @Override
+        public Class<?> getReturnType() {
+            return TestComponent2.class;
         }
     }
 

--- a/dsl/test/interpreter/mockecs/TestComponent2.java
+++ b/dsl/test/interpreter/mockecs/TestComponent2.java
@@ -48,11 +48,11 @@ public class TestComponent2 extends Component {
     }
 
     @DSLExtensionMethod(name = "my_method", extendedType = TestComponent2.class)
-    public static class MyMethod implements IDSLExtensionMethod<TestComponent2> {
+    public static class MyMethod implements IDSLExtensionMethod<TestComponent2, TestComponent2> {
         public static MyMethod instance = new MyMethod();
 
         @Override
-        public Object call(
+        public TestComponent2 call(
                 DSLInterpreter interpreter, TestComponent2 instance, List<Object> params) {
             String param1 = (String) params.get(0);
             Integer param2 = (Integer) params.get(1);
@@ -62,18 +62,13 @@ public class TestComponent2 extends Component {
             instance.member2 = param2;
             instance.member3 = param3;
 
-            return this;
+            return instance;
         }
 
         @Override
         public List<Class<?>> getParameterTypes() {
             var arr = new Class<?>[] {String.class, Integer.class, String.class};
             return Arrays.stream(arr).toList();
-        }
-
-        @Override
-        public Class<?> getReturnType() {
-            return TestComponent2.class;
         }
     }
 

--- a/dsl/test/interpreter/mockecs/TestComponent2.java
+++ b/dsl/test/interpreter/mockecs/TestComponent2.java
@@ -1,7 +1,5 @@
 package interpreter.mockecs;
 
-import interpreter.DSLInterpreter;
-
 import semanticanalysis.types.*;
 
 import java.util.Arrays;
@@ -52,8 +50,7 @@ public class TestComponent2 extends Component {
         public static MyMethod instance = new MyMethod();
 
         @Override
-        public TestComponent2 call(
-                DSLInterpreter interpreter, TestComponent2 instance, List<Object> params) {
+        public TestComponent2 call(TestComponent2 instance, List<Object> params) {
             String param1 = (String) params.get(0);
             Integer param2 = (Integer) params.get(1);
             String param3 = (String) params.get(2);

--- a/dsl/test/interpreter/mockecs/TestComponent2.java
+++ b/dsl/test/interpreter/mockecs/TestComponent2.java
@@ -54,7 +54,6 @@ public class TestComponent2 extends Component {
         @Override
         public Object call(
                 DSLInterpreter interpreter, TestComponent2 instance, List<Object> params) {
-            // TestComponent1 param1 = (TestComponent1) params[0];
             String param1 = (String) params.get(0);
             Integer param2 = (Integer) params.get(1);
             String param3 = (String) params.get(2);
@@ -68,7 +67,6 @@ public class TestComponent2 extends Component {
 
         @Override
         public List<Class<?>> getParameterTypes() {
-            // var arr = new Class<?>[] {TestComponent1.class, Integer.class, String.class};
             var arr = new Class<?>[] {String.class, Integer.class, String.class};
             return Arrays.stream(arr).toList();
         }

--- a/dsl/test/interpreter/mockecs/TestComponent2.java
+++ b/dsl/test/interpreter/mockecs/TestComponent2.java
@@ -52,8 +52,9 @@ public class TestComponent2 extends Component {
         public static MyMethod instance = new MyMethod();
 
         @Override
-        public Object call(DSLInterpreter interpreter, TestComponent2 instance, List<Object> params) {
-            //TestComponent1 param1 = (TestComponent1) params[0];
+        public Object call(
+                DSLInterpreter interpreter, TestComponent2 instance, List<Object> params) {
+            // TestComponent1 param1 = (TestComponent1) params[0];
             String param1 = (String) params.get(0);
             Integer param2 = (Integer) params.get(1);
             String param3 = (String) params.get(2);
@@ -67,7 +68,7 @@ public class TestComponent2 extends Component {
 
         @Override
         public List<Class<?>> getParameterTypes() {
-            //var arr = new Class<?>[] {TestComponent1.class, Integer.class, String.class};
+            // var arr = new Class<?>[] {TestComponent1.class, Integer.class, String.class};
             var arr = new Class<?>[] {String.class, Integer.class, String.class};
             return Arrays.stream(arr).toList();
         }

--- a/dsl/test/semanticanalysis/types/TestTypeBuilder.java
+++ b/dsl/test/semanticanalysis/types/TestTypeBuilder.java
@@ -333,9 +333,7 @@ public class TestTypeBuilder {
     @Test
     public void testTypeForNull() {
         TestEnvironment env = new TestEnvironment();
-        var type = env.getTypeBuilder()
-                    .createDSLTypeForJavaTypeInScope(
-                        env.getGlobalScope(), null);
+        var type = env.getTypeBuilder().createDSLTypeForJavaTypeInScope(env.getGlobalScope(), null);
         Assert.assertEquals(BuiltInType.noType, type);
     }
 }

--- a/dsl/test/semanticanalysis/types/TestTypeBuilder.java
+++ b/dsl/test/semanticanalysis/types/TestTypeBuilder.java
@@ -7,6 +7,7 @@ import dslToGame.graph.Graph;
 import interpreter.TestEnvironment;
 import interpreter.mockecs.*;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 import semanticanalysis.Scope;
@@ -327,5 +328,14 @@ public class TestTypeBuilder {
         assertEquals("float<>", floatSetSymbol.getDataType().getName());
         setType = (SetType) floatSetSymbol.getDataType();
         assertEquals(BuiltInType.floatType, setType.getElementType());
+    }
+
+    @Test
+    public void testTypeForNull() {
+        TestEnvironment env = new TestEnvironment();
+        var type = env.getTypeBuilder()
+                    .createDSLTypeForJavaTypeInScope(
+                        env.getGlobalScope(), null);
+        Assert.assertEquals(BuiltInType.noType, type);
     }
 }


### PR DESCRIPTION
Fixes #781 

Implementiert zwei Methoden-Arten (native Methoden und externe Methoden). Beide Methoden-Arten nutzen das Pattern, was bereits für #955 genutzt wurde. Sie werden also als innere statische Klasse mit einer statischen Instanz und `private`-Konstruktor erzeugt. Die statische Instanz wird zur Erzeugung der entsprechenden Symbole verwendet, welche die Methode in der Symboltabelle repräsentieren.

### 1. native Methoden

Native Methoden sind Methoden, die direkt mit den nativen Datentypen der DSL verbunden sind (bspw. die `add`-Methode eines Listen-Typen). Native Methoden implementieren `IInstanceCallable` und werden als `NativeMethod`-Symbol abgebildet und im entsprechenden Datentyp, in dem sie verfügbar sind, gebunden.

### 2. externe Methoden

Externe Methoden sind Methoden, die Datentypen, welche per `@DSLType` Annotation erstellt werden, hinzugefügt werden.
Sie implementieren `IDSLExtensionMethod` und werden als `ExtensionMethod`-Symbol im entsprechenden Datentyp gebunden.