### PR TITLE
[DUNGEON] add Questlog

### DIFF
--- a/dungeon/src/Starter.java
+++ b/dungeon/src/Starter.java
@@ -279,6 +279,7 @@ public class Starter {
         return (task, taskContents) -> {
             selectedPoint =
                     ((PayloadTaskContent) taskContents.stream().findFirst().get()).payload();
+            task.state(Task.TaskState.FINISHED_PERFECT);
         };
     }
 

--- a/dungeon/src/task/Task.java
+++ b/dungeon/src/task/Task.java
@@ -6,7 +6,6 @@ import petriNet.Place;
 
 import semanticanalysis.types.DSLType;
 
-
 import java.util.*;
 import java.util.function.BiFunction;
 import java.util.stream.Stream;

--- a/dungeon/src/task/Task.java
+++ b/dungeon/src/task/Task.java
@@ -6,6 +6,7 @@ import petriNet.Place;
 
 import semanticanalysis.types.DSLType;
 
+
 import java.util.*;
 import java.util.function.BiFunction;
 import java.util.stream.Stream;
@@ -30,6 +31,8 @@ import java.util.stream.Stream;
  */
 @DSLType
 public abstract class Task {
+
+    private static final Set<Task> ALL_TASKS = new HashSet<>();
     private static final String DEFAULT_TASK_TEXT = "No task description provided";
     private static final TaskState DEFAULT_TASK_STATE = TaskState.INACTIVE;
     private TaskState state;
@@ -45,6 +48,7 @@ public abstract class Task {
      * with an empty content-collection and without an {@link TaskComponent}.
      */
     public Task() {
+        ALL_TASKS.add(this);
         state = DEFAULT_TASK_STATE;
         taskText = DEFAULT_TASK_TEXT;
         content = new LinkedList<>();
@@ -168,6 +172,15 @@ public abstract class Task {
      */
     public void scoringFunction(BiFunction<Task, Set<TaskContent>, Float> scoringFunction) {
         this.scoringFunction = scoringFunction;
+    }
+
+    /**
+     * Get a stream of all Task-Objects that exist.
+     *
+     * @return Stream of all Task-Objects that ever exist.
+     */
+    public static Stream<Task> allTasks() {
+        return new HashSet<>(ALL_TASKS).stream();
     }
 
     /**

--- a/game/src/contrib/configuration/KeyboardConfig.java
+++ b/game/src/contrib/configuration/KeyboardConfig.java
@@ -60,4 +60,7 @@ public class KeyboardConfig {
     public static final ConfigKey<Integer> DEBUG_TELEPORT_TO_CURSOR =
             new ConfigKey<>(
                     new String[] {"debug", "teleport_cursor"}, new ConfigIntValue(Input.Keys.O));
+
+    public static final ConfigKey<Integer> QUESTLOG =
+            new ConfigKey<>(new String[] {"menue", "questlog"}, new ConfigIntValue(Input.Keys.M));
 }


### PR DESCRIPTION
fixes #616 

- fügt dem Dungeon-Starter einen Knopf zum Anzeigen des Questlogs hinzu (Default `M`)
- Beim aufrufen werden die Task-Beschreibungen aller aktiven Tasks angezeigt
- Dafür wird in `Task` eine zentrale statische Liste geführt bei dem jedes `Task` Objekt beim erzeugen hinzugefügt wird (vielleicht wandert das später noch wo anders hin (Petri Netz?)

- Hübsch ist das noch nicht, aber das Problem ist in #907 hinterlegt  



![image](https://github.com/Programmiermethoden/Dungeon/assets/32962412/fa1e41d5-b5d9-49be-9b20-a16dc357f422)
