### PR TITLE
Tool: add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Dieser PR fügt eine minimale Dependabot-Konfiguration hinzu, die die verwendeten GitHub-Actions überwacht und bei neuen Versionen automatisch einen Update-PR vorschlägt. Die Konfiguration könnte in Zukunft erweitert werden, um auch Gradle-Abhängigkeiten automatisiert zu aktualisieren.

@AMatutat Bitte einmal freigeben.