### PR TITLE
[DSL] Bugfix: Auflösung von Parametern in Methodenaufrufen

### DIFF
--- a/dsl/src/interpreter/DSLInterpreter.java
+++ b/dsl/src/interpreter/DSLInterpreter.java
@@ -675,11 +675,11 @@ public class DSLInterpreter implements AstVisitor<Object> {
         // 1. we resolve an IdNode at the rhs of the MemberAccessNode
         // 2. we resolve an FuncCallNode at the rhs of the MemberAccessNode
         if (rhs.type.equals(Node.Type.Identifier)) {
-            this.memoryStack.push(lhsValue.getMemorySpace());
+            this.memoryStack.push(memorySpaceToUse);
             rhsValue = (Value) rhs.accept(this);
             this.memoryStack.pop();
         } else if (rhs.type.equals(Node.Type.FuncCall)) {
-            this.instanceMemoryStack.push(lhsValue.getMemorySpace());
+            this.instanceMemoryStack.push(memorySpaceToUse);
             rhsValue = (Value) rhs.accept(this);
             this.instanceMemoryStack.pop();
         }

--- a/dsl/src/interpreter/DSLInterpreter.java
+++ b/dsl/src/interpreter/DSLInterpreter.java
@@ -35,6 +35,7 @@ import java.util.*;
 public class DSLInterpreter implements AstVisitor<Object> {
     private RuntimeEnvironment environment;
     private final ArrayDeque<IMemorySpace> memoryStack;
+    private final ArrayDeque<IMemorySpace> instanceMemoryStack;
     private final IMemorySpace globalSpace;
 
     private SymbolTable symbolTable() {
@@ -45,6 +46,10 @@ public class DSLInterpreter implements AstVisitor<Object> {
         return this.memoryStack.peek();
     }
 
+    public IMemorySpace getCurrentInstanceMemorySpace() {
+        return this.instanceMemoryStack.peek();
+    }
+
     private final ArrayDeque<Node> statementStack;
 
     private static final String RETURN_VALUE_NAME = "$return_value$";
@@ -52,6 +57,7 @@ public class DSLInterpreter implements AstVisitor<Object> {
     /** Constructor. */
     public DSLInterpreter() {
         memoryStack = new ArrayDeque<>();
+        instanceMemoryStack = new ArrayDeque<>();
         globalSpace = new MemorySpace();
         statementStack = new ArrayDeque<>();
         memoryStack.push(globalSpace);
@@ -641,11 +647,42 @@ public class DSLInterpreter implements AstVisitor<Object> {
 
     @Override
     public Object visit(MemberAccessNode node) {
-        Value lhs = (Value) node.getLhs().accept(this);
+        Node currentNode = node;
+        Node lhs;
+        Node rhs = Node.NONE;
+        IMemorySpace memorySpaceToUse = this.getCurrentMemorySpace();
 
-        this.memoryStack.push(lhs.getMemorySpace());
-        Value rhsValue = (Value) node.getRhs().accept(this);
-        this.memoryStack.pop();
+        Value lhsValue = Value.NONE;
+        while (currentNode.type.equals(Node.Type.MemberAccess)) {
+            lhs = ((MemberAccessNode)currentNode).getLhs();
+            rhs = ((MemberAccessNode)currentNode).getRhs();
+
+            if (lhs.type.equals(Node.Type.Identifier)) {
+                String nameToResolve = ((IdNode) lhs).getName();
+                lhsValue = memorySpaceToUse.resolve(nameToResolve);
+            } else if (lhs.type.equals(Node.Type.FuncCall)) {
+                this.instanceMemoryStack.push(memorySpaceToUse);
+                lhsValue = (Value)lhs.accept(this);
+                this.instanceMemoryStack.pop();
+            }
+
+            currentNode = rhs;
+            memorySpaceToUse = lhsValue.getMemorySpace();
+        }
+
+        Value rhsValue = Value.NONE;
+        // if we arrive here, we have got two options:
+        // 1. we resolve an IdNode at the rhs of the MemberAccessNode
+        // 2. we resolve an FuncCallNode at the rhs of the MemberAccessNode
+        if (rhs.type.equals(Node.Type.Identifier)) {
+            this.memoryStack.push(lhsValue.getMemorySpace());
+            rhsValue = (Value) rhs.accept(this);
+            this.memoryStack.pop();
+        } else if (rhs.type.equals(Node.Type.FuncCall)) {
+            this.instanceMemoryStack.push(lhsValue.getMemorySpace());
+            rhsValue = (Value) rhs.accept(this);
+            this.instanceMemoryStack.pop();
+        }
 
         return rhsValue;
     }

--- a/dsl/src/interpreter/DSLInterpreter.java
+++ b/dsl/src/interpreter/DSLInterpreter.java
@@ -654,15 +654,15 @@ public class DSLInterpreter implements AstVisitor<Object> {
 
         Value lhsValue = Value.NONE;
         while (currentNode.type.equals(Node.Type.MemberAccess)) {
-            lhs = ((MemberAccessNode)currentNode).getLhs();
-            rhs = ((MemberAccessNode)currentNode).getRhs();
+            lhs = ((MemberAccessNode) currentNode).getLhs();
+            rhs = ((MemberAccessNode) currentNode).getRhs();
 
             if (lhs.type.equals(Node.Type.Identifier)) {
                 String nameToResolve = ((IdNode) lhs).getName();
                 lhsValue = memorySpaceToUse.resolve(nameToResolve);
             } else if (lhs.type.equals(Node.Type.FuncCall)) {
                 this.instanceMemoryStack.push(memorySpaceToUse);
-                lhsValue = (Value)lhs.accept(this);
+                lhsValue = (Value) lhs.accept(this);
                 this.instanceMemoryStack.pop();
             }
 

--- a/dsl/src/parser/ast/AggregateValueDefinitionNode.java
+++ b/dsl/src/parser/ast/AggregateValueDefinitionNode.java
@@ -46,8 +46,8 @@ public class AggregateValueDefinitionNode extends Node {
      */
     public AggregateValueDefinitionNode(Node idNode, Node propertyDefinitionList) {
         super(Type.AggregateValueDefinition, new ArrayList<>(2));
-        this.children.add(idNode);
-        this.children.add(propertyDefinitionList);
+        this.addChild(idNode);
+        this.addChild(propertyDefinitionList);
     }
 
     @Override

--- a/dsl/src/parser/ast/BinaryNode.java
+++ b/dsl/src/parser/ast/BinaryNode.java
@@ -10,21 +10,21 @@ public abstract class BinaryNode extends Node {
      * @return the right-hand-side of the binary node
      */
     public Node getRhs() {
-        return children.get(rhsIdx);
+        return getChild(rhsIdx);
     }
 
     /**
      * @return the left-hand-side of the binary node
      */
     public Node getLhs() {
-        return children.get(lhsIdx);
+        return getChild(lhsIdx);
     }
 
     protected BinaryNode(Type type, Node lhs, Node rhs) {
         super(type, new ArrayList<>(2));
 
-        children.add(lhs);
-        children.add(rhs);
+        addChild(lhs);
+        addChild(rhs);
     }
 
     @Override

--- a/dsl/src/parser/ast/ConditionalStmtNodeIf.java
+++ b/dsl/src/parser/ast/ConditionalStmtNodeIf.java
@@ -33,8 +33,8 @@ public class ConditionalStmtNodeIf extends Node {
     public ConditionalStmtNodeIf(Node condition, Node stmt) {
         super(Type.ConditionalStmtIf, new ArrayList<>(2));
 
-        this.children.add(condition);
-        this.children.add(stmt);
+        this.addChild(condition);
+        this.addChild(stmt);
     }
 
     @Override

--- a/dsl/src/parser/ast/ConditionalStmtNodeIfElse.java
+++ b/dsl/src/parser/ast/ConditionalStmtNodeIfElse.java
@@ -44,9 +44,9 @@ public class ConditionalStmtNodeIfElse extends Node {
     public ConditionalStmtNodeIfElse(Node condition, Node stmtIf, Node stmtElse) {
         super(Type.ConditionalStmtIfElse, new ArrayList<>(3));
 
-        this.children.add(condition);
-        this.children.add(stmtIf);
-        this.children.add(stmtElse);
+        this.addChild(condition);
+        this.addChild(stmtIf);
+        this.addChild(stmtElse);
     }
 
     @Override

--- a/dsl/src/parser/ast/DotDefNode.java
+++ b/dsl/src/parser/ast/DotDefNode.java
@@ -18,7 +18,7 @@ public class DotDefNode extends Node {
      * @return the IdNode corresponding to the identifier of the graph
      */
     public Node getIdNode() {
-        return this.children.get(idNodeIdx);
+        return this.getChild(idNodeIdx);
     }
 
     /**
@@ -32,7 +32,7 @@ public class DotDefNode extends Node {
      * @return all dot statements in the graph definition as a list
      */
     public List<Node> getStmtNodes() {
-        return this.children.subList(dotStmtStartIdx, this.children.size());
+        return this.getChildren().subList(dotStmtStartIdx, this.getChildren().size());
     }
 
     public enum Type {
@@ -52,8 +52,8 @@ public class DotDefNode extends Node {
      */
     public DotDefNode(Type graphType, Node graphId, ArrayList<Node> dotStmts) {
         super(Node.Type.DotDefinition, new ArrayList<>(dotStmts.size() + 1));
-        this.children.add(graphId);
-        this.children.addAll(dotStmts);
+        this.addChild(graphId);
+        dotStmts.forEach(this::addChild);
         this.graphType = graphType;
     }
 

--- a/dsl/src/parser/ast/EdgeRhsNode.java
+++ b/dsl/src/parser/ast/EdgeRhsNode.java
@@ -10,14 +10,14 @@ public class EdgeRhsNode extends Node {
      * @return The EdgeOpNode corresponding to the EdgeOperator
      */
     public Node getEdgeOpNode() {
-        return this.children.get(edgeOpIdx);
+        return this.getChild(edgeOpIdx);
     }
 
     /**
      * @return The IdNode corresponding to the referenced identifier on the right-hand-side
      */
     public Node getIdNode() {
-        return this.children.get(idNodeIdx);
+        return this.getChild(idNodeIdx);
     }
 
     /**
@@ -35,8 +35,8 @@ public class EdgeRhsNode extends Node {
      */
     public EdgeRhsNode(Node edgeOpNode, Node idNode) {
         super(Type.DotEdgeRHS, new ArrayList<>(2));
-        this.children.add(edgeOpNode);
-        this.children.add(idNode);
+        this.addChild(edgeOpNode);
+        this.addChild(idNode);
     }
 
     @Override

--- a/dsl/src/parser/ast/EdgeStmtNode.java
+++ b/dsl/src/parser/ast/EdgeStmtNode.java
@@ -19,24 +19,24 @@ public class EdgeStmtNode extends Node {
      */
     public EdgeStmtNode(Node lhsID, ArrayList<Node> rhsStmts, Node attrList) {
         super(Type.DotEdgeStmt, new ArrayList<>());
-        this.children.add(lhsID);
-        this.children.addAll(rhsStmts);
-        this.attrListIdx = this.children.size();
-        this.children.add(attrList);
+        this.addChild(lhsID);
+        rhsStmts.forEach(this::addChild);
+        this.attrListIdx = this.getChildren().size();
+        this.addChild(attrList);
     }
 
     /**
      * @return The {@link IdNode} corresponding to the identifier on the left-hand-side
      */
     public Node getLhsId() {
-        return this.children.get(lhsIdIdx);
+        return this.getChild(lhsIdIdx);
     }
 
     /**
      * @return A list of {@link EdgeRhsNode}s of the statement
      */
     public List<Node> getRhsStmts() {
-        return this.children.subList(rhsStmtsStartIdx, attrListIdx);
+        return this.getChildren().subList(rhsStmtsStartIdx, attrListIdx);
     }
 
     /**
@@ -44,7 +44,7 @@ public class EdgeStmtNode extends Node {
      *     'Node.NONE', if there is no attribute list)
      */
     public Node getAttrList() {
-        return this.children.get(attrListIdx);
+        return this.getChild(attrListIdx);
     }
 
     @Override

--- a/dsl/src/parser/ast/FuncCallNode.java
+++ b/dsl/src/parser/ast/FuncCallNode.java
@@ -31,7 +31,7 @@ public class FuncCallNode extends Node {
      * @return List of the AstNodes corresponding to the parameters of the function call
      */
     public List<Node> getParameters() {
-        return this.children.get(paramListIdx).getChildren();
+        return this.getChild(paramListIdx).getChildren();
     }
 
     /**
@@ -43,8 +43,8 @@ public class FuncCallNode extends Node {
     public FuncCallNode(Node id, Node paramList) {
         super(Type.FuncCall, new ArrayList<>(paramList.getChildren().size() + 1));
 
-        this.children.add(id);
-        this.children.add(paramList);
+        this.addChild(id);
+        this.addChild(paramList);
     }
 
     @Override

--- a/dsl/src/parser/ast/FuncDefNode.java
+++ b/dsl/src/parser/ast/FuncDefNode.java
@@ -70,7 +70,7 @@ public class FuncDefNode extends Node {
      * @return List of the AstNodes corresponding to the parameters of the function call
      */
     public List<Node> getParameters() {
-        return this.children.get(paramListIdx).getChildren();
+        return this.getChild(paramListIdx).getChildren();
     }
 
     /**
@@ -82,10 +82,10 @@ public class FuncDefNode extends Node {
     public FuncDefNode(Node id, Node paramList, Node retType, Node stmtBlock) {
         super(Type.FuncDef, new ArrayList<>(4));
 
-        this.children.add(id);
-        this.children.add(paramList);
-        this.children.add(retType);
-        this.children.add(stmtBlock);
+        this.addChild(id);
+        this.addChild(paramList);
+        this.addChild(retType);
+        this.addChild(stmtBlock);
     }
 
     @Override

--- a/dsl/src/parser/ast/ListDefinitionNode.java
+++ b/dsl/src/parser/ast/ListDefinitionNode.java
@@ -10,7 +10,7 @@ public class ListDefinitionNode extends Node {
 
     public ListDefinitionNode(Node entryList) {
         super(Type.ListDefinitionNode, new ArrayList<>(1));
-        this.children.add(entryList);
+        this.addChild(entryList);
     }
 
     @Override

--- a/dsl/src/parser/ast/ListTypeIdentifierNode.java
+++ b/dsl/src/parser/ast/ListTypeIdentifierNode.java
@@ -12,7 +12,7 @@ public class ListTypeIdentifierNode extends IdNode {
                 Type.ListTypeIdentifierNode,
                 innerTypeNode.getName() + "[]",
                 innerTypeNode.getSourceFileReference());
-        this.children.add(innerTypeNode);
+        this.addChild(innerTypeNode);
     }
 
     public IdNode getInnerTypeNode() {

--- a/dsl/src/parser/ast/Node.java
+++ b/dsl/src/parser/ast/Node.java
@@ -72,7 +72,7 @@ public class Node {
 
     public static Node NONE = new Node(Type.NONE, new ArrayList<>());
 
-    protected ArrayList<Node> children;
+    private ArrayList<Node> children;
     public final Type type;
     private Node parent;
     private SourceFileReference sourceFileReference = SourceFileReference.NULL;
@@ -141,13 +141,22 @@ public class Node {
         return children.get(idx);
     }
 
+    public void addChild(Node node) {
+        this.children.add(node);
+        node.parent = this;
+    }
+
+    public Node getParent() {
+        return parent;
+    }
+
     /**
      * Get all children of this node.
      *
      * @return List of all children of the node.
      */
     public ArrayList<Node> getChildren() {
-        return children;
+        return new ArrayList<>(children);
     }
 
     /**

--- a/dsl/src/parser/ast/ObjectDefNode.java
+++ b/dsl/src/parser/ast/ObjectDefNode.java
@@ -71,7 +71,7 @@ public class ObjectDefNode extends Node {
      * @return A List of AstNodes corresponding to property definitions
      */
     public List<Node> getPropertyDefinitions() {
-        return this.children.get(propertyDefListIdx).getChildren();
+        return this.getChild(propertyDefListIdx).getChildren();
     }
 
     /**
@@ -88,9 +88,9 @@ public class ObjectDefNode extends Node {
                 new ArrayList<>(propertyDefList.getChildren().size() + 2));
         this.type = type;
 
-        this.children.add(typeSpecifier);
-        this.children.add(id);
-        this.children.add(propertyDefList);
+        this.addChild(typeSpecifier);
+        this.addChild(id);
+        this.addChild(propertyDefList);
     }
 
     @Override

--- a/dsl/src/parser/ast/ParamDefNode.java
+++ b/dsl/src/parser/ast/ParamDefNode.java
@@ -24,8 +24,8 @@ public class ParamDefNode extends Node {
 
     public ParamDefNode(Node typeIdNode, Node idNode) {
         super(Type.ParamDef, new ArrayList<>(2));
-        this.children.add(typeIdNode);
-        this.children.add(idNode);
+        this.addChild(typeIdNode);
+        this.addChild(idNode);
     }
 
     @Override

--- a/dsl/src/parser/ast/PropertyDefNode.java
+++ b/dsl/src/parser/ast/PropertyDefNode.java
@@ -12,7 +12,7 @@ public class PropertyDefNode extends Node {
      * @return the AstNode corresponding to the identifier (lhs) of the property definition
      */
     public Node getIdNode() {
-        return this.children.get(idIdx);
+        return this.getChild(idIdx);
     }
 
     /**
@@ -21,7 +21,7 @@ public class PropertyDefNode extends Node {
      * @return
      */
     public Node getStmtNode() {
-        return this.children.get(stmtIdx);
+        return this.getChild(stmtIdx);
     }
 
     /**
@@ -41,8 +41,8 @@ public class PropertyDefNode extends Node {
      */
     public PropertyDefNode(Node id, Node stmt) {
         super(Type.PropertyDefinition, new ArrayList<>(2));
-        this.children.add(id);
-        this.children.add(stmt);
+        this.addChild(id);
+        this.addChild(stmt);
     }
 
     @Override

--- a/dsl/src/parser/ast/PrototypeDefinitionNode.java
+++ b/dsl/src/parser/ast/PrototypeDefinitionNode.java
@@ -45,8 +45,8 @@ public class PrototypeDefinitionNode extends Node {
      */
     public PrototypeDefinitionNode(Node idNode, Node componentDefinitionList) {
         super(Type.PrototypeDefinition, new ArrayList<Node>(2));
-        this.children.add(idNode);
-        this.children.add(componentDefinitionList);
+        this.addChild(idNode);
+        this.addChild(componentDefinitionList);
     }
 
     @Override

--- a/dsl/src/parser/ast/ReturnStmtNode.java
+++ b/dsl/src/parser/ast/ReturnStmtNode.java
@@ -7,7 +7,7 @@ public class ReturnStmtNode extends Node {
 
     public ReturnStmtNode(Node innerStmt) {
         super(Type.ReturnStmt);
-        this.children.add(innerStmt);
+        this.addChild(innerStmt);
     }
 
     @Override

--- a/dsl/src/parser/ast/SetDefinitionNode.java
+++ b/dsl/src/parser/ast/SetDefinitionNode.java
@@ -9,7 +9,7 @@ public class SetDefinitionNode extends Node {
 
     public SetDefinitionNode(Node entryList) {
         super(Type.SetDefinitionNode, new ArrayList<>(1));
-        this.children.add(entryList);
+        this.addChild(entryList);
     }
 
     @Override

--- a/dsl/src/parser/ast/SetTypeIdentifierNode.java
+++ b/dsl/src/parser/ast/SetTypeIdentifierNode.java
@@ -12,7 +12,7 @@ public class SetTypeIdentifierNode extends IdNode {
                 Type.SetTypeIdentifierNode,
                 innerTypeNode.getName() + "<>",
                 innerTypeNode.getSourceFileReference());
-        this.children.add(innerTypeNode);
+        this.addChild(innerTypeNode);
     }
 
     public IdNode getInnerTypeNode() {

--- a/dsl/src/parser/ast/StmtBlockNode.java
+++ b/dsl/src/parser/ast/StmtBlockNode.java
@@ -9,7 +9,7 @@ public class StmtBlockNode extends Node {
 
     public StmtBlockNode(Node stmtList) {
         super(Type.Block);
-        this.children.add(stmtList);
+        this.addChild(stmtList);
     }
 
     @Override

--- a/dsl/src/parser/ast/UnaryNode.java
+++ b/dsl/src/parser/ast/UnaryNode.java
@@ -21,7 +21,7 @@ public class UnaryNode extends Node {
     public UnaryNode(UnaryType type, Node inner) {
         super(Type.Unary, new ArrayList<>(1));
         this.unaryType = type;
-        this.children.add(inner);
+        this.addChild(inner);
     }
 
     @Override

--- a/dsl/src/runtime/nativefunctions/ExtensionMethod.java
+++ b/dsl/src/runtime/nativefunctions/ExtensionMethod.java
@@ -44,7 +44,7 @@ public class ExtensionMethod extends Symbol implements ICallable {
     @Override
     public Object call(DSLInterpreter interperter, List<Node> parameters) {
         // resolve "THIS_VALUE"
-        Value instance = interperter.getCurrentMemorySpace().resolve(Value.THIS_NAME);
+        Value instance = interperter.getCurrentInstanceMemorySpace().resolve(Value.THIS_NAME);
         Object instanceObject = instance.getInternalValue();
 
         // interpret parameters and extract internal values

--- a/dsl/src/runtime/nativefunctions/ExtensionMethod.java
+++ b/dsl/src/runtime/nativefunctions/ExtensionMethod.java
@@ -64,6 +64,6 @@ public class ExtensionMethod extends Symbol implements ICallable {
 
     @Override
     public FunctionType getFunctionType() {
-        return null;
+        return (FunctionType) this.dataType;
     }
 }

--- a/dsl/src/runtime/nativefunctions/NativeMethod.java
+++ b/dsl/src/runtime/nativefunctions/NativeMethod.java
@@ -44,7 +44,7 @@ public class NativeMethod extends Symbol implements ICallable {
     @Override
     public Object call(DSLInterpreter interperter, List<Node> parameters) {
         // resolve "THIS_VALUE"
-        Value instance = interperter.getCurrentMemorySpace().resolve(Value.THIS_NAME);
+        Value instance = interperter.getCurrentInstanceMemorySpace().resolve(Value.THIS_NAME);
         return this.instanceCallable.call(interperter, instance, parameters);
     }
 

--- a/dsl/src/runtime/nativefunctions/NativeMethod.java
+++ b/dsl/src/runtime/nativefunctions/NativeMethod.java
@@ -55,6 +55,6 @@ public class NativeMethod extends Symbol implements ICallable {
 
     @Override
     public FunctionType getFunctionType() {
-        return null;
+        return (FunctionType) this.dataType;
     }
 }

--- a/dsl/src/semanticanalysis/SemanticAnalyzer.java
+++ b/dsl/src/semanticanalysis/SemanticAnalyzer.java
@@ -29,7 +29,6 @@ import runtime.nativefunctions.NativeFunction;
 
 import semanticanalysis.types.*;
 
-import java.lang.reflect.Member;
 import java.util.Stack;
 // importing all required classes from symbolTable will be to verbose
 // CHECKSTYLE:OFF: AvoidStarImport
@@ -331,7 +330,8 @@ public class SemanticAnalyzer implements AstVisitor<Void> {
     public Void visit(FuncCallNode node) {
         Node parentNode = node.getParent();
         if (parentNode.type.equals(Node.Type.MemberAccess)) {
-            // symbol will be resolved in the visit-implementation of MemberAccessNode, as it requires
+            // symbol will be resolved in the visit-implementation of MemberAccessNode, as it
+            // requires
             // resolving in the datatype of the preceding member-access expression
         } else {
             Symbol funcSymbol = this.symbolTable.getSymbolsForAstNode(node).get(0);
@@ -340,11 +340,12 @@ public class SemanticAnalyzer implements AstVisitor<Void> {
                 funcSymbol = currentScope().resolve(funcName, true);
                 if (funcSymbol.equals(Symbol.NULL)) {
                     throw new RuntimeException(
-                        "Function with name " + funcName + " could not be resolved!");
+                            "Function with name " + funcName + " could not be resolved!");
                 }
 
                 if (!(funcSymbol instanceof ICallable)) {
-                    throw new RuntimeException("Symbol with name " + funcName + " is not callable!");
+                    throw new RuntimeException(
+                            "Symbol with name " + funcName + " is not callable!");
                 }
 
                 this.symbolTable.addSymbolNodeRelation(funcSymbol, node, false);
@@ -453,11 +454,11 @@ public class SemanticAnalyzer implements AstVisitor<Void> {
         IScope scopeToUse = this.currentScope();
 
         while (currentNode.type.equals(Node.Type.MemberAccess)) {
-            lhs = ((MemberAccessNode)currentNode).getLhs();
-            rhs = ((MemberAccessNode)currentNode).getRhs();
+            lhs = ((MemberAccessNode) currentNode).getLhs();
+            rhs = ((MemberAccessNode) currentNode).getRhs();
 
             // resolve name of lhs in scope
-            //lhsDataType = BuiltInType.noType;
+            // lhsDataType = BuiltInType.noType;
             if (lhs.type.equals(Node.Type.Identifier)) {
                 String nameToResolve = ((IdNode) lhs).getName();
                 Symbol symbol = scopeToUse.resolve(nameToResolve);
@@ -482,9 +483,9 @@ public class SemanticAnalyzer implements AstVisitor<Void> {
 
             if (!(lhsDataType instanceof ScopedSymbol lhsTypeScopedSymbol)) {
                 throw new RuntimeException(
-                    "Datatype "
-                        + lhsDataType.getName()
-                        + " of lhs in member access is no scoped symbol!");
+                        "Datatype "
+                                + lhsDataType.getName()
+                                + " of lhs in member access is no scoped symbol!");
             }
             scopeToUse = lhsTypeScopedSymbol;
         }
@@ -499,11 +500,11 @@ public class SemanticAnalyzer implements AstVisitor<Void> {
             scopeStack.pop();
         } else if (rhs.type.equals(Node.Type.FuncCall)) {
             // resolve function name in scope to use
-            String funcName = ((FuncCallNode)rhs).getIdName();
+            String funcName = ((FuncCallNode) rhs).getIdName();
             Symbol funcSymbol = scopeToUse.resolve(funcName, true);
             if (funcSymbol.equals(Symbol.NULL)) {
                 throw new RuntimeException(
-                    "Function with name " + funcName + " could not be resolved!");
+                        "Function with name " + funcName + " could not be resolved!");
             }
 
             if (!(funcSymbol instanceof ICallable)) {

--- a/dsl/src/semanticanalysis/SemanticAnalyzer.java
+++ b/dsl/src/semanticanalysis/SemanticAnalyzer.java
@@ -330,7 +330,7 @@ public class SemanticAnalyzer implements AstVisitor<Void> {
     @Override
     public Void visit(FuncCallNode node) {
         Node parentNode = node.getParent();
-        if (parentNode.type.equals(Node.Type.MemberAccess) && ((MemberAccessNode)parentNode).getRhs().equals(node)) {
+        if (parentNode.type.equals(Node.Type.MemberAccess)) {
             // symbol will be resolved in the visit-implementation of MemberAccessNode, as it requires
             // resolving in the datatype of the preceding member-access expression
         } else {
@@ -470,10 +470,12 @@ public class SemanticAnalyzer implements AstVisitor<Void> {
 
                 // resolve function definition
                 String functionName = ((FuncCallNode) lhs).getIdName();
-                FunctionSymbol functionSymbol =
-                    (FunctionSymbol) scopeToUse.resolve(functionName);
-                FunctionType functionType = (FunctionType) functionSymbol.getDataType();
+                Symbol resolvedFunction = scopeToUse.resolve(functionName);
+                ICallable callable = (ICallable) resolvedFunction;
+                FunctionType functionType = callable.getFunctionType();
                 lhsDataType = functionType.getReturnType();
+
+                symbolTable.addSymbolNodeRelation(resolvedFunction, lhs, false);
             }
 
             currentNode = rhs;

--- a/dsl/src/semanticanalysis/SemanticAnalyzer.java
+++ b/dsl/src/semanticanalysis/SemanticAnalyzer.java
@@ -29,6 +29,7 @@ import runtime.nativefunctions.NativeFunction;
 
 import semanticanalysis.types.*;
 
+import java.lang.reflect.Member;
 import java.util.Stack;
 // importing all required classes from symbolTable will be to verbose
 // CHECKSTYLE:OFF: AvoidStarImport
@@ -328,20 +329,27 @@ public class SemanticAnalyzer implements AstVisitor<Void> {
 
     @Override
     public Void visit(FuncCallNode node) {
-        // resolve function definition in global scope
-        String funcName = node.getIdName();
+        Node parentNode = node.getParent();
+        if (parentNode.type.equals(Node.Type.MemberAccess) && ((MemberAccessNode)parentNode).getRhs().equals(node)) {
+            // symbol will be resolved in the visit-implementation of MemberAccessNode, as it requires
+            // resolving in the datatype of the preceding member-access expression
+        } else {
+            Symbol funcSymbol = this.symbolTable.getSymbolsForAstNode(node).get(0);
+            if (funcSymbol == Symbol.NULL) {
+                String funcName = node.getIdName();
+                funcSymbol = currentScope().resolve(funcName, true);
+                if (funcSymbol.equals(Symbol.NULL)) {
+                    throw new RuntimeException(
+                        "Function with name " + funcName + " could not be resolved!");
+                }
 
-        var funcSymbol = currentScope().resolve(funcName, true);
-        if (funcSymbol.equals(Symbol.NULL)) {
-            throw new RuntimeException(
-                    "Function with name " + funcName + " could not be resolved!");
+                if (!(funcSymbol instanceof ICallable)) {
+                    throw new RuntimeException("Symbol with name " + funcName + " is not callable!");
+                }
+
+                this.symbolTable.addSymbolNodeRelation(funcSymbol, node, false);
+            }
         }
-
-        if (!(funcSymbol instanceof ICallable)) {
-            throw new RuntimeException("Symbol with name " + funcName + " is not callable!");
-        }
-
-        this.symbolTable.addSymbolNodeRelation(funcSymbol, node, false);
 
         for (var parameter : node.getParameters()) {
             parameter.accept(this);
@@ -438,41 +446,71 @@ public class SemanticAnalyzer implements AstVisitor<Void> {
 
     @Override
     public Void visit(MemberAccessNode node) {
-        Node lhs = node.getLhs();
-
-        // resolve name of lhs in scope
+        Node currentNode = node;
+        Node lhs = Node.NONE;
+        Node rhs = Node.NONE;
         IType lhsDataType = BuiltInType.noType;
-        if (lhs.type.equals(Node.Type.Identifier)) {
-            String nameToResolve = ((IdNode) lhs).getName();
-            Symbol symbol = this.currentScope().resolve(nameToResolve);
-            lhsDataType = symbol.getDataType();
+        IScope scopeToUse = this.currentScope();
 
-            symbolTable.addSymbolNodeRelation(symbol, lhs, false);
-        } else if (lhs.type.equals(Node.Type.FuncCall)) {
-            // visit function call itself (resolve parameters etc.)
-            lhs.accept(this);
+        while (currentNode.type.equals(Node.Type.MemberAccess)) {
+            lhs = ((MemberAccessNode)currentNode).getLhs();
+            rhs = ((MemberAccessNode)currentNode).getRhs();
 
-            // resolve function definition
-            String functionName = ((FuncCallNode) lhs).getIdName();
-            FunctionSymbol functionSymbol =
-                    (FunctionSymbol) this.currentScope().resolve(functionName);
-            FunctionType functionType = (FunctionType) functionSymbol.getDataType();
-            lhsDataType = functionType.getReturnType();
-        }
+            // resolve name of lhs in scope
+            //lhsDataType = BuiltInType.noType;
+            if (lhs.type.equals(Node.Type.Identifier)) {
+                String nameToResolve = ((IdNode) lhs).getName();
+                Symbol symbol = scopeToUse.resolve(nameToResolve);
+                lhsDataType = symbol.getDataType();
 
-        if (!(lhsDataType instanceof ScopedSymbol lhsTypeScopedSymbol)) {
-            throw new RuntimeException(
+                symbolTable.addSymbolNodeRelation(symbol, lhs, false);
+            } else if (lhs.type.equals(Node.Type.FuncCall)) {
+                // visit function call itself (resolve parameters etc.)
+                lhs.accept(this);
+
+                // resolve function definition
+                String functionName = ((FuncCallNode) lhs).getIdName();
+                FunctionSymbol functionSymbol =
+                    (FunctionSymbol) scopeToUse.resolve(functionName);
+                FunctionType functionType = (FunctionType) functionSymbol.getDataType();
+                lhsDataType = functionType.getReturnType();
+            }
+
+            currentNode = rhs;
+
+            if (!(lhsDataType instanceof ScopedSymbol lhsTypeScopedSymbol)) {
+                throw new RuntimeException(
                     "Datatype "
-                            + lhsDataType.getName()
-                            + " of lhs in member access is no scoped symbol!");
+                        + lhsDataType.getName()
+                        + " of lhs in member access is no scoped symbol!");
+            }
+            scopeToUse = lhsTypeScopedSymbol;
         }
 
-        Node rhs = node.getRhs();
-        // resolve rhs-name in scope of the type of the lhs-symbol
-        // -> put datatype of lhs on scope-stack
-        scopeStack.push(lhsTypeScopedSymbol);
-        rhs.accept(this);
-        scopeStack.pop();
+        // if we arrive here, we have got two options:
+        // 1. we resolve an IdNode at the rhs of the MemberAccessNode
+        // 2. we resolve an FuncCallNode at the rhs of the MemberAccessNode
+        if (rhs.type.equals(Node.Type.Identifier)) {
+            // push lhsDataType on stack
+            scopeStack.push(scopeToUse);
+            rhs.accept(this);
+            scopeStack.pop();
+        } else if (rhs.type.equals(Node.Type.FuncCall)) {
+            // resolve function name in scope to use
+            String funcName = ((FuncCallNode)rhs).getIdName();
+            Symbol funcSymbol = scopeToUse.resolve(funcName, true);
+            if (funcSymbol.equals(Symbol.NULL)) {
+                throw new RuntimeException(
+                    "Function with name " + funcName + " could not be resolved!");
+            }
+
+            if (!(funcSymbol instanceof ICallable)) {
+                throw new RuntimeException("Symbol with name " + funcName + " is not callable!");
+            }
+            this.symbolTable.addSymbolNodeRelation(funcSymbol, rhs, false);
+
+            rhs.accept(this);
+        }
 
         return null;
     }

--- a/dsl/test/interpreter/TestDSLInterpreter.java
+++ b/dsl/test/interpreter/TestDSLInterpreter.java
@@ -2454,7 +2454,8 @@ public class TestDSLInterpreter {
 
         fn func(entity ent) {
             // in test_component2.my_method, `member` of the instance will be set to the first parameter
-            ent.test_component2.my_method("Hello, World!", 42, "Nope");
+            //ent.test_component2.my_method("Hello, World!", 42, "Nope");
+            ent.test_component2.my_method(ent.test_component1.member1, 42, "Nope");
             print(ent.test_component2.member1);
         }
 

--- a/dsl/test/interpreter/TestDSLInterpreter.java
+++ b/dsl/test/interpreter/TestDSLInterpreter.java
@@ -2506,7 +2506,7 @@ public class TestDSLInterpreter {
     @Test
     public void testChainedExtensionMethodCall() {
         String program =
-            """
+                """
     entity_type my_type {
         test_component1 {
             member1: 42,
@@ -2539,30 +2539,30 @@ public class TestDSLInterpreter {
         DSLInterpreter interpreter = new DSLInterpreter();
         env.getTypeBuilder().createDSLTypeForJavaTypeInScope(env.getGlobalScope(), Entity.class);
         env.getTypeBuilder()
-            .createDSLTypeForJavaTypeInScope(
-                env.getGlobalScope(), TestComponentEntityConsumerCallback.class);
+                .createDSLTypeForJavaTypeInScope(
+                        env.getGlobalScope(), TestComponentEntityConsumerCallback.class);
         env.getTypeBuilder()
-            .createDSLTypeForJavaTypeInScope(env.getGlobalScope(), TestComponent1.class);
+                .createDSLTypeForJavaTypeInScope(env.getGlobalScope(), TestComponent1.class);
         env.getTypeBuilder()
-            .createDSLTypeForJavaTypeInScope(env.getGlobalScope(), TestComponent2.class);
+                .createDSLTypeForJavaTypeInScope(env.getGlobalScope(), TestComponent2.class);
         env.getTypeBuilder()
-            .bindProperty(env.getGlobalScope(), Entity.TestComponent1Property.instance);
+                .bindProperty(env.getGlobalScope(), Entity.TestComponent1Property.instance);
         env.getTypeBuilder()
-            .bindProperty(env.getGlobalScope(), Entity.TestComponent2Property.instance);
+                .bindProperty(env.getGlobalScope(), Entity.TestComponent2Property.instance);
         env.getTypeBuilder().bindMethod(env.getGlobalScope(), TestComponent2.MyMethod.instance);
 
         var config =
-            (CustomQuestConfig)
-                Helpers.generateQuestConfigWithCustomTypes(program, env, interpreter);
+                (CustomQuestConfig)
+                        Helpers.generateQuestConfigWithCustomTypes(program, env, interpreter);
 
         var entity = config.entity();
 
         TestComponentEntityConsumerCallback componentWithConsumer =
-            (TestComponentEntityConsumerCallback)
-                entity.components.stream()
-                    .filter(c -> c instanceof TestComponentEntityConsumerCallback)
-                    .toList()
-                    .get(0);
+                (TestComponentEntityConsumerCallback)
+                        entity.components.stream()
+                                .filter(c -> c instanceof TestComponentEntityConsumerCallback)
+                                .toList()
+                                .get(0);
 
         componentWithConsumer.consumer.accept(entity);
 

--- a/dsl/test/interpreter/TestDSLInterpreter.java
+++ b/dsl/test/interpreter/TestDSLInterpreter.java
@@ -2453,10 +2453,9 @@ public class TestDSLInterpreter {
         }
 
         fn func(entity ent) {
-            // in test_component2.my_method, `member` of the instance will be set to the first parameter
-            //ent.test_component2.my_method("Hello, World!", 42, "Nope");
-            ent.test_component2.my_method(ent.test_component1.member1, 42, "Nope");
-            print(ent.test_component2.member1);
+            // in test_component2.my_method, `member2` of the instance will be set to the first parameter
+            ent.test_component2.my_method(ent.test_component1.member1, 42);
+            print(ent.test_component2.member2);
         }
 
         quest_config c {
@@ -2501,6 +2500,73 @@ public class TestDSLInterpreter {
         componentWithConsumer.consumer.accept(entity);
 
         String output = outputStream.toString();
-        assertEquals("Hello, World!" + System.lineSeparator(), output);
+        assertEquals("42" + System.lineSeparator(), output);
+    }
+
+    @Test
+    public void testChainedExtensionMethodCall() {
+        String program =
+            """
+    entity_type my_type {
+        test_component1 {
+            member1: 42,
+            member2: 3.14,
+            member3: "Hello, World!"
+        },
+        test_component2 {},
+        test_component_with_callback {
+            consumer: func
+        }
+    }
+
+    fn func(entity ent) {
+        // in test_component2.my_method, `member2` of the instance will be set to the first parameter
+        ent.test_component2.my_method(ent.test_component1.member1, 42).my_method(42, 42);
+        print(ent.test_component2.member2);
+    }
+
+    quest_config c {
+        entity: instantiate(my_type)
+    }
+    """;
+
+        // print currently just prints to system.out, so we need to
+        // check the contents for the printed string
+        var outputStream = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(outputStream));
+
+        TestEnvironment env = new TestEnvironment();
+        DSLInterpreter interpreter = new DSLInterpreter();
+        env.getTypeBuilder().createDSLTypeForJavaTypeInScope(env.getGlobalScope(), Entity.class);
+        env.getTypeBuilder()
+            .createDSLTypeForJavaTypeInScope(
+                env.getGlobalScope(), TestComponentEntityConsumerCallback.class);
+        env.getTypeBuilder()
+            .createDSLTypeForJavaTypeInScope(env.getGlobalScope(), TestComponent1.class);
+        env.getTypeBuilder()
+            .createDSLTypeForJavaTypeInScope(env.getGlobalScope(), TestComponent2.class);
+        env.getTypeBuilder()
+            .bindProperty(env.getGlobalScope(), Entity.TestComponent1Property.instance);
+        env.getTypeBuilder()
+            .bindProperty(env.getGlobalScope(), Entity.TestComponent2Property.instance);
+        env.getTypeBuilder().bindMethod(env.getGlobalScope(), TestComponent2.MyMethod.instance);
+
+        var config =
+            (CustomQuestConfig)
+                Helpers.generateQuestConfigWithCustomTypes(program, env, interpreter);
+
+        var entity = config.entity();
+
+        TestComponentEntityConsumerCallback componentWithConsumer =
+            (TestComponentEntityConsumerCallback)
+                entity.components.stream()
+                    .filter(c -> c instanceof TestComponentEntityConsumerCallback)
+                    .toList()
+                    .get(0);
+
+        componentWithConsumer.consumer.accept(entity);
+
+        String output = outputStream.toString();
+        assertEquals("42" + System.lineSeparator(), output);
     }
 }

--- a/dsl/test/interpreter/mockecs/TestComponent2.java
+++ b/dsl/test/interpreter/mockecs/TestComponent2.java
@@ -51,20 +51,18 @@ public class TestComponent2 extends Component {
 
         @Override
         public TestComponent2 call(TestComponent2 instance, List<Object> params) {
-            String param1 = (String) params.get(0);
+            Integer param1 = (Integer) params.get(0);
             Integer param2 = (Integer) params.get(1);
-            String param3 = (String) params.get(2);
 
-            instance.member1 = param1;
-            instance.member2 = param2;
-            instance.member3 = param3;
+            instance.member2 = param1;
+            instance.member3 = param2.toString();
 
             return instance;
         }
 
         @Override
         public List<Class<?>> getParameterTypes() {
-            var arr = new Class<?>[] {String.class, Integer.class, String.class};
+            var arr = new Class<?>[] {Integer.class, Integer.class};
             return Arrays.stream(arr).toList();
         }
     }

--- a/dsl/test/semanticanalysis/TestSemanticAnalyzer.java
+++ b/dsl/test/semanticanalysis/TestSemanticAnalyzer.java
@@ -592,11 +592,10 @@ public class TestSemanticAnalyzer {
         Assert.assertEquals(member1Symbol, symbolForMember1Identifier);
     }
 
-
     @Test
     public void memberAccessFuncCallChainedMethod() {
         String program =
-            """
+                """
         fn other_func(test_component2 comp) -> test_component2 {
             return comp;
         }
@@ -609,9 +608,8 @@ public class TestSemanticAnalyzer {
 
         TestEnvironment env = new TestEnvironment();
         env.getTypeBuilder()
-            .createDSLTypeForJavaTypeInScope(env.getGlobalScope(), TestComponent2.class);
-        env.getTypeBuilder()
-            .bindMethod(env.getGlobalScope(), TestComponent2.MyMethod.instance);
+                .createDSLTypeForJavaTypeInScope(env.getGlobalScope(), TestComponent2.class);
+        env.getTypeBuilder().bindMethod(env.getGlobalScope(), TestComponent2.MyMethod.instance);
 
         var ast = Helpers.getASTFromString(program);
         var result = Helpers.getSymtableForASTWithCustomEnvironment(ast, env);
@@ -619,14 +617,14 @@ public class TestSemanticAnalyzer {
 
         FuncDefNode otherFuncDefNode = (FuncDefNode) ast.getChild(0);
         FunctionSymbol otherFuncSymbol =
-            (FunctionSymbol) symbolTable.getSymbolsForAstNode(otherFuncDefNode).get(0);
+                (FunctionSymbol) symbolTable.getSymbolsForAstNode(otherFuncDefNode).get(0);
         FuncDefNode testFuncDefNode = (FuncDefNode) ast.getChild(1);
 
         var stmtList = testFuncDefNode.getStmts();
         var printStmt = stmtList.get(0);
         var printStmtFuncCall = (FuncCallNode) printStmt;
         MemberAccessNode printParameterNode =
-            (MemberAccessNode) (printStmtFuncCall.getParameters().get(0));
+                (MemberAccessNode) (printStmtFuncCall.getParameters().get(0));
 
         Assert.assertEquals(Node.Type.MemberAccess, printParameterNode.type);
 
@@ -645,7 +643,7 @@ public class TestSemanticAnalyzer {
         Assert.assertEquals(1, symbolsForMethodCall.size());
 
         AggregateType testComponent2Type =
-            (AggregateType) symbolTable.globalScope.resolveType("test_component2");
+                (AggregateType) symbolTable.globalScope.resolveType("test_component2");
         Symbol methodDeclSymbol = testComponent2Type.resolve("my_method");
 
         var symbolForMethodCall = symbolsForMethodCall.get(0);
@@ -662,7 +660,6 @@ public class TestSemanticAnalyzer {
         var symbolForMember1Identifier = symbolsForMember1Identifier.get(0);
         Assert.assertEquals(member1Symbol, symbolForMember1Identifier);
     }
-
 
     @Test
     public void testVariableCreation() {


### PR DESCRIPTION
Fixes #1005 

Umbau der ursprünglich rekursiven Behandlung von `MemberAccess`-Knoten in iterative Version (in `SemanticAnalyzer` und `DSLInterpreter`).
Im `DSLInterpreter` wird ein neuer Instanz-`IMemorySpace`-Stack hinzugefügt, auf den der `MemorySpace` des `Values` gelegt wird, welcher als Instanz für den Methoden-Aufruf verwendet werden soll. In der `call`-Implementierung von `ExtensionMethod` und `NativeMethod` wird über diesen Stack der `$THIS$`-Value aufgelöst, der auf die entsprechende Instanz zeigt. Die Instanz kann nicht auf den regulären `memoryStack` des `DSLInterpreter`s gelegt werden, da die Parameter des Methodenaufrufs in dem umliegenden Scope des Methodenaufrufs aufgelöst werden müssen und nicht in dem Scope der Instanz, welche für den Methodenaufruf verwendet werden soll.

Fügt die `addChild`-Methode zu `Node` hinzu, sodass der `parent`-Knoten richtig gesetzt wird (die für die `visit`-Implementierung für `MemberAccess`-Knoten im `SemanticAnalyzer` benötigt wird), daher werden alle `Node`-Erweiterungen angepasst.