### PR TITLE
[DUNGEON] move `HUD` and advanced Level-Generator from `core` to `contrib`

### DIFF
--- a/dungeon/src/starter/Starter.java
+++ b/dungeon/src/starter/Starter.java
@@ -4,6 +4,7 @@ import contrib.components.InteractionComponent;
 import contrib.configuration.KeyboardConfig;
 import contrib.crafting.Crafting;
 import contrib.entities.EntityFactory;
+import contrib.hud.UITools;
 import contrib.systems.*;
 
 import core.Entity;
@@ -11,7 +12,6 @@ import core.Game;
 import core.components.DrawComponent;
 import core.components.PlayerComponent;
 import core.components.PositionComponent;
-import core.hud.UITools;
 import core.level.TileLevel;
 import core.level.elements.ILevel;
 import core.level.generator.graphBased.RoombasedLevelGenerator;
@@ -194,6 +194,7 @@ public class Starter {
         Game.add(new ProjectileSystem());
         Game.add(new HealthbarSystem());
         Game.add(new HeroUISystem());
+        Game.add(new HudSystem());
     }
 
     private static Set<DSLEntryPoint> processCLIArguments(String[] args) throws IOException {

--- a/dungeon/src/starter/Starter.java
+++ b/dungeon/src/starter/Starter.java
@@ -5,6 +5,7 @@ import contrib.configuration.KeyboardConfig;
 import contrib.crafting.Crafting;
 import contrib.entities.EntityFactory;
 import contrib.hud.UITools;
+import contrib.level.generator.graphBased.RoombasedLevelGenerator;
 import contrib.systems.*;
 
 import core.Entity;
@@ -14,7 +15,6 @@ import core.components.PlayerComponent;
 import core.components.PositionComponent;
 import core.level.TileLevel;
 import core.level.elements.ILevel;
-import core.level.generator.graphBased.RoombasedLevelGenerator;
 import core.level.utils.DesignLabel;
 import core.level.utils.LevelElement;
 

--- a/dungeon/src/task/quizquestion/QuizDialogDesign.java
+++ b/dungeon/src/task/quizquestion/QuizDialogDesign.java
@@ -6,7 +6,8 @@ import com.badlogic.gdx.scenes.scene2d.Group;
 import com.badlogic.gdx.scenes.scene2d.ui.*;
 import com.badlogic.gdx.utils.Align;
 
-import core.hud.DialogDesign;
+import contrib.hud.DialogDesign;
+
 import core.utils.Constants;
 
 public class QuizDialogDesign {

--- a/dungeon/src/task/quizquestion/QuizUI.java
+++ b/dungeon/src/task/quizquestion/QuizUI.java
@@ -3,10 +3,12 @@ package task.quizquestion;
 import com.badlogic.gdx.scenes.scene2d.ui.Dialog;
 import com.badlogic.gdx.scenes.scene2d.ui.Skin;
 
+import contrib.components.UIComponent;
+import contrib.hud.TextDialog;
+import contrib.hud.UITools;
+
 import core.Entity;
 import core.Game;
-import core.hud.TextDialog;
-import core.hud.UITools;
 
 import java.util.Objects;
 import java.util.function.BiFunction;
@@ -29,8 +31,8 @@ public class QuizUI {
      *
      * @param question Question to show on the HUD
      * @param resulthandlerLinker callback function
-     * @return the Entity that stores the {@link core.components.UIComponent} with the UI-Elements
-     *     The entity will already be added to the game by this method.
+     * @return the Entity that stores the {@link UIComponent} with the UI-Elements The entity will
+     *     already be added to the game by this method.
      */
     public static Entity showQuizDialog(
             Quiz question,
@@ -40,8 +42,8 @@ public class QuizUI {
                 showQuizDialog(
                         question,
                         formatStringForDialogWindow(question.taskText()),
-                        core.hud.UITools.DEFAULT_DIALOG_CONFIRM,
-                        core.hud.UITools.DEFAULT_DIALOG_TITLE,
+                        UITools.DEFAULT_DIALOG_CONFIRM,
+                        UITools.DEFAULT_DIALOG_TITLE,
                         resulthandlerLinker);
         Game.add(entity);
         return entity;
@@ -54,14 +56,13 @@ public class QuizUI {
      * <p>Use default callback method, that will delete the hud-entity from the game.
      *
      * @param question Question to show on the HUD
-     * @return the Entity that stores the {@link core.components.UIComponent} with the UI-Elements
-     *     The entity will already be added to the game by this method.
+     * @return the Entity that stores the {@link UIComponent} with the UI-Elements The entity will
+     *     already be added to the game by this method.
      */
     public static Entity showQuizDialog(Quiz question) {
         return showQuizDialog(
                 question,
-                (entity) ->
-                        createResultHandlerQuiz(entity, core.hud.UITools.DEFAULT_DIALOG_CONFIRM));
+                (entity) -> createResultHandlerQuiz(entity, UITools.DEFAULT_DIALOG_CONFIRM));
     }
 
     /**
@@ -72,8 +73,8 @@ public class QuizUI {
      * text and picture, single or multiple choice ) in the Dialog
      *
      * @param question Various question configurations
-     * @return the Entity that stores the {@link core.components.UIComponent} with the UI-Elements
-     *     The entity will already be added to the game by this method.
+     * @return the Entity that stores the {@link UIComponent} with the UI-Elements The entity will
+     *     already be added to the game by this method.
      */
     private static Entity showQuizDialog(
             Quiz question,
@@ -83,7 +84,7 @@ public class QuizUI {
             Function<Entity, BiFunction<TextDialog, String, Boolean>> resulthandlerLinker) {
         Entity entity = new Entity();
 
-        core.hud.UITools.show(
+        UITools.show(
                 () -> {
                     Dialog quizDialog =
                             createQuizDialog(

--- a/dungeon/src/task/quizquestion/UIAnswerCallback.java
+++ b/dungeon/src/task/quizquestion/UIAnswerCallback.java
@@ -9,10 +9,11 @@ import com.badlogic.gdx.scenes.scene2d.ui.TextArea;
 import com.badlogic.gdx.scenes.scene2d.ui.VerticalGroup;
 import com.badlogic.gdx.utils.SnapshotArray;
 
+import contrib.hud.TextDialog;
+import contrib.hud.UITools;
+
 import core.Entity;
 import core.Game;
-import core.hud.TextDialog;
-import core.hud.UITools;
 
 import task.Task;
 import task.TaskContent;

--- a/dungeon/test/manual/quizquestion/CallbackTest.java
+++ b/dungeon/test/manual/quizquestion/CallbackTest.java
@@ -5,13 +5,13 @@ import com.badlogic.gdx.Input;
 
 import contrib.components.InteractionComponent;
 import contrib.entities.EntityFactory;
+import contrib.hud.UITools;
 import contrib.systems.*;
 
 import core.Entity;
 import core.Game;
 import core.components.DrawComponent;
 import core.components.PositionComponent;
-import core.hud.UITools;
 import core.level.utils.LevelSize;
 import core.systems.LevelSystem;
 
@@ -71,6 +71,7 @@ public class CallbackTest {
                         Game.add(new HealthSystem());
                         Game.add(new XPSystem());
                         Game.add(new ProjectileSystem());
+                        Game.add(new HudSystem());
                         Entity hero = EntityFactory.newHero();
                         Game.hero(hero);
                         Game.add(hero);

--- a/dungeon/test/manual/taskgeneration/TaskGenerationTest.java
+++ b/dungeon/test/manual/taskgeneration/TaskGenerationTest.java
@@ -2,13 +2,13 @@ package manual.taskgeneration;
 
 import contrib.components.InteractionComponent;
 import contrib.entities.EntityFactory;
+import contrib.hud.UITools;
 import contrib.systems.*;
 
 import core.Entity;
 import core.Game;
 import core.components.DrawComponent;
 import core.components.PositionComponent;
-import core.hud.UITools;
 import core.level.utils.LevelSize;
 import core.systems.LevelSystem;
 
@@ -58,6 +58,7 @@ public class TaskGenerationTest {
                         Game.add(new ProjectileSystem());
                         Game.add(new HealthbarSystem());
                         Game.add(new HeroUISystem());
+                        Game.add(new HudSystem());
                         Entity hero = EntityFactory.newHero();
                         Game.hero(hero);
                         Game.add(hero);

--- a/dungeon/test/task/TaskContentDoorOpenerTest.java
+++ b/dungeon/test/task/TaskContentDoorOpenerTest.java
@@ -2,15 +2,16 @@ package task;
 
 import static org.junit.Assert.assertTrue;
 
+import contrib.level.generator.GeneratorUtils;
+import contrib.level.generator.graphBased.RoombasedLevelGenerator;
+import contrib.level.generator.graphBased.levelGraph.Direction;
+import contrib.level.generator.graphBased.levelGraph.GraphGenerator;
+import contrib.level.generator.graphBased.levelGraph.LevelGraph;
+import contrib.level.generator.graphBased.levelGraph.Node;
+
 import core.Entity;
 import core.level.elements.tile.DoorTile;
-import core.level.generator.graphBased.RoombasedLevelGenerator;
-import core.level.generator.graphBased.levelGraph.Direction;
-import core.level.generator.graphBased.levelGraph.GraphGenerator;
-import core.level.generator.graphBased.levelGraph.LevelGraph;
-import core.level.generator.graphBased.levelGraph.Node;
 import core.level.utils.DesignLabel;
-import core.level.utils.GeneratorUtils;
 import core.utils.Tuple;
 
 import org.junit.Before;

--- a/game/src/contrib/components/UIComponent.java
+++ b/game/src/contrib/components/UIComponent.java
@@ -1,4 +1,4 @@
-package core.components;
+package contrib.components;
 
 import com.badlogic.gdx.scenes.scene2d.Group;
 

--- a/game/src/contrib/configuration/KeyboardConfig.java
+++ b/game/src/contrib/configuration/KeyboardConfig.java
@@ -63,4 +63,6 @@ public class KeyboardConfig {
 
     public static final ConfigKey<Integer> QUESTLOG =
             new ConfigKey<>(new String[] {"menue", "questlog"}, new ConfigIntValue(Input.Keys.M));
+    public static final ConfigKey<Integer> PAUSE =
+            new ConfigKey<>(new String[] {"pause", "pause_game"}, new ConfigIntValue(Input.Keys.P));
 }

--- a/game/src/contrib/hud/DialogDesign.java
+++ b/game/src/contrib/hud/DialogDesign.java
@@ -1,4 +1,4 @@
-package core.hud;
+package contrib.hud;
 
 import com.badlogic.gdx.scenes.scene2d.Actor;
 import com.badlogic.gdx.scenes.scene2d.Group;

--- a/game/src/contrib/hud/DialogFactory.java
+++ b/game/src/contrib/hud/DialogFactory.java
@@ -1,4 +1,4 @@
-package core.hud;
+package contrib.hud;
 
 import com.badlogic.gdx.scenes.scene2d.ui.Dialog;
 import com.badlogic.gdx.scenes.scene2d.ui.Skin;

--- a/game/src/contrib/hud/GUICombination.java
+++ b/game/src/contrib/hud/GUICombination.java
@@ -6,6 +6,8 @@ import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.scenes.scene2d.Group;
 import com.badlogic.gdx.scenes.scene2d.utils.DragAndDrop;
 
+import contrib.components.UIComponent;
+
 import core.Game;
 
 import java.util.ArrayList;
@@ -21,7 +23,7 @@ import java.util.Arrays;
  *
  * <p>The class inherits from {@link Group} so it can be added to a {@link
  * com.badlogic.gdx.scenes.scene2d.Stage Stage} to be displayed. This should happen through the use
- * of a {@link core.components.UIComponent}.
+ * of a {@link UIComponent}.
  */
 public class GUICombination extends Group {
 

--- a/game/src/contrib/hud/TextDialog.java
+++ b/game/src/contrib/hud/TextDialog.java
@@ -1,4 +1,4 @@
-package core.hud;
+package contrib.hud;
 
 import com.badlogic.gdx.scenes.scene2d.ui.Dialog;
 import com.badlogic.gdx.scenes.scene2d.ui.Skin;

--- a/game/src/contrib/hud/UITools.java
+++ b/game/src/contrib/hud/UITools.java
@@ -1,13 +1,14 @@
-package core.hud;
+package contrib.hud;
 
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.scenes.scene2d.Actor;
 import com.badlogic.gdx.scenes.scene2d.ui.Dialog;
 import com.badlogic.gdx.scenes.scene2d.ui.Skin;
 
+import contrib.components.UIComponent;
+
 import core.Entity;
 import core.Game;
-import core.components.UIComponent;
 import core.utils.Constants;
 
 import java.util.Objects;

--- a/game/src/contrib/hud/heroUI/HeroUITools.java
+++ b/game/src/contrib/hud/heroUI/HeroUITools.java
@@ -7,8 +7,9 @@ import com.badlogic.gdx.scenes.scene2d.ui.ProgressBar;
 import com.badlogic.gdx.scenes.scene2d.utils.NinePatchDrawable;
 import com.badlogic.gdx.scenes.scene2d.utils.TextureRegionDrawable;
 
+import contrib.hud.UITools;
+
 import core.Game;
-import core.hud.UITools;
 
 /** Collection of Utility Methods for popups */
 public class HeroUITools {

--- a/game/src/contrib/level/generator/GeneratorUtils.java
+++ b/game/src/contrib/level/generator/GeneratorUtils.java
@@ -1,9 +1,12 @@
-package core.level.utils;
+package contrib.level.generator;
+
+import contrib.level.generator.graphBased.levelGraph.Direction;
 
 import core.level.Tile;
 import core.level.elements.ILevel;
 import core.level.elements.tile.DoorTile;
-import core.level.generator.graphBased.levelGraph.Direction;
+import core.level.utils.LevelElement;
+import core.level.utils.TileTextureFactory;
 
 import java.util.Optional;
 

--- a/game/src/contrib/level/generator/graphBased/RoomGenerator.java
+++ b/game/src/contrib/level/generator/graphBased/RoomGenerator.java
@@ -1,9 +1,10 @@
-package core.level.generator.graphBased;
+package contrib.level.generator.graphBased;
 
 import static core.level.elements.ILevel.RANDOM;
 
-import core.level.generator.graphBased.levelGraph.Direction;
-import core.level.generator.graphBased.levelGraph.Node;
+import contrib.level.generator.graphBased.levelGraph.Direction;
+import contrib.level.generator.graphBased.levelGraph.Node;
+
 import core.level.utils.Coordinate;
 import core.level.utils.LevelElement;
 import core.level.utils.LevelSize;

--- a/game/src/contrib/level/generator/graphBased/RoombasedLevelGenerator.java
+++ b/game/src/contrib/level/generator/graphBased/RoombasedLevelGenerator.java
@@ -1,4 +1,10 @@
-package core.level.generator.graphBased;
+package contrib.level.generator.graphBased;
+
+import contrib.level.generator.GeneratorUtils;
+import contrib.level.generator.graphBased.levelGraph.Direction;
+import contrib.level.generator.graphBased.levelGraph.GraphGenerator;
+import contrib.level.generator.graphBased.levelGraph.LevelGraph;
+import contrib.level.generator.graphBased.levelGraph.Node;
 
 import core.Entity;
 import core.Game;
@@ -8,10 +14,6 @@ import core.level.Tile;
 import core.level.TileLevel;
 import core.level.elements.ILevel;
 import core.level.elements.tile.DoorTile;
-import core.level.generator.graphBased.levelGraph.Direction;
-import core.level.generator.graphBased.levelGraph.GraphGenerator;
-import core.level.generator.graphBased.levelGraph.LevelGraph;
-import core.level.generator.graphBased.levelGraph.Node;
 import core.level.utils.*;
 import core.utils.IVoidFunction;
 
@@ -121,16 +123,14 @@ public class RoombasedLevelGenerator {
      */
     private static void configureDoors(Node node) {
         for (DoorTile door : node.level().doorTiles()) {
-            Direction doorDirection =
-                    core.level.utils.GeneratorUtils.doorDirection(node.level(), door);
+            Direction doorDirection = GeneratorUtils.doorDirection(node.level(), door);
 
             // find neighbour door
             Node neighbour = node.neighbours()[doorDirection.value()];
             DoorTile neighbourDoor = null;
             for (DoorTile doorTile : neighbour.level().doorTiles())
                 if (Direction.opposite(doorDirection)
-                        == core.level.utils.GeneratorUtils.doorDirection(
-                                neighbour.level(), doorTile)) {
+                        == GeneratorUtils.doorDirection(neighbour.level(), doorTile)) {
                     neighbourDoor = doorTile;
                     break;
                 }

--- a/game/src/contrib/level/generator/graphBased/levelGraph/Direction.java
+++ b/game/src/contrib/level/generator/graphBased/levelGraph/Direction.java
@@ -1,4 +1,4 @@
-package core.level.generator.graphBased.levelGraph;
+package contrib.level.generator.graphBased.levelGraph;
 
 /** The different directions in which nodes can be connected to each other. */
 public enum Direction {

--- a/game/src/contrib/level/generator/graphBased/levelGraph/GraphGenerator.java
+++ b/game/src/contrib/level/generator/graphBased/levelGraph/GraphGenerator.java
@@ -1,4 +1,4 @@
-package core.level.generator.graphBased.levelGraph;
+package contrib.level.generator.graphBased.levelGraph;
 
 import core.Entity;
 

--- a/game/src/contrib/level/generator/graphBased/levelGraph/LevelGraph.java
+++ b/game/src/contrib/level/generator/graphBased/levelGraph/LevelGraph.java
@@ -1,4 +1,4 @@
-package core.level.generator.graphBased.levelGraph;
+package contrib.level.generator.graphBased.levelGraph;
 
 import core.Entity;
 import core.utils.Tuple;

--- a/game/src/contrib/level/generator/graphBased/levelGraph/Node.java
+++ b/game/src/contrib/level/generator/graphBased/levelGraph/Node.java
@@ -1,4 +1,4 @@
-package core.level.generator.graphBased.levelGraph;
+package contrib.level.generator.graphBased.levelGraph;
 
 import core.Entity;
 import core.level.elements.ILevel;

--- a/game/src/contrib/level/generator/perlinNoise/NoiseArea.java
+++ b/game/src/contrib/level/generator/perlinNoise/NoiseArea.java
@@ -1,4 +1,4 @@
-package core.level.generator.perlinNoise;
+package contrib.level.generator.perlinNoise;
 
 import core.level.utils.Coordinate;
 

--- a/game/src/contrib/level/generator/perlinNoise/NoiseAreaValues.java
+++ b/game/src/contrib/level/generator/perlinNoise/NoiseAreaValues.java
@@ -1,4 +1,4 @@
-package core.level.generator.perlinNoise;
+package contrib.level.generator.perlinNoise;
 
 import core.level.utils.Coordinate;
 

--- a/game/src/contrib/level/generator/perlinNoise/PerlinNoise.java
+++ b/game/src/contrib/level/generator/perlinNoise/PerlinNoise.java
@@ -1,4 +1,4 @@
-package core.level.generator.perlinNoise;
+package contrib.level.generator.perlinNoise;
 
 import java.util.Random;
 

--- a/game/src/contrib/level/generator/perlinNoise/PerlinNoiseGenerator.java
+++ b/game/src/contrib/level/generator/perlinNoise/PerlinNoiseGenerator.java
@@ -1,4 +1,4 @@
-package core.level.generator.perlinNoise;
+package contrib.level.generator.perlinNoise;
 
 import core.level.TileLevel;
 import core.level.elements.ILevel;

--- a/game/src/contrib/systems/HealthbarSystem.java
+++ b/game/src/contrib/systems/HealthbarSystem.java
@@ -7,13 +7,13 @@ import com.badlogic.gdx.scenes.scene2d.ui.Container;
 import com.badlogic.gdx.scenes.scene2d.ui.ProgressBar;
 
 import contrib.components.HealthComponent;
+import contrib.components.UIComponent;
 import contrib.hud.heroUI.HeroUITools;
 
 import core.Entity;
 import core.Game;
 import core.System;
 import core.components.PositionComponent;
-import core.components.UIComponent;
 import core.systems.CameraSystem;
 import core.utils.Point;
 import core.utils.logging.CustomLogLevel;

--- a/game/src/contrib/systems/HeroUISystem.java
+++ b/game/src/contrib/systems/HeroUISystem.java
@@ -5,15 +5,15 @@ import com.badlogic.gdx.scenes.scene2d.Group;
 import com.badlogic.gdx.scenes.scene2d.ui.Label;
 import com.badlogic.gdx.scenes.scene2d.ui.ProgressBar;
 
+import contrib.components.UIComponent;
 import contrib.components.XPComponent;
+import contrib.hud.UITools;
 import contrib.hud.heroUI.HeroUITools;
 
 import core.Entity;
 import core.Game;
 import core.System;
 import core.components.PlayerComponent;
-import core.components.UIComponent;
-import core.hud.UITools;
 import core.utils.components.MissingComponentException;
 
 import java.util.HashMap;

--- a/game/src/contrib/systems/HudSystem.java
+++ b/game/src/contrib/systems/HudSystem.java
@@ -1,12 +1,13 @@
-package core.systems;
+package contrib.systems;
 
 import com.badlogic.gdx.scenes.scene2d.Group;
 import com.badlogic.gdx.scenes.scene2d.Stage;
 
+import contrib.components.UIComponent;
+
 import core.Entity;
 import core.Game;
 import core.System;
-import core.components.UIComponent;
 import core.utils.components.MissingComponentException;
 
 import java.util.HashMap;

--- a/game/src/contrib/utils/components/Debugger.java
+++ b/game/src/contrib/utils/components/Debugger.java
@@ -5,7 +5,9 @@ import com.badlogic.gdx.Gdx;
 import contrib.components.AIComponent;
 import contrib.components.CollideComponent;
 import contrib.components.HealthComponent;
+import contrib.components.UIComponent;
 import contrib.configuration.KeyboardConfig;
+import contrib.hud.UITools;
 import contrib.utils.components.ai.fight.CollideAI;
 import contrib.utils.components.ai.idle.RadiusWalk;
 import contrib.utils.components.ai.transition.SelfDefendTransition;
@@ -192,6 +194,22 @@ public class Debugger {
         }
     }
 
+    private static Entity pauseMenu;
+
+    public static void PAUSE_GAME() {
+        if (pauseMenu == null
+                || pauseMenu
+                        .fetch(UIComponent.class)
+                        .map(x -> x.dialog().getStage() == null)
+                        .orElse(false)) pauseMenu = newPauseMenu();
+    }
+
+    private static Entity newPauseMenu() {
+        Entity entity = UITools.generateNewTextDialog("Pause", "Continue", "Pausemenu");
+        entity.fetch(UIComponent.class).ifPresent(y -> y.dialog().setVisible(true));
+        return entity;
+    }
+
     /**
      * Checks for key input corresponding to Debugger functionalities, and executes the relevant
      * function if detected.
@@ -213,5 +231,6 @@ public class Debugger {
             Debugger.TOGGLE_LEVEL_SIZE();
         if (Gdx.input.isKeyJustPressed(KeyboardConfig.DEBUG_SPAWN_MONSTER.value()))
             Debugger.SPAWN_MONSTER_ON_CURSOR();
+        if (Gdx.input.isKeyJustPressed(KeyboardConfig.PAUSE.value())) Debugger.PAUSE_GAME();
     }
 }

--- a/game/src/core/Game.java
+++ b/game/src/core/Game.java
@@ -14,9 +14,7 @@ import com.badlogic.gdx.utils.Scaling;
 import com.badlogic.gdx.utils.viewport.ScalingViewport;
 
 import core.components.PositionComponent;
-import core.components.UIComponent;
 import core.configuration.Configuration;
-import core.hud.UITools;
 import core.level.Tile;
 import core.level.elements.ILevel;
 import core.level.generator.postGeneration.WallGenerator;
@@ -794,23 +792,9 @@ public final class Game extends ScreenAdapter {
         userOnFrame.execute();
     }
 
-    /**
-     * A Variable which only is used to check whether the UI still exists.
-     *
-     * <p>should be moved with the debug key for pause
-     */
-    private Entity pauseMenu;
     /** Just for debugging, remove later. */
     private void debugKeys() {
-        if (Gdx.input.isKeyJustPressed(Input.Keys.P)) {
-            // Text Dialogue (output of information texts)
-            if (pauseMenu == null
-                    || pauseMenu
-                            .fetch(UIComponent.class)
-                            .map(x -> x.dialog().getStage() == null)
-                            .orElse(false)) pauseMenu = newPauseMenu();
-
-        } else if (Gdx.input.isKeyJustPressed(Input.Keys.UP)) {
+        if (Gdx.input.isKeyJustPressed(Input.Keys.UP)) {
             // toggle UI "debug rendering"
             stage().ifPresent(x -> x.setDebugAll(uiDebugFlag = !uiDebugFlag));
         }
@@ -825,12 +809,6 @@ public final class Game extends ScreenAdapter {
                 Gdx.graphics.setWindowedMode(WINDOW_WIDTH, WINDOW_HEIGHT);
             }
         }
-    }
-
-    private Entity newPauseMenu() {
-        Entity entity = UITools.generateNewTextDialog("Pause", "Continue", "Pausemenu");
-        entity.fetch(UIComponent.class).ifPresent(y -> y.dialog().setVisible(true));
-        return entity;
     }
 
     /**
@@ -873,7 +851,6 @@ public final class Game extends ScreenAdapter {
         add(new DrawSystem());
         add(new VelocitySystem());
         add(new PlayerSystem());
-        add(new HudSystem());
     }
 
     @Override

--- a/game/src/starter/Main.java
+++ b/game/src/starter/Main.java
@@ -2,13 +2,13 @@ package starter;
 
 import contrib.crafting.Crafting;
 import contrib.entities.EntityFactory;
+import contrib.level.generator.graphBased.RoombasedLevelGenerator;
 import contrib.systems.*;
 import contrib.utils.components.Debugger;
 
 import core.Entity;
 import core.Game;
 import core.level.elements.ILevel;
-import core.level.generator.graphBased.RoombasedLevelGenerator;
 import core.level.utils.DesignLabel;
 import core.level.utils.LevelSize;
 

--- a/game/src/starter/Main.java
+++ b/game/src/starter/Main.java
@@ -139,5 +139,6 @@ public class Main {
         Game.add(new ProjectileSystem());
         Game.add(new HealthbarSystem());
         Game.add(new HeroUISystem());
+        Game.add(new HudSystem());
     }
 }

--- a/game/test/contrib/level/PerlinNoiseGeneratorTest.java
+++ b/game/test/contrib/level/PerlinNoiseGeneratorTest.java
@@ -1,9 +1,10 @@
-package core.level.generator;
+package contrib.level;
 
 import static org.junit.Assert.assertNotNull;
 
+import contrib.level.generator.perlinNoise.PerlinNoiseGenerator;
+
 import core.level.elements.ILevel;
-import core.level.generator.perlinNoise.PerlinNoiseGenerator;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/game/test/manual/level/generator/graphBased/GraphGeneratorTest.java
+++ b/game/test/manual/level/generator/graphBased/GraphGeneratorTest.java
@@ -1,8 +1,9 @@
 package manual.level.generator.graphBased;
 
+import contrib.level.generator.graphBased.levelGraph.GraphGenerator;
+import contrib.level.generator.graphBased.levelGraph.LevelGraph;
+
 import core.Entity;
-import core.level.generator.graphBased.levelGraph.GraphGenerator;
-import core.level.generator.graphBased.levelGraph.LevelGraph;
 
 import java.awt.*;
 import java.awt.datatransfer.Clipboard;


### PR DESCRIPTION
Um das `core` Package weiter zu verschlanken habe ich sowohl alle Bestandteile des `HUD` als auch die umfangreicheren Levelgeneratoren in das `contrib` Package verschoben.

Dadurch wird das core-Framework schlanker und einfacher für Studis zu verwenden. 


Funktionalität für das Dungeon-Projekt bleibt unbeeinträchtigt, da wir hier sowieso mit `core` als auch `contrib` arbeiten. 