### PR TITLE
[GAME/DUNGEON/DSL] update auf Java 21 LTS

### DIFF
--- a/.github/workflows/github_ci.yml
+++ b/.github/workflows/github_ci.yml
@@ -14,10 +14,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v3
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
           cache: gradle
       - name: Build with Gradle
@@ -57,10 +57,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v3
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
           cache: gradle
       - name: JUnit
@@ -74,10 +74,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v3
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
           cache: gradle
       - name: JUnit
@@ -90,10 +90,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v3
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
           cache: gradle
       - name: Checkstyle
@@ -106,10 +106,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v3
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
           cache: gradle
       - name: Spotless

--- a/.github/workflows/publish_github.yml
+++ b/.github/workflows/publish_github.yml
@@ -10,10 +10,10 @@ jobs:
         steps:
             -   name: Checkout action
                 uses: actions/checkout@v4
-            -   name: Set up Java
+            -   name: Set up JDK 21
                 uses: actions/setup-java@v3
                 with:
-                    java-version: '17'
+                    java-version: '21'
                     distribution: 'temurin'
             -   name: Build the jar file
                 run: ./gradlew jar buildJavadocZip

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The Dungeon uses the [PM-Dungeon](https://github.com/Programmiermethoden/PM-Dung
 
 ## Requirements
 
--   Java SE Development Kit 17.0.x LTS
+-   Java SE Development Kit 21.0.x LTS
 
 ## Contributing
 

--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ dependencies {
     antlr "org.antlr:antlr4:4.11.1"
 }
 
-sourceCompatibility = 17
+sourceCompatibility = 21
 [compileJava, compileTestJava]*.options*.encoding = "UTF-8"
 sourceSets.main.java.srcDirs = ["game/src/", "dsl/src/", "dungeon/src", "$projectDir/build/generated-src/"]
 sourceSets.main.resources.srcDirs = ["game/assets/"]


### PR DESCRIPTION
fixes #1010

Muss noch getestet werden, aber noch kann ich mir JDK 21 nicht runterladen (vermutlich bin ich einfach blind) 

Vermutlich müssen wir auch warten bis unsere ganzen Distributer entsprechend eine JDK 21 anbieten:

https://github.com/Programmiermethoden/Dungeon/wiki/JDK-Kompatibilit%C3%A4t
