### PR TITLE
[DUNGEON] implement structure for replacement and assign task

### DIFF
--- a/dsl/src/interpreter/DSLInterpreter.java
+++ b/dsl/src/interpreter/DSLInterpreter.java
@@ -22,7 +22,7 @@ import semanticanalysis.*;
 // CHECKSTYLE:ON: AvoidStarImport
 import semanticanalysis.types.*;
 
-import task.quizquestion.Quiz;
+import task.Quiz;
 
 import java.util.*;
 

--- a/dsl/src/runtime/GameEnvironment.java
+++ b/dsl/src/runtime/GameEnvironment.java
@@ -20,8 +20,8 @@ import semanticanalysis.types.IDSLTypeProperty;
 import semanticanalysis.types.IType;
 import semanticanalysis.types.TypeBuilder;
 
+import task.Quiz;
 import task.Task;
-import task.quizquestion.Quiz;
 import task.taskdsltypes.MultipleChoiceTask;
 import task.taskdsltypes.SingleChoiceDescriptionProperty;
 import task.taskdsltypes.SingleChoiceTask;

--- a/dsl/test/interpreter/TestDSLInterpreter.java
+++ b/dsl/test/interpreter/TestDSLInterpreter.java
@@ -19,8 +19,8 @@ import runtime.*;
 import semanticanalysis.SemanticAnalyzer;
 import semanticanalysis.types.*;
 
+import task.Quiz;
 import task.quizquestion.MultipleChoice;
-import task.quizquestion.Quiz;
 import task.quizquestion.SingleChoice;
 
 import taskdependencygraph.TaskDependencyGraph;

--- a/dungeon/src/starter/Starter.java
+++ b/dungeon/src/starter/Starter.java
@@ -23,9 +23,9 @@ import dungeonFiles.DslFileLoader;
 
 import interpreter.DSLEntryPointFinder;
 
+import task.Quiz;
 import task.Task;
 import task.TaskContent;
-import task.quizquestion.Quiz;
 import task.quizquestion.SingleChoice;
 import task.quizquestion.UIAnswerCallback;
 

--- a/dungeon/src/task/AssignTask.java
+++ b/dungeon/src/task/AssignTask.java
@@ -1,0 +1,34 @@
+package task;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Assignment Task.
+ *
+ * <p>Stores a Map as a solution with Elements as keys (for example, an index) and a Set of Elements
+ * as values that should be assigned to the keys.
+ */
+public class AssignTask extends Task {
+    private final Map<Element, Set<Element>> solution;
+
+    /**
+     * Create an Assignment Task with the given solution map.
+     *
+     * @param solution The map containing Elements as keys and Sets of Elements as values.
+     */
+    public AssignTask(Map<Element, Set<Element>> solution) {
+        super();
+        this.solution = solution;
+    }
+
+    /**
+     * Get a copy of the solution map.
+     *
+     * @return A copy of the solution map.
+     */
+    public Map<Element, Set<Element>> solution() {
+        return new HashMap<>(solution);
+    }
+}

--- a/dungeon/src/task/Element.java
+++ b/dungeon/src/task/Element.java
@@ -1,0 +1,31 @@
+package task;
+
+/**
+ * Generic storage for a single value that is a {@link TaskContent}.
+ *
+ * @param <T>
+ */
+public class Element<T> extends TaskContent {
+    private final T content;
+
+    /**
+     * Create a new element that can be used as {@link TaskContent}.
+     *
+     * <p>This content will not automatically register itself with the task. Call {@link
+     * Task#addContent(TaskContent)} for that.
+     *
+     * @param task Task to which this content belongs.
+     * @param content Content to store in this element.
+     */
+    public Element(Task task, T content) {
+        super(task);
+        this.content = content;
+    }
+
+    /**
+     * @return The content of this element.
+     */
+    public T content() {
+        return content;
+    }
+}

--- a/dungeon/src/task/Quiz.java
+++ b/dungeon/src/task/Quiz.java
@@ -1,12 +1,14 @@
-package task.quizquestion;
+package task;
 
 import com.badlogic.gdx.scenes.scene2d.ui.Image;
 
 import semanticanalysis.types.DSLType;
 import semanticanalysis.types.DSLTypeMember;
 
-import task.Task;
-import task.TaskContent;
+import task.quizquestion.FreeText;
+import task.quizquestion.MultipleChoice;
+import task.quizquestion.QuizUI;
+import task.quizquestion.SingleChoice;
 
 import java.util.ArrayList;
 import java.util.HashSet;

--- a/dungeon/src/task/ReplacementTask.java
+++ b/dungeon/src/task/ReplacementTask.java
@@ -1,0 +1,41 @@
+package task;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A Replacement Task.
+ *
+ * <p>Stores a collection of elements as a solution and a set of rules as replacement terms.
+ */
+public class ReplacementTask extends Task {
+    private final List<Element> solution;
+    private final List<Rule> rules;
+
+    /**
+     * Create a new Replacement Task.
+     *
+     * @param solution This List contains the final Element-Set that is the solution of the task.
+     * @param rules Rules that define which and how elements can be replaced.
+     */
+    public ReplacementTask(List<Element> solution, List<Rule> rules) {
+        super();
+        this.solution = solution;
+        this.rules = rules;
+    }
+
+    public List<Element> solution() {
+        return new ArrayList<>(solution);
+    }
+
+    public List<Rule> rules() {
+        return new ArrayList<>(rules);
+    }
+
+    /**
+     * Rules for how elements can be replaced by each other.
+     *
+     * <p>This is basically an abstract implementation of {@link contrib.crafting.Recipe}.
+     */
+    public record Rule(boolean ordered, Element[] input, Element[] output) {}
+}

--- a/dungeon/src/task/quizquestion/FreeText.java
+++ b/dungeon/src/task/quizquestion/FreeText.java
@@ -2,6 +2,8 @@ package task.quizquestion;
 
 import com.badlogic.gdx.scenes.scene2d.ui.Image;
 
+import task.Quiz;
+
 /** A {@link Quiz} that needs the player to enter a text. */
 public class FreeText extends Quiz {
     public FreeText(String questionText, Image image) {

--- a/dungeon/src/task/quizquestion/MultipleChoice.java
+++ b/dungeon/src/task/quizquestion/MultipleChoice.java
@@ -2,6 +2,8 @@ package task.quizquestion;
 
 import com.badlogic.gdx.scenes.scene2d.ui.Image;
 
+import task.Quiz;
+
 /**
  * A {@link Quiz} that needs the player to select multiple answers from a collection of
  * possibilities.

--- a/dungeon/src/task/quizquestion/QuizDialogDesign.java
+++ b/dungeon/src/task/quizquestion/QuizDialogDesign.java
@@ -9,6 +9,8 @@ import com.badlogic.gdx.utils.Align;
 import core.hud.DialogDesign;
 import core.utils.Constants;
 
+import task.Quiz;
+
 public class QuizDialogDesign {
 
     public static final String ANSWERS_GROUP_NAME = "Answers";

--- a/dungeon/src/task/quizquestion/QuizUI.java
+++ b/dungeon/src/task/quizquestion/QuizUI.java
@@ -8,6 +8,8 @@ import core.Game;
 import core.hud.TextDialog;
 import core.hud.UITools;
 
+import task.Quiz;
+
 import java.util.Objects;
 import java.util.function.BiFunction;
 import java.util.function.Function;

--- a/dungeon/src/task/quizquestion/SingleChoice.java
+++ b/dungeon/src/task/quizquestion/SingleChoice.java
@@ -2,6 +2,8 @@ package task.quizquestion;
 
 import com.badlogic.gdx.scenes.scene2d.ui.Image;
 
+import task.Quiz;
+
 /** A {@link Quiz} that needs the player to select one answer from a collection of possibilities. */
 public class SingleChoice extends Quiz {
     public SingleChoice(String questionText, Image image) {

--- a/dungeon/src/task/quizquestion/UIAnswerCallback.java
+++ b/dungeon/src/task/quizquestion/UIAnswerCallback.java
@@ -14,6 +14,7 @@ import core.Game;
 import core.hud.TextDialog;
 import core.hud.UITools;
 
+import task.Quiz;
 import task.Task;
 import task.TaskContent;
 

--- a/dungeon/src/task/taskdsltypes/MultipleChoiceTask.java
+++ b/dungeon/src/task/taskdsltypes/MultipleChoiceTask.java
@@ -3,10 +3,10 @@ package task.taskdsltypes;
 import semanticanalysis.types.DSLTypeAdapter;
 import semanticanalysis.types.DSLTypeMember;
 
+import task.Quiz;
 import task.Task;
 import task.TaskContent;
 import task.quizquestion.MultipleChoice;
-import task.quizquestion.Quiz;
 
 import java.util.List;
 import java.util.Set;

--- a/dungeon/src/task/taskdsltypes/SingleChoiceDescriptionProperty.java
+++ b/dungeon/src/task/taskdsltypes/SingleChoiceDescriptionProperty.java
@@ -3,7 +3,7 @@ package task.taskdsltypes;
 import semanticanalysis.types.DSLTypeProperty;
 import semanticanalysis.types.IDSLTypeProperty;
 
-import task.quizquestion.Quiz;
+import task.Quiz;
 
 @DSLTypeProperty(name = "description", extendedType = SingleChoiceTask.class)
 public class SingleChoiceDescriptionProperty implements IDSLTypeProperty<Quiz, String> {

--- a/dungeon/src/task/taskdsltypes/SingleChoiceTask.java
+++ b/dungeon/src/task/taskdsltypes/SingleChoiceTask.java
@@ -3,9 +3,9 @@ package task.taskdsltypes;
 import semanticanalysis.types.DSLTypeAdapter;
 import semanticanalysis.types.DSLTypeMember;
 
+import task.Quiz;
 import task.Task;
 import task.TaskContent;
-import task.quizquestion.Quiz;
 import task.quizquestion.SingleChoice;
 
 import java.util.List;

--- a/dungeon/test/manual/quizquestion/CallbackTest.java
+++ b/dungeon/test/manual/quizquestion/CallbackTest.java
@@ -15,6 +15,7 @@ import core.hud.UITools;
 import core.level.utils.LevelSize;
 import core.systems.LevelSystem;
 
+import task.Quiz;
 import task.Task;
 import task.TaskContent;
 import task.components.TaskComponent;

--- a/dungeon/test/manual/quizquestion/QuizQuestionUITest.java
+++ b/dungeon/test/manual/quizquestion/QuizQuestionUITest.java
@@ -7,6 +7,7 @@ import com.badlogic.gdx.scenes.scene2d.ui.Image;
 
 import core.Game;
 
+import task.Quiz;
 import task.quizquestion.*;
 
 import java.util.Random;

--- a/dungeon/test/manual/taskgeneration/TaskGenerationTest.java
+++ b/dungeon/test/manual/taskgeneration/TaskGenerationTest.java
@@ -17,10 +17,10 @@ import dungeonFiles.DungeonConfig;
 
 import interpreter.DSLInterpreter;
 
+import task.Quiz;
 import task.Task;
 import task.TaskContent;
 import task.components.TaskComponent;
-import task.quizquestion.Quiz;
 import task.quizquestion.UIAnswerCallback;
 
 import java.io.IOException;


### PR DESCRIPTION
fixes #1013, fixes #1014

- Fügt im wesentlichen die besprochene Struktur (siehe UML) hinzu
![image](https://github.com/Programmiermethoden/Dungeon/assets/32962412/3ba4fbd9-21dc-443d-ae0a-7defbe33f5b2)
- Schiebt die Klasse `Quest` auf die selbe Ebene mit den anderen Tasks, so bleibt es einheitlich 