### PR TITLE
[Game] fix pause no longer opens after closing with hotkey

### DIFF
--- a/game/src/contrib/utils/components/Debugger.java
+++ b/game/src/contrib/utils/components/Debugger.java
@@ -201,7 +201,7 @@ public class Debugger {
                 || pauseMenu
                         .fetch(UIComponent.class)
                         .map(x -> x.dialog().getStage() == null)
-                        .orElse(false)) pauseMenu = newPauseMenu();
+                        .orElse(true)) pauseMenu = newPauseMenu();
     }
 
     private static Entity newPauseMenu() {


### PR DESCRIPTION
fixes #1028 
Hotkey Fenster schließen (Escape) entfernt zusätzlich von Herunternehmen des Elements vom UI auch die Komponente. Daher hatte das Pausemenu nicht mitbekommen, dass dort eine Änderung war. Ich war mir sicher, alle Fälle durchprobiert zu haben. Öffnen und schließen über UI sowie über Hotkey 