### PR TITLE
[DOC] add Zusammensfassung: An Analysis Framework for Designing Declarative Knowledge Training Games Using Roguelite Genre (Related Work)

### DIFF
--- a/doc/related_work/analysis_framework.md
+++ b/doc/related_work/analysis_framework.md
@@ -17,4 +17,8 @@ title: "An Analysis Framework for Designing Declarative Knowledge Training Games
 
 ## Zusammenfassung 
 
-tbd
+Beim Entwickeln von Videospielen müssen bekanntlich Design-Entscheidungen getroffen werden, welche Spielefeatures in welcher Form implementiert werden und wie sich bestimmte Aktionen im Spiel verhalten. In der klassischen Entwicklung würde ich diese Entscheidungen mit dem Hintergedanken 'Was macht am meisten Spaß?' treffen. Wenn Spiele für die Lehre eingesetzt werden, muss natürlich auch die Frage im Vordergrund stehen: 'Was steigert den Lernerfolg?'
+
+Das Paper stellt ein Framework vor, das dabei hilft, die beiden Blickwinkel 'Lehre' und 'Game' besser miteinander in Verbindung zu setzen. Dafür wurden 11 Fragen aufgestellt, die sich unter anderem damit beschäftigen, wie die Schwierigkeit des Spiels gesteuert werden kann, was passieren soll, wenn der Spieler stirbt, oder welche Aspekte des Spiels zufallsgeneriert sind und sich von Lauf zu Lauf verändern und welche statisch sind.
+
+Das Paper versucht nicht, diese Fragen generell und abschließend zu beantworten, sondern zeigt (anhand eines Fallbeispiels), wie man sich für seinen Anwendungsfall der 'besten Antwort' auf die einzelnen Fragen annähern kann."

--- a/doc/related_work/analysis_framework.md
+++ b/doc/related_work/analysis_framework.md
@@ -21,4 +21,4 @@ Beim Entwickeln von Videospielen müssen bekanntlich Design-Entscheidungen getro
 
 Das Paper stellt ein Framework vor, das dabei hilft, die beiden Blickwinkel 'Lehre' und 'Game' besser miteinander in Verbindung zu setzen. Dafür wurden 11 Fragen aufgestellt, die sich unter anderem damit beschäftigen, wie die Schwierigkeit des Spiels gesteuert werden kann, was passieren soll, wenn der Spieler stirbt, oder welche Aspekte des Spiels zufallsgeneriert sind und sich von Lauf zu Lauf verändern und welche statisch sind.
 
-Das Paper versucht nicht, diese Fragen generell und abschließend zu beantworten, sondern zeigt (anhand eines Fallbeispiels), wie man sich für seinen Anwendungsfall der 'besten Antwort' auf die einzelnen Fragen annähern kann."
+Das Paper versucht nicht, diese Fragen generell und abschließend zu beantworten, sondern zeigt (anhand eines Fallbeispiels), wie man sich für seinen Anwendungsfall der 'besten Antwort' auf die einzelnen Fragen annähern kann.


### PR DESCRIPTION
Fügt die Zusammenfassung für das Paper 'Ein Analyserahmen für die Gestaltung von deklarativen Wissens-Trainingspielen im Roguelite-Genre' hinzu.

Das Paper beschäftigt sich relativ lange mit ihrem 'Fallbeispiel', aber für uns ist eigentlich die Grundprämisse interessanter: 'Welche Fragen muss ich mir stellen, wenn ich ein Rogue-Like als Lernspiel verwenden möchte?' Daher habe ich die Zusammenfassung genau auf diesen Punkt fokussiert.

Die Zusammenfassung ist auch nicht als Ersatz für das Paper gedacht, sondern eher als Anreiz zum Vertiefen: 'Schau mal, was sie gemacht haben. Lohnt es sich, noch genauer hineinzusehen?'