### PR TITLE
[Dungeon] add `Task#find` to find the entity to a `TaskContent`

### DIFF
--- a/dungeon/src/task/Task.java
+++ b/dungeon/src/task/Task.java
@@ -7,9 +7,11 @@ import petriNet.Place;
 import semanticanalysis.types.DSLType;
 
 import task.components.TaskComponent;
+import task.components.TaskContentComponent;
 
 import java.util.*;
 import java.util.function.BiFunction;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
@@ -205,6 +207,31 @@ public abstract class Task {
      */
     public static Stream<Task> allTasks() {
         return new HashSet<>(ALL_TASKS).stream();
+    }
+
+    /**
+     * Finds the entity that implements the TaskContentComponent linked to the given TaskContent.
+     *
+     * @param content The task content to find the entity for.
+     * @return The entity that implements the TaskContentComponent linked to the given content.
+     */
+    public Entity find(TaskContent content) {
+        final Entity[] found = {null};
+        entitySets.forEach(
+                set ->
+                        set.forEach(
+                                entity ->
+                                        entity.fetch(TaskContentComponent.class)
+                                                .ifPresent(
+                                                        taskContentComponent -> {
+                                                            if (taskContentComponent.stream()
+                                                                    .collect(Collectors.toSet())
+                                                                    .contains(content)) {
+                                                                found[0] = entity;
+                                                            }
+                                                        })));
+
+        return found[0];
     }
 
     /**

--- a/game/src/starter/Main.java
+++ b/game/src/starter/Main.java
@@ -19,7 +19,7 @@ import java.util.Set;
 public class Main {
     public static void main(String[] args) throws IOException {
         // toggle this to off, if you want to use the default level generator
-        boolean useRoomBasedLevel = true;
+        boolean useRoomBasedLevel = false;
 
         Game.initBaseLogger();
         Debugger debugger = new Debugger();

--- a/game/src/starter/Main.java
+++ b/game/src/starter/Main.java
@@ -19,7 +19,7 @@ import java.util.Set;
 public class Main {
     public static void main(String[] args) throws IOException {
         // toggle this to off, if you want to use the default level generator
-        boolean useRoomBasedLevel = false;
+        boolean useRoomBasedLevel = true;
 
         Game.initBaseLogger();
         Debugger debugger = new Debugger();


### PR DESCRIPTION
fixes #1045 

- iteriert über alle entitäten die zu einem Task gehören und sucht sich die Entität aus, die das `TaskContentComponent` implementiert, welches mit den übergebenen `TaskContent` gelinkt ist. 