### PR TITLE
[DSL] Interpretation von `DSLEntryPoint`

### DIFF
--- a/dsl/src/interpreter/DSLInterpreter.java
+++ b/dsl/src/interpreter/DSLInterpreter.java
@@ -5,6 +5,7 @@ import antlr.main.DungeonDSLParser;
 
 import dungeonFiles.DSLEntryPoint;
 import dungeonFiles.DungeonConfig;
+
 import interpreter.dot.Interpreter;
 
 import org.antlr.v4.runtime.CharStreams;

--- a/dsl/src/interpreter/DSLInterpreter.java
+++ b/dsl/src/interpreter/DSLInterpreter.java
@@ -66,6 +66,13 @@ public class DSLInterpreter implements AstVisitor<Object> {
         memoryStack.push(globalSpace);
     }
 
+    /**
+     * Create a {@link DungeonConfig} instance for given {@link DSLEntryPoint}, this will reset the
+     * environment of this {@link DSLInterpreter}
+     *
+     * @param entryPoint the {@link DSLEntryPoint} to interpret.
+     * @return the interpreted {@link DungeonConfig}.
+     */
     public DungeonConfig interpretEntryPoint(DSLEntryPoint entryPoint) {
         Node filesRootASTNode = entryPoint.file().rootASTNode();
 
@@ -333,7 +340,7 @@ public class DSLInterpreter implements AstVisitor<Object> {
         return Value.NONE;
     }
 
-    public DungeonConfig generateQuestConfig(ObjectDefNode configDefinitionNode) {
+    protected DungeonConfig generateQuestConfig(ObjectDefNode configDefinitionNode) {
         createGameObjectPrototypes(this.environment);
         Value configValue = (Value) configDefinitionNode.accept(this);
         Object config = configValue.getInternalValue();

--- a/dsl/test/interpreter/TetsDSLEntryPointFinder.java
+++ b/dsl/test/interpreter/TetsDSLEntryPointFinder.java
@@ -2,8 +2,11 @@ package interpreter;
 
 import dungeonFiles.DSLEntryPoint;
 
+import dungeonFiles.DungeonConfig;
 import org.junit.Assert;
 import org.junit.Test;
+import task.Task;
+import taskdependencygraph.TaskNode;
 
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -58,5 +61,62 @@ public class TetsDSLEntryPointFinder {
         DSLEntryPoint forthEntryPoint = entryPoints.get(3);
         Assert.assertEquals("my_completely_other_config", forthEntryPoint.displayName());
         Assert.assertEquals(secondPath, forthEntryPoint.file().filePath());
+    }
+
+    @Test
+    public void testEntryPointToDungeonConfig() {
+        List<DSLEntryPoint> entryPoints = new ArrayList<>();
+        DSLEntryPointFinder finder = new DSLEntryPointFinder();
+        URL resource1 = getClass().getClassLoader().getResource("config1.dng");
+        assert resource1 != null;
+        Path firstPath = null;
+        try {
+            firstPath = Path.of(resource1.toURI());
+            var entryPointsFromFile = finder.getEntryPoints(firstPath).get();
+            entryPoints.addAll(entryPointsFromFile);
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+
+        URL resource2 = getClass().getClassLoader().getResource("config2.dng");
+        assert resource2 != null;
+        Path secondPath = null;
+        try {
+            secondPath = Path.of(resource2.toURI());
+            var entryPointsFromFile = finder.getEntryPoints(secondPath).get();
+            entryPoints.addAll(entryPointsFromFile);
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+
+        DSLInterpreter interpreter = new DSLInterpreter();
+
+        DSLEntryPoint firstEntryPoint = entryPoints.get(0);
+        DungeonConfig config = interpreter.interpretEntryPoint(firstEntryPoint);
+        Assert.assertEquals("This is my config 1", config.displayName());
+        TaskNode taskNode = config.dependencyGraph().nodeIterator().next();
+        Task task = taskNode.task();
+        Assert.assertEquals("Task1", task.taskText());
+
+        DSLEntryPoint secondEntryPoint = entryPoints.get(1);
+        config = interpreter.interpretEntryPoint(secondEntryPoint);
+        Assert.assertEquals("my_other_config", config.displayName());
+        taskNode = config.dependencyGraph().nodeIterator().next();
+        task = taskNode.task();
+        Assert.assertEquals("Task2", task.taskText());
+
+        DSLEntryPoint thirdEntryPoint = entryPoints.get(2);
+        config = interpreter.interpretEntryPoint(thirdEntryPoint);
+        Assert.assertEquals("This is my config 2", config.displayName());
+        taskNode = config.dependencyGraph().nodeIterator().next();
+        task = taskNode.task();
+        Assert.assertEquals("Kuckuck1", task.taskText());
+
+        DSLEntryPoint forthEntryPoint = entryPoints.get(3);
+        config = interpreter.interpretEntryPoint(forthEntryPoint);
+        Assert.assertEquals("my_completely_other_config", config.displayName());
+        taskNode = config.dependencyGraph().nodeIterator().next();
+        task = taskNode.task();
+        Assert.assertEquals("Kuckuck2", task.taskText());
     }
 }

--- a/dsl/test/interpreter/TetsDSLEntryPointFinder.java
+++ b/dsl/test/interpreter/TetsDSLEntryPointFinder.java
@@ -1,11 +1,13 @@
 package interpreter;
 
 import dungeonFiles.DSLEntryPoint;
-
 import dungeonFiles.DungeonConfig;
+
 import org.junit.Assert;
 import org.junit.Test;
+
 import task.Task;
+
 import taskdependencygraph.TaskNode;
 
 import java.net.URISyntaxException;

--- a/dsl/test_resources/config1.dng
+++ b/dsl/test_resources/config1.dng
@@ -1,14 +1,28 @@
-single_choice_task my_task {
-    description: "Hello",
+single_choice_task my_task1 {
+    description: "Task1",
     answers: ["1", "2", "3"],
     correct_answer_index: 2
 }
 
+single_choice_task my_task2 {
+    description: "Task2",
+    answers: ["1", "2", "3"],
+    correct_answer_index: 2
+}
+
+graph g1 {
+    my_task1
+}
+
+graph g2 {
+    my_task2
+}
+
 dungeon_config my_config {
     name: "This is my config 1",
-    tasks: [my_task]
+    dependency_graph: g1
 }
 
 dungeon_config my_other_config {
-    tasks: [my_task]
+    dependency_graph: g2
 }

--- a/dsl/test_resources/config2.dng
+++ b/dsl/test_resources/config2.dng
@@ -1,14 +1,28 @@
-single_choice_task my_task {
-    description: "Kuckuck",
+single_choice_task my_task1 {
+    description: "Kuckuck1",
     answers: ["1", "2", "3"],
     correct_answer_index: 2
 }
 
+single_choice_task my_task2 {
+    description: "Kuckuck2",
+    answers: ["1", "2", "3"],
+    correct_answer_index: 2
+}
+
+graph g1 {
+    my_task1
+}
+
+graph g2 {
+    my_task2
+}
+
 dungeon_config my_other_config {
     name: "This is my config 2",
-    tasks: [my_task]
+    dependency_graph: g1
 }
 
 dungeon_config my_completely_other_config {
-    tasks: [my_task]
+    dependency_graph: g2
 }


### PR DESCRIPTION
Implementiert die Interpretation eines `DSLEntryPoint` durch den `DSLInterpreter`.
Aktuell wird für jeden `DSLEntryPoint` das komplette Environment des DSLInterpreters neu aufgebaut. Aktuell unterstützt der DSLInterpreter auch nur DSL-Definitionen, die sich auf eine Datei beschränken, daher führt das zu keinen Problemen. Sobald an der Interpretation einer DSL-Definition mehrere Dateien beteiligt sind (bspw. wenn #171 umgesetzt ist) oder Funktionsdefinitionen potenziell länger als eine DungeonConfig leben (z.B. Taskbuilder, siehe #1041 ), sollte das geändert werden.