### PR TITLE
[GAME] Entities offset fix

### DIFF
--- a/game/src/core/systems/LevelSystem.java
+++ b/game/src/core/systems/LevelSystem.java
@@ -173,7 +173,7 @@ public final class LevelSystem extends System {
                 if (t.levelElement() != LevelElement.SKIP) {
                     String texturePath = t.texturePath();
                     if (!mapping.containsKey(texturePath)) {
-                        mapping.put(texturePath, new PainterConfig(texturePath));
+                        mapping.put(texturePath, new PainterConfig(texturePath, 0.5f, 0.25f));
                     }
                     painter.draw(t.position(), texturePath, mapping.get(texturePath));
                 }

--- a/game/src/core/utils/components/draw/PainterConfig.java
+++ b/game/src/core/utils/components/draw/PainterConfig.java
@@ -25,7 +25,7 @@ public class PainterConfig {
     }
 
     private PainterConfig(Texture texture) {
-        this(-0.85f, -0.5f, 1, texture);
+        this(0f, 0f, 1, texture);
     }
 
     /**
@@ -36,6 +36,17 @@ public class PainterConfig {
      */
     public PainterConfig(String texturePath) {
         this(TextureMap.instance().textureAt(texturePath));
+    }
+
+    /**
+     * Paints the given texture at the given position on the given batch with default offset and
+     * default scaling.
+     *
+     * @param texturePath path to the texture
+     */
+    public PainterConfig(String texturePath, float xOffset, float yOffset) {
+        // half the texture xOffset, yOffset is a quarter texture down
+        this(xOffset, yOffset, 1, TextureMap.instance().textureAt(texturePath));
     }
 
     /**


### PR DESCRIPTION
fixes #925

Die Level Tiles werden um eine halbe Texture offset und dadurch befinden sich Helden und Monster in der Mitte des Tiles anstelle von dem oberen rechten Rand.