### PR TITLE
[GAME] fix bug where entities spawn in the wall (or outside the level)

### DIFF
--- a/game/src/core/components/PositionComponent.java
+++ b/game/src/core/components/PositionComponent.java
@@ -1,9 +1,7 @@
 package core.components;
 
 import core.Component;
-import core.Game;
 import core.level.Tile;
-import core.level.utils.LevelElement;
 import core.utils.Point;
 
 import semanticanalysis.types.DSLType;
@@ -54,18 +52,12 @@ public final class PositionComponent implements Component {
     /**
      * Creates a new PositionComponent with a random position.
      *
-     * <p>Sets the position of this entity on a random floor tile in the level. If no level is
-     * loaded, the position is set to {@link #ILLEGAL_POSITION}. Keep in mind that if the associated
-     * entity is processed by the {@link core.systems.PositionSystem}, {@link #ILLEGAL_POSITION}
-     * will be replaced with a random accessible position.
+     * <p>Sets the position of this entity to {@link #ILLEGAL_POSITION}. Keep in mind that if the
+     * associated entity is processed by the {@link core.systems.PositionSystem}, {@link
+     * #ILLEGAL_POSITION} will be replaced with a random accessible position.
      */
     public PositionComponent() {
-
-        if (Game.currentLevel() != null) {
-            position = Game.randomTilePoint(LevelElement.FLOOR);
-        } else {
-            position = ILLEGAL_POSITION;
-        }
+        position = ILLEGAL_POSITION;
     }
 
     /**

--- a/game/test/contrib/entities/MonsterTest.java
+++ b/game/test/contrib/entities/MonsterTest.java
@@ -55,9 +55,6 @@ public class MonsterTest {
         Optional<PositionComponent> positionComponent = m.fetch(PositionComponent.class);
         assertTrue("Entity needs the PositionComponent.", positionComponent.isPresent());
         PositionComponent pc = positionComponent.get();
-        assertTrue(
-                "Entity needs to spawn somewhere accessible",
-                Game.currentLevel().tileAt(pc.position().toCoordinate()).isAccessible());
 
         Optional<HealthComponent> HealthComponent = m.fetch(HealthComponent.class);
         assertTrue("Entity needs the HealthComponent to take damage", HealthComponent.isPresent());

--- a/game/test/core/systems/CameraSystemTest.java
+++ b/game/test/core/systems/CameraSystemTest.java
@@ -52,11 +52,10 @@ public class CameraSystemTest {
     public void executeWithEntity() {
         Game.currentLevel(level);
         Entity entity = new Entity();
-        PositionComponent positionComponent = new PositionComponent();
+        expectedFocusPoint = new Point(3, 3);
+        PositionComponent positionComponent = new PositionComponent(expectedFocusPoint);
         entity.addComponent(positionComponent);
         entity.addComponent(new CameraComponent());
-
-        expectedFocusPoint = positionComponent.position();
 
         cameraSystem.execute();
         assertEquals(expectedFocusPoint.x, CameraSystem.camera().position.x, 0.001);


### PR DESCRIPTION
fixes #1065

Das Problem war, dass einige Entitäten nicht (wie es korrekt gewesen wäre) mit einer Illegalen-Position initialisiert wurden, sondern sich ein zufälliges Floor-Tile aus den Wizard-Quest-Selector level gesucht hatten. 
Ich habe den Ctor im PositionComponent so verändert, das Entitäten immer mit einer Illegalen Position initialisiert werden (der rest wird eh vom `PositonSystem` erledigt).


