### PR TITLE
[GAME] Items now get dropped at the Illegal Position

### DIFF
--- a/game/src/contrib/entities/WorldItemBuilder.java
+++ b/game/src/contrib/entities/WorldItemBuilder.java
@@ -21,7 +21,7 @@ public class WorldItemBuilder {
      */
     public static Entity buildWorldItem(Item item) {
         Entity droppedItem = new Entity();
-        droppedItem.addComponent(new PositionComponent(new Point(0, 0)));
+        droppedItem.addComponent(new PositionComponent(PositionComponent.ILLEGAL_POSITION));
         droppedItem.addComponent(new DrawComponent(item.worldAnimation()));
         droppedItem.addComponent(new ItemComponent(item));
 


### PR DESCRIPTION
Der `WorldItemBuilder` platziert ein runtergefallenes Item nun per default auf die Illegale Position, das `PositionSystem` schiebt die dann auf eine gültige Position.