### PR TITLE
[GAME] add SpikeSystem, hero now gets damage if he collides with monster

### DIFF
--- a/dungeon/src/starter/Starter.java
+++ b/dungeon/src/starter/Starter.java
@@ -195,6 +195,7 @@ public class Starter {
         Game.add(new HealthbarSystem());
         Game.add(new HeroUISystem());
         Game.add(new HudSystem());
+        Game.add(new SpikeSystem());
     }
 
     private static Set<DSLEntryPoint> processCLIArguments(String[] args) throws IOException {

--- a/game/src/contrib/components/SpikyComponent.java
+++ b/game/src/contrib/components/SpikyComponent.java
@@ -1,0 +1,89 @@
+package contrib.components;
+
+import contrib.utils.components.health.Damage;
+import contrib.utils.components.health.DamageType;
+
+import core.Component;
+
+/**
+ * Marks an Entity as "spiky".
+ *
+ * <p>In combination with the {@link HealthComponent} and {@link CollideComponent}, the {@link
+ * SpikyComponent} can be used to apply damage to an entity (like the hero) on collision.
+ *
+ * <p>This component stores information about the {@link DamageType}, the damage amount, so you can
+ * create a new {@link contrib.utils.components.health.Damage} object.
+ *
+ * <p>This component also stores a cooldown (in frames) so you can prevent continuous damage. The
+ * cooldown will be reduced by the {@link contrib.systems.SpikeSystem}.
+ *
+ * <p>To apply damage on collision, first create an entity (like a monster) with a {@link
+ * CollideComponent} and {@link SpikyComponent}. Also create an entity (like the hero) that has a
+ * {@link CollideComponent} and {@link HealthComponent}. Now implement the damage calculation. In
+ * the hero's collision method, check whether the other entity (the monster) implements the {@link
+ * SpikyComponent} and whether the cooldown has expired ({@link #isActive()}). If so, use {@link
+ * HealthComponent#receiveHit(Damage)} to deal damage to the hero. Remember to activate the cooldown
+ * of this component using {@link #activateCoolDown()}.
+ *
+ * <p>Use {@link #damageAmount} and {@link #damageType} to get the damage information.
+ *
+ * @see contrib.entities.EntityFactory
+ */
+public class SpikyComponent implements Component {
+    private final int damageAmount;
+    private final DamageType damageType;
+
+    private final int coolDown;
+    private int currentCoolDown;
+
+    /**
+     * Create a new {@link SpikyComponent}.
+     *
+     * @param damageAmount The amount of damage that should be caused on collision.
+     * @param damageType The type of damage to cause.
+     * @param coolDown How many frames to wait before reapplying damage to an entity.
+     */
+    public SpikyComponent(int damageAmount, DamageType damageType, int coolDown) {
+        this.damageAmount = damageAmount;
+        this.damageType = damageType;
+        this.coolDown = coolDown;
+        this.currentCoolDown = coolDown;
+    }
+
+    /**
+     * Amount of damage to cause.
+     *
+     * @return amount of damage.
+     */
+    public int damageAmount() {
+        return damageAmount;
+    }
+
+    /**
+     * Type of damage to cause.
+     *
+     * @return the type of damage.
+     */
+    public DamageType damageType() {
+        return damageType;
+    }
+
+    /**
+     * Is the cool down 0?
+     *
+     * @return true if the cool down is 0, false if not.
+     */
+    public boolean isActive() {
+        return currentCoolDown == 0;
+    }
+
+    /** Set the current cool down to the cool down configured in the constructor. */
+    public void activateCoolDown() {
+        currentCoolDown = coolDown;
+    }
+
+    /** Reduce the current cool down by one. */
+    public void reduceCoolDown() {
+        currentCoolDown = Math.max(0, currentCoolDown - 1);
+    }
+}

--- a/game/src/contrib/systems/SpikeSystem.java
+++ b/game/src/contrib/systems/SpikeSystem.java
@@ -1,0 +1,23 @@
+package contrib.systems;
+
+import contrib.components.SpikyComponent;
+
+import core.System;
+
+/**
+ * Reduces the current cool down for each {@link SpikyComponent} once per frame.
+ *
+ * @see SpikyComponent
+ */
+public class SpikeSystem extends System {
+
+    /** Create new SpikeSystem. */
+    public SpikeSystem() {
+        super(SpikyComponent.class);
+    }
+
+    @Override
+    public void execute() {
+        entityStream().forEach(e -> e.fetch(SpikyComponent.class).orElseThrow().reduceCoolDown());
+    }
+}

--- a/game/src/starter/Main.java
+++ b/game/src/starter/Main.java
@@ -152,5 +152,6 @@ public class Main {
         Game.add(new HealthbarSystem());
         Game.add(new HeroUISystem());
         Game.add(new HudSystem());
+        Game.add(new SpikeSystem());
     }
 }


### PR DESCRIPTION
Kleine Änderungen für ein besseres Spielgefühl.
Es kann nun Schaden bei Kollision verursacht werden.

- Fügt das `SpikyComponent` hinzu (dieses speichert den Schaden-Wert, Typ und den Cool Down (Zeit zwischen zwei Schadensberechnungen bei Kollision).
- Fügt das `SpikeSystem` hinzu, welches pro Frame den Cool Down reduziert.
- Implementiert das Component in den Monstern.
- Implementiert das Schadensverhalten im Callback des `CollideComponent` im Helden.

## Wie funktioniert das?
Eigentlich recht einfach: Während einer Kollision überprüfe ich, ob `other` (also der, mit dem ich kollidiere) ein `SpikyComponent` hat und, wenn ja, ob dieses aktiv ist (nicht auf Cool Down). Wenn beides der Fall ist, kann ich `you` (also mir, z.B. dem Helden) Schaden hinzufügen. Dafür nehme ich die Informationen aus dem `SpikyComponent` des Monsters und erstelle mir ein `Damage`-Objekt, mit dem ich dann dem `HealthComponent` des Helden Schaden zufüge. Anschließend setze ich den Cool Down des `SpikyComponent`.