### PR TITLE
[GAME] better Items and Crafting settings

### DIFF
--- a/game/assets/recipes/healtpotion_berry.recipe
+++ b/game/assets/recipes/healtpotion_berry.recipe
@@ -1,17 +1,24 @@
 {
-    "ordered": true,
+    "ordered": false,
     "ingredients": [
         {
             "type": "item",
             "item": {
-                "id": "ItemResourceIronOre",
+                "id": "ItemResourceBerry",
                 "count": 1
             }
         },
         {
             "type": "item",
             "item": {
-                "id": "ItemResourceWood",
+                "id": "ItemResourceBerry",
+                "count": 1
+            }
+        },
+        {
+            "type": "item",
+            "item": {
+                "id": "ItemPotionWater",
                 "count": 1
             }
         }
@@ -20,7 +27,7 @@
         {
             "type": "item",
             "item": {
-                "id": "ItemResourceSteel",
+                "id": "ItemPotionHealth",
                 "count": 1
             }
         }

--- a/game/assets/recipes/healtpotion_mushroom.recipe
+++ b/game/assets/recipes/healtpotion_mushroom.recipe
@@ -1,0 +1,28 @@
+{
+    "ordered": false,
+    "ingredients": [
+        {
+            "type": "item",
+            "item": {
+                "id": "ItemResourceBerry",
+                "count": 1
+            }
+        },
+        {
+            "type": "item",
+            "item": {
+                "id": "ItemPotionWater",
+                "count": 1
+            }
+        }
+    ],
+    "results": [
+        {
+            "type": "item",
+            "item": {
+                "id": "ItemPotionHealth",
+                "count": 1
+            }
+        }
+    ]
+}

--- a/game/assets/recipes/healtpotion_mushroom.recipe
+++ b/game/assets/recipes/healtpotion_mushroom.recipe
@@ -4,7 +4,7 @@
         {
             "type": "item",
             "item": {
-                "id": "ItemResourceBerry",
+                "id": "ItemResourceMushroomRed",
                 "count": 1
             }
         },

--- a/game/src/contrib/item/Item.java
+++ b/game/src/contrib/item/Item.java
@@ -348,7 +348,6 @@ public class Item implements CraftingIngredient, CraftingResult {
      */
     public void use(Entity user) {
         user.fetch(InventoryComponent.class).ifPresent(component -> component.remove(this));
-        System.out.printf("Item \"%s\" used by entity %d\n", this.displayName, user.id());
     }
 
     @Override

--- a/game/src/contrib/item/concreteItem/ItemPotionHealth.java
+++ b/game/src/contrib/item/concreteItem/ItemPotionHealth.java
@@ -1,14 +1,39 @@
 package contrib.item.concreteItem;
 
+import contrib.components.HealthComponent;
+import contrib.components.InventoryComponent;
 import contrib.item.Item;
+import contrib.utils.components.health.Damage;
+import contrib.utils.components.health.DamageType;
 
+import core.Entity;
 import core.utils.components.draw.Animation;
 
 public class ItemPotionHealth extends Item {
+
+    private static final int HEAL_AMOUNT = 50;
+
     public ItemPotionHealth() {
         super(
                 "Health Potion",
-                "A health potion. It heals you several health points.",
+                "A health potion. It heals you for " + HEAL_AMOUNT + " health points.",
                 Animation.of("items/potion/health_potion.png"));
+    }
+
+    @Override
+    public void use(Entity e, Item itemData) {
+        e.fetch(InventoryComponent.class)
+                .ifPresent(
+                        component -> {
+                            component.remove(itemData);
+                            e.fetch(HealthComponent.class)
+                                    .ifPresent(
+                                            hc ->
+                                                    hc.receiveHit(
+                                                            new Damage(
+                                                                    -HEAL_AMOUNT,
+                                                                    DamageType.HEAL,
+                                                                    null)));
+                        });
     }
 }

--- a/game/src/contrib/item/concreteItem/ItemPotionHealth.java
+++ b/game/src/contrib/item/concreteItem/ItemPotionHealth.java
@@ -21,11 +21,11 @@ public class ItemPotionHealth extends Item {
     }
 
     @Override
-    public void use(Entity e, Item itemData) {
+    public void use(Entity e) {
         e.fetch(InventoryComponent.class)
                 .ifPresent(
                         component -> {
-                            component.remove(itemData);
+                            component.remove(this);
                             e.fetch(HealthComponent.class)
                                     .ifPresent(
                                             hc ->

--- a/game/src/contrib/item/concreteItem/ItemPotionWater.java
+++ b/game/src/contrib/item/concreteItem/ItemPotionWater.java
@@ -23,11 +23,11 @@ public class ItemPotionWater extends Item {
     }
 
     @Override
-    public void use(Entity e, Item itemData) {
+    public void use(Entity e) {
         e.fetch(InventoryComponent.class)
                 .ifPresent(
                         component -> {
-                            component.remove(itemData);
+                            component.remove(this);
                             e.fetch(HealthComponent.class)
                                     .ifPresent(
                                             hc ->

--- a/game/src/contrib/item/concreteItem/ItemPotionWater.java
+++ b/game/src/contrib/item/concreteItem/ItemPotionWater.java
@@ -1,14 +1,41 @@
 package contrib.item.concreteItem;
 
+import contrib.components.HealthComponent;
+import contrib.components.InventoryComponent;
 import contrib.item.Item;
+import contrib.utils.components.health.Damage;
+import contrib.utils.components.health.DamageType;
 
+import core.Entity;
 import core.utils.components.draw.Animation;
 
 public class ItemPotionWater extends Item {
+
+    private static final int HEAL_AMOUNT = 5;
+
     public ItemPotionWater() {
         super(
                 "Bottle of Water",
-                "A bottle of water. It's not very useful except for hydration.",
+                "A bottle of water. It's not very useful except for hydration. It heals you for "
+                        + HEAL_AMOUNT
+                        + " health points.",
                 Animation.of("items/potion/water_bottle.png"));
+    }
+
+    @Override
+    public void use(Entity e, Item itemData) {
+        e.fetch(InventoryComponent.class)
+                .ifPresent(
+                        component -> {
+                            component.remove(itemData);
+                            e.fetch(HealthComponent.class)
+                                    .ifPresent(
+                                            hc ->
+                                                    hc.receiveHit(
+                                                            new Damage(
+                                                                    -HEAL_AMOUNT,
+                                                                    DamageType.HEAL,
+                                                                    null)));
+                        });
     }
 }

--- a/game/src/contrib/item/concreteItem/ItemResourceBerry.java
+++ b/game/src/contrib/item/concreteItem/ItemResourceBerry.java
@@ -1,11 +1,36 @@
 package contrib.item.concreteItem;
 
+import contrib.components.HealthComponent;
+import contrib.components.InventoryComponent;
 import contrib.item.Item;
+import contrib.utils.components.health.Damage;
+import contrib.utils.components.health.DamageType;
 
+import core.Entity;
 import core.utils.components.draw.Animation;
 
 public class ItemResourceBerry extends Item {
+
+    private static final int HEAL_AMOUNT = 5;
+
     public ItemResourceBerry() {
         super("Berry", "A berry.", Animation.of("items/resource/berry.png"));
+    }
+
+    @Override
+    public void use(Entity e, Item itemData) {
+        e.fetch(InventoryComponent.class)
+                .ifPresent(
+                        component -> {
+                            component.remove(itemData);
+                            e.fetch(HealthComponent.class)
+                                    .ifPresent(
+                                            hc ->
+                                                    hc.receiveHit(
+                                                            new Damage(
+                                                                    -HEAL_AMOUNT,
+                                                                    DamageType.HEAL,
+                                                                    null)));
+                        });
     }
 }

--- a/game/src/contrib/item/concreteItem/ItemResourceBerry.java
+++ b/game/src/contrib/item/concreteItem/ItemResourceBerry.java
@@ -18,11 +18,11 @@ public class ItemResourceBerry extends Item {
     }
 
     @Override
-    public void use(Entity e, Item itemData) {
+    public void use(Entity e) {
         e.fetch(InventoryComponent.class)
                 .ifPresent(
                         component -> {
-                            component.remove(itemData);
+                            component.remove(this);
                             e.fetch(HealthComponent.class)
                                     .ifPresent(
                                             hc ->

--- a/game/src/contrib/item/concreteItem/ItemResourceEgg.java
+++ b/game/src/contrib/item/concreteItem/ItemResourceEgg.java
@@ -1,14 +1,43 @@
 package contrib.item.concreteItem;
 
+import contrib.components.InventoryComponent;
+import contrib.entities.EntityFactory;
 import contrib.item.Item;
 
+import core.Entity;
+import core.Game;
+import core.components.PositionComponent;
 import core.utils.components.draw.Animation;
 
+import java.io.IOException;
+
 public class ItemResourceEgg extends Item {
+
     public ItemResourceEgg() {
         super(
                 "Egg",
                 "An egg. What was there before? The chicken or the egg?",
                 Animation.of("items/resource/egg.png"));
+    }
+
+    @Override
+    public void use(Entity e, Item itemData) {
+        e.fetch(InventoryComponent.class)
+                .ifPresent(
+                        component -> {
+                            component.remove(itemData);
+                            try {
+                                Entity monster = EntityFactory.randomMonster();
+                                monster.fetch(PositionComponent.class)
+                                        .orElseThrow()
+                                        .position(
+                                                e.fetch(PositionComponent.class)
+                                                        .orElseThrow()
+                                                        .position());
+                                Game.add(monster);
+                            } catch (IOException ex) {
+                                throw new RuntimeException(ex);
+                            }
+                        });
     }
 }

--- a/game/src/contrib/item/concreteItem/ItemResourceEgg.java
+++ b/game/src/contrib/item/concreteItem/ItemResourceEgg.java
@@ -21,11 +21,11 @@ public class ItemResourceEgg extends Item {
     }
 
     @Override
-    public void use(Entity e, Item itemData) {
+    public void use(Entity e) {
         e.fetch(InventoryComponent.class)
                 .ifPresent(
                         component -> {
-                            component.remove(itemData);
+                            component.remove(this);
                             try {
                                 Entity monster = EntityFactory.randomMonster();
                                 monster.fetch(PositionComponent.class)

--- a/game/src/contrib/item/concreteItem/ItemResourceMushroomRed.java
+++ b/game/src/contrib/item/concreteItem/ItemResourceMushroomRed.java
@@ -1,11 +1,36 @@
 package contrib.item.concreteItem;
 
+import contrib.components.HealthComponent;
+import contrib.components.InventoryComponent;
 import contrib.item.Item;
+import contrib.utils.components.health.Damage;
+import contrib.utils.components.health.DamageType;
 
+import core.Entity;
 import core.utils.components.draw.Animation;
 
 public class ItemResourceMushroomRed extends Item {
+
+    private static final int DAMAGE_AMOUNT = 20;
+
     public ItemResourceMushroomRed() {
         super("Red Mushroom", "A red mushroom.", Animation.of("items/resource/mushroom_red.png"));
+    }
+
+    @Override
+    public void use(Entity e, Item itemData) {
+        e.fetch(InventoryComponent.class)
+                .ifPresent(
+                        component -> {
+                            component.remove(itemData);
+                            e.fetch(HealthComponent.class)
+                                    .ifPresent(
+                                            hc ->
+                                                    hc.receiveHit(
+                                                            new Damage(
+                                                                    DAMAGE_AMOUNT,
+                                                                    DamageType.POISON,
+                                                                    null)));
+                        });
     }
 }

--- a/game/src/contrib/item/concreteItem/ItemResourceMushroomRed.java
+++ b/game/src/contrib/item/concreteItem/ItemResourceMushroomRed.java
@@ -18,11 +18,11 @@ public class ItemResourceMushroomRed extends Item {
     }
 
     @Override
-    public void use(Entity e, Item itemData) {
+    public void use(Entity e) {
         e.fetch(InventoryComponent.class)
                 .ifPresent(
                         component -> {
-                            component.remove(itemData);
+                            component.remove(this);
                             e.fetch(HealthComponent.class)
                                     .ifPresent(
                                             hc ->

--- a/game/src/contrib/utils/components/health/DamageType.java
+++ b/game/src/contrib/utils/components/health/DamageType.java
@@ -4,5 +4,7 @@ package contrib.utils.components.health;
 public enum DamageType {
     PHYSICAL,
     MAGIC,
-    FIRE
+    FIRE,
+    HEAL,
+    POISON,
 }

--- a/game/src/contrib/utils/components/item/ItemDataGenerator.java
+++ b/game/src/contrib/utils/components/item/ItemDataGenerator.java
@@ -1,8 +1,6 @@
 package contrib.utils.components.item;
 
-import contrib.item.concreteItem.ItemDefault;
-
-import core.utils.components.draw.Animation;
+import contrib.item.concreteItem.*;
 
 import java.util.Random;
 
@@ -15,10 +13,12 @@ public class ItemDataGenerator {
      * @return a new randomItemData
      */
     public contrib.item.Item generateItemData() {
-        return new ItemDefault(
-                "Default Item",
-                "Default Item description",
-                new Animation("animation/missing_texture.png"),
-                new Animation("animation/missing_texture.png"));
+        return switch (rand.nextInt(8)) {
+            case 0 -> new ItemPotionHealth();
+            case 1, 2 -> new ItemPotionWater();
+            case 3, 4 -> new ItemResourceBerry();
+            case 5, 6 -> new ItemResourceEgg();
+            default -> new ItemResourceMushroomRed();
+        };
     }
 }


### PR DESCRIPTION
Im wesentlichen entfernt dieser PR einen Großteil der Item-Typen als Random-Loot option (die Item machen eh noch nichts, die blockieren also nur den Spiel-Flow).

Einige Items habe ich "fertig" implementiert
- Heiltränke heilen den Spieler
- Wasser und Beeren heilen dien Spieler leicht, können aber zu Heiltränken gebraut werden (2 Beeren + 1 Wasser)
- Pilze fügen den Helden Schaden zu, außer er braut sie mit Wasser zu einen Heiltrank
- Ei lässt ein Monster auf den Helden spawnen. 

