### PR TITLE
[GAME] remove random edges in levelgraph

### DIFF
--- a/game/src/contrib/level/generator/graphBased/LevelGraphGenerator.java
+++ b/game/src/contrib/level/generator/graphBased/LevelGraphGenerator.java
@@ -46,7 +46,8 @@ public class LevelGraphGenerator {
         // this will generate a tree
         entityCollections.forEach(graph::add);
         // draw some random edges to make it more fun
-        graph.addRandomEdges(RANGE_OF_RANDOM_EDGE_COUNT);
+        // TODO add some more rules so the level graph are more fun and less confusing
+        // graph.addRandomEdges(RANGE_OF_RANDOM_EDGE_COUNT);
         return graph;
     }
 


### PR DESCRIPTION
Beim generieren der Level-Graphen hatte ich am Ende noch zufällig Kanten in den Graphen gezeichnet, damit dieser etwas spannender und abwechslungsreicher wird.
In der praxis werden die Level dadurch aber eher verwirrend und mühsam zu durchqueren (man verläuft sich ständig)
Ich hab diese Funktion jetzt erstmal deaktiviert. 


Perspektivisch könnte man da nochmal ran (#1092) 