### PR TITLE
[GAME] Items aus Inventar per Tastendruck verwenden

### DIFF
--- a/game/src/contrib/configuration/KeyboardConfig.java
+++ b/game/src/contrib/configuration/KeyboardConfig.java
@@ -23,6 +23,8 @@ public class KeyboardConfig {
             new ConfigKey<>(new String[] {"ui", "close"}, new ConfigIntValue(Input.Keys.ESCAPE));
     public static final ConfigKey<Integer> INTERACT_WORLD =
             new ConfigKey<>(new String[] {"interact", "world"}, new ConfigIntValue(Input.Keys.E));
+    public static final ConfigKey<Integer> USE_ITEM =
+            new ConfigKey<>(new String[] {"item", "use"}, new ConfigIntValue(Input.Keys.E));
     public static final ConfigKey<Integer> FIRST_SKILL =
             new ConfigKey<>(new String[] {"skill", "first"}, new ConfigIntValue(Input.Keys.Q));
     public static final ConfigKey<Integer> SECOND_SKILL =

--- a/game/src/contrib/entities/EntityFactory.java
+++ b/game/src/contrib/entities/EntityFactory.java
@@ -147,9 +147,11 @@ public class EntityFactory {
                     UIComponent uiComponent = e.fetch(UIComponent.class).orElse(null);
                     if (uiComponent != null) {
                         if (uiComponent.dialog() instanceof GUICombination) {
+                            InventoryGUI.inHeroInventory = false;
                             e.removeComponent(UIComponent.class);
                         }
                     } else {
+                        InventoryGUI.inHeroInventory = true;
                         e.addComponent(
                                 new UIComponent(new GUICombination(new InventoryGUI(ic)), true));
                     }
@@ -185,6 +187,7 @@ public class EntityFactory {
                                     // zindex
                                     .orElse(null);
                     if (firstUI != null) {
+                        InventoryGUI.inHeroInventory = false;
                         firstUI.a().removeComponent(UIComponent.class);
                         if (firstUI.a().componentStream().findAny().isEmpty()) {
                             Game.remove(firstUI.a()); // delete unused Entity
@@ -251,18 +254,18 @@ public class EntityFactory {
                 new InteractionComponent(
                         defaultInteractionRadius,
                         true,
-                        (entity, who) -> {
-                            who.fetch(InventoryComponent.class)
-                                    .ifPresent(
-                                            whoIc -> {
-                                                who.addComponent(
-                                                        new UIComponent(
-                                                                new GUICombination(
-                                                                        new InventoryGUI(whoIc),
-                                                                        new InventoryGUI(ic)),
-                                                                false));
-                                            });
-                        }));
+                        (entity, who) ->
+                                who.fetch(InventoryComponent.class)
+                                        .ifPresent(
+                                                whoIc ->
+                                                        who.addComponent(
+                                                                new UIComponent(
+                                                                        new GUICombination(
+                                                                                new InventoryGUI(
+                                                                                        whoIc),
+                                                                                new InventoryGUI(
+                                                                                        ic)),
+                                                                        false)))));
         DrawComponent dc = new DrawComponent("objects/treasurechest");
         chest.addComponent(dc);
         dc.getAnimation(CoreAnimations.IDLE_RIGHT).ifPresent(a -> a.setLoop(false));
@@ -285,17 +288,18 @@ public class EntityFactory {
                 new InteractionComponent(
                         1f,
                         true,
-                        (entity, who) -> {
-                            who.fetch(InventoryComponent.class)
-                                    .ifPresent(
-                                            ic ->
-                                                    who.addComponent(
-                                                            new UIComponent(
-                                                                    new GUICombination(
-                                                                            new InventoryGUI(ic),
-                                                                            new CraftingGUI(ic)),
-                                                                    true)));
-                        }));
+                        (entity, who) ->
+                                who.fetch(InventoryComponent.class)
+                                        .ifPresent(
+                                                ic ->
+                                                        who.addComponent(
+                                                                new UIComponent(
+                                                                        new GUICombination(
+                                                                                new InventoryGUI(
+                                                                                        ic),
+                                                                                new CraftingGUI(
+                                                                                        ic)),
+                                                                        true)))));
         return cauldron;
     }
 

--- a/game/src/contrib/hud/inventory/InventoryGUI.java
+++ b/game/src/contrib/hud/inventory/InventoryGUI.java
@@ -11,6 +11,7 @@ import com.badlogic.gdx.graphics.g2d.GlyphLayout;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
 import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.scenes.scene2d.InputEvent;
+import com.badlogic.gdx.scenes.scene2d.InputListener;
 import com.badlogic.gdx.scenes.scene2d.ui.Image;
 import com.badlogic.gdx.scenes.scene2d.utils.DragAndDrop;
 
@@ -67,6 +68,8 @@ public class InventoryGUI extends CombinableGUI {
         this.inventoryComponent = inventoryComponent;
         this.title = title;
         this.slotsPerRow = Math.min(MAX_ITEMS_PER_ROW, this.inventoryComponent.items().length);
+
+        addInputListener();
     }
 
     /**
@@ -303,6 +306,25 @@ public class InventoryGUI extends CombinableGUI {
                         }
                     }
                 });
+    }
+
+    private void addInputListener() {
+        Game.stage().orElseThrow().setKeyboardFocus(this.actor());
+
+        this.actor().setBounds(0, 0, this.width(), this.height());
+
+        this.actor()
+                .addListener(
+                        new InputListener() {
+                            @Override
+                            public boolean keyTyped(InputEvent event, char character) {
+                                if (character == 'e' || character == 'E') {
+                                    System.out.println("USING ITEM");
+                                    return true;
+                                }
+                                return false;
+                            }
+                        });
     }
 
     @Override

--- a/game/src/contrib/hud/inventory/InventoryGUI.java
+++ b/game/src/contrib/hud/inventory/InventoryGUI.java
@@ -102,6 +102,13 @@ public class InventoryGUI extends CombinableGUI {
         this.drawItemInfo(batch);
     }
 
+    private int getSlotByMousePosition() {
+        Vector2 mousePos =
+                new Vector2(Gdx.input.getX(), Gdx.graphics.getHeight() - Gdx.input.getY());
+        Vector2 relMousePos = new Vector2(mousePos.x - this.x(), mousePos.y - this.y());
+        return getSlotByCoordinates(relMousePos.x, relMousePos.y);
+    }
+
     private int getSlotByCoordinates(int x, int y) {
         return (x / this.slotSize) + (y / this.slotSize) * this.slotsPerRow;
     }
@@ -319,12 +326,18 @@ public class InventoryGUI extends CombinableGUI {
                             @Override
                             public boolean keyTyped(InputEvent event, char character) {
                                 if (character == 'e' || character == 'E') {
-                                    System.out.println("USING ITEM");
+                                    useItem(
+                                            InventoryGUI.this.inventoryComponent.get(
+                                                    getSlotByMousePosition()));
                                     return true;
                                 }
                                 return false;
                             }
                         });
+    }
+
+    private void useItem(Item item) {
+        if (item != null) item.use(Game.hero().get(), item);
     }
 
     @Override

--- a/game/src/contrib/hud/inventory/InventoryGUI.java
+++ b/game/src/contrib/hud/inventory/InventoryGUI.java
@@ -35,6 +35,7 @@ public class InventoryGUI extends CombinableGUI {
     private static final BitmapFont bitmapFont;
     private static final Texture texture;
     private static final TextureRegion background, hoverBackground;
+    public static boolean inHeroInventory = false;
 
     static {
         // Prepare background texture
@@ -325,7 +326,7 @@ public class InventoryGUI extends CombinableGUI {
                         new InputListener() {
                             @Override
                             public boolean keyTyped(InputEvent event, char character) {
-                                if (character == 'e' || character == 'E') {
+                                if (inHeroInventory && (character == 'e' || character == 'E')) {
                                     useItem(
                                             InventoryGUI.this.inventoryComponent.get(
                                                     getSlotByMousePosition()));
@@ -337,7 +338,7 @@ public class InventoryGUI extends CombinableGUI {
     }
 
     private void useItem(Item item) {
-        if (item != null) item.use(Game.hero().get(), item);
+        if (item != null) item.use(Game.hero().get());
     }
 
     @Override

--- a/game/src/contrib/hud/inventory/InventoryGUI.java
+++ b/game/src/contrib/hud/inventory/InventoryGUI.java
@@ -345,7 +345,8 @@ public class InventoryGUI extends CombinableGUI {
     }
 
     private void useItem(Item item) {
-        if (item != null) item.use(Game.hero().get());
+        if (item != null)
+            item.use(Game.hero().orElseThrow(() -> new NullPointerException("There is no hero")));
     }
 
     @Override

--- a/game/src/contrib/hud/inventory/InventoryGUI.java
+++ b/game/src/contrib/hud/inventory/InventoryGUI.java
@@ -37,6 +37,12 @@ public class InventoryGUI extends CombinableGUI {
     private static final BitmapFont bitmapFont;
     private static final Texture texture;
     private static final TextureRegion background, hoverBackground;
+    /**
+     * Boolean to check if the opened inventory belongs to the hero. Items that are in an inventory
+     * which does not belong to the hero, e.g. a treasure chest, are not usable.
+     *
+     * <p>Will be set to true if the hero inventory is opened and set to false if it's closed.
+     */
     public static boolean inHeroInventory = false;
 
     static {

--- a/game/src/contrib/hud/inventory/InventoryGUI.java
+++ b/game/src/contrib/hud/inventory/InventoryGUI.java
@@ -1,6 +1,7 @@
 package contrib.hud.inventory;
 
 import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Input;
 import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.Pixmap;
@@ -16,6 +17,7 @@ import com.badlogic.gdx.scenes.scene2d.ui.Image;
 import com.badlogic.gdx.scenes.scene2d.utils.DragAndDrop;
 
 import contrib.components.InventoryComponent;
+import contrib.configuration.KeyboardConfig;
 import contrib.hud.CombinableGUI;
 import contrib.hud.GUICombination;
 import contrib.item.Item;
@@ -326,7 +328,12 @@ public class InventoryGUI extends CombinableGUI {
                         new InputListener() {
                             @Override
                             public boolean keyTyped(InputEvent event, char character) {
-                                if (inHeroInventory && (character == 'e' || character == 'E')) {
+                                if (inHeroInventory
+                                        && (Character.toLowerCase(character)
+                                                == Input.Keys.toString(
+                                                                KeyboardConfig.USE_ITEM.value())
+                                                        .toLowerCase()
+                                                        .toCharArray()[0])) {
                                     useItem(
                                             InventoryGUI.this.inventoryComponent.get(
                                                     getSlotByMousePosition()));

--- a/game/src/contrib/item/Item.java
+++ b/game/src/contrib/item/Item.java
@@ -344,16 +344,11 @@ public class Item implements CraftingIngredient, CraftingResult {
      * Defines the behavior when an item gets used. Prints a message to the console and removes the
      * item from the inventory.
      *
-     * @param e Entity that uses the item
-     * @param itemData Item that is used
+     * @param user Entity that uses the item.
      */
-    public static void use(Entity e, Item itemData) {
-        e.fetch(InventoryComponent.class)
-                .ifPresent(
-                        component -> {
-                            component.remove(itemData);
-                        });
-        System.out.printf("Item \"%s\" used by entity %d\n", itemData.displayName, e.id());
+    public void use(Entity user) {
+        user.fetch(InventoryComponent.class).ifPresent(component -> component.remove(this));
+        System.out.printf("Item \"%s\" used by entity %d\n", this.displayName, user.id());
     }
 
     @Override

--- a/game/test/contrib/utils/components/item/ItemTest.java
+++ b/game/test/contrib/utils/components/item/ItemTest.java
@@ -99,7 +99,7 @@ public class ItemTest {
     }
 
     @Test
-    public void testWorldAnimatiob() {
+    public void testWorldAnimation() {
         Item item = new Item("Test item", "Test description", defaultAnimation);
         item.worldAnimation(worldAnimation);
 
@@ -178,7 +178,7 @@ public class ItemTest {
 
     /** Tests if item can be collected from entity with full inventory. */
     @Test
-    public void testCollectFullInevntory() {
+    public void testCollectFullInventory() {
         assertEquals("There should be no entity in the game", 0, Game.entityStream().count());
 
         Item item = new Item("Test item", "Test description", defaultAnimation);
@@ -204,7 +204,7 @@ public class ItemTest {
         assertTrue(
                 "ItemActive needs to be in entities inventory.",
                 Arrays.asList(inventoryComponent.items()).contains(item));
-        item.use(entity, item);
+        item.use(entity);
         assertFalse(
                 "Item was not removed from inventory after use.",
                 Arrays.asList(inventoryComponent.items()).contains(item));


### PR DESCRIPTION
fixes #950

Die Items im Inventar können nun per Tastendruck benutzt werden. Dazu muss mit der Maus über das Item gehovert und die Taste 'E' gedrückt werden. 
*Hinweis*: Items, die in einem anderen Inventar sind (z.B. das der Schatztruhe), können nicht direkt benutzt werden und müssen erst in das Spielerinventar gepackt werden.