### PR TITLE
[DUNGEON] add grading functions

### DIFF
--- a/dungeon/src/reporting/GradingFunctions.java
+++ b/dungeon/src/reporting/GradingFunctions.java
@@ -1,0 +1,38 @@
+package reporting;
+
+import task.Task;
+import task.TaskContent;
+import task.quizquestion.SingleChoice;
+
+import java.util.Set;
+import java.util.function.BiFunction;
+
+/** Contanins different grading functions for the different task types. */
+public class GradingFunctions {
+
+    /**
+     * A simple grading function for {@link SingleChoice} Task.
+     *
+     * <p>The function will check if the given answer is the correct answer, and if so, it will
+     * return the full amount of points; otherwise, it will return 0 points.
+     *
+     * @return BiFunction that can be used for {@link Task#scoringFunction(BiFunction)}
+     */
+    public static BiFunction<Task, Set<TaskContent>, Float> singleChoiceGrading() {
+        return new BiFunction<Task, Set<TaskContent>, Float>() {
+            @Override
+            public Float apply(Task task, Set<TaskContent> contents) {
+                SingleChoice singleChoice = (SingleChoice) task;
+                int index = singleChoice.correctAnswerIndices().get(0);
+                TaskContent correctAnswer = singleChoice.contentByIndex(index);
+                TaskContent givenAnswer =
+                        contents.stream()
+                                .findFirst()
+                                .orElseThrow(
+                                        () -> new IllegalArgumentException("No answer was given"));
+                if (correctAnswer == givenAnswer) return singleChoice.points();
+                else return 0f;
+            }
+        };
+    }
+}

--- a/dungeon/src/reporting/GradingFunctions.java
+++ b/dungeon/src/reporting/GradingFunctions.java
@@ -1,15 +1,10 @@
 package reporting;
 
-import task.Element;
-import task.ReplacementTask;
-import task.Task;
-import task.TaskContent;
+import task.*;
 import task.quizquestion.MultipleChoice;
 import task.quizquestion.SingleChoice;
 
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.function.BiFunction;
 
 /** Contanins different grading functions for the different task types. */
@@ -59,11 +54,11 @@ public class GradingFunctions {
                     for (int index : multipleChoice.correctAnswerIndices())
                         correctAnswers.add(multipleChoice.contentByIndex(index));
 
-                    float pointPerAnswer = multipleChoice.points() / correctAnswers.size();
+                    float pointsPerAnswer = multipleChoice.points() / correctAnswers.size();
                     float reachedPoints = 0f;
                     for (TaskContent answer : givenAnswers) {
-                        if (correctAnswers.contains(answer)) reachedPoints += pointPerAnswer;
-                        else reachedPoints -= pointPerAnswer;
+                        if (correctAnswers.contains(answer)) reachedPoints += pointsPerAnswer;
+                        else reachedPoints -= pointsPerAnswer;
                     }
                     return Math.max(0, reachedPoints);
                 };
@@ -84,11 +79,73 @@ public class GradingFunctions {
             ReplacementTask replacementTask = (ReplacementTask) task;
 
             List<Element> solution = replacementTask.solution();
-            float pointPerAnswer = replacementTask.points() / solution.size();
+            float pointsPerAnswer = replacementTask.points() / solution.size();
             float reachedPoints = 0f;
             for (TaskContent answer : answers)
-                if (solution.contains(answer)) reachedPoints += pointPerAnswer;
+                if (solution.contains(answer)) reachedPoints += pointsPerAnswer;
             return reachedPoints;
+        };
+    }
+
+    /**
+     * A simple grading function for the {@link AssignTask}.
+     *
+     * <p>For each correct answer, points will be added
+     *
+     * <p>The amount of points given per answer is calculated by the number of points the Task is
+     * worth divided by the count of correct answers.
+     *
+     * @return a BiFunction that can be used for {@link Task#scoringFunction(BiFunction)}
+     */
+    public static BiFunction<Task, Set<TaskContent>, Float> assignGradingEasy() {
+        return (task, containers) -> {
+            AssignTask assignTask = (AssignTask) task;
+            Map<Element, Set<Element>> solution = assignTask.solution();
+            float pointsPerAnswer = assignTask.points() / solution.values().size();
+            float reachedPoints = 0f;
+            // TODO Wie komm ich an die gegebene antort Map? Lösung: Signatur der BiFunction müsste
+            // für jeden aufgabentyp unterschiedlich sein dürfen
+            Map<Element, Set<Element>> givenAnswers = new HashMap<>();
+
+            for (Element container : givenAnswers.keySet()) {
+                Set<Element> correctSolSet = solution.get(container);
+                for (Element content : givenAnswers.get(container))
+                    if (correctSolSet.contains(content)) reachedPoints += pointsPerAnswer;
+            }
+            return reachedPoints;
+        };
+    }
+
+    /**
+     * A simple grading function for the {@link AssignTask}.
+     *
+     * <p>For each correct answer, points will be added; for each wrong answer, points will be
+     * removed.
+     *
+     * <p>The amount of points given/removed per answer is calculated by the number of points the
+     * Task is worth divided by the count of correct answers.
+     *
+     * <p>The return value cannot be lower than 0.
+     *
+     * @return a BiFunction that can be used for {@link Task#scoringFunction(BiFunction)}
+     */
+    public static BiFunction<Task, Set<TaskContent>, Float> assignGradingHard() {
+        return (task, containers) -> {
+            AssignTask assignTask = (AssignTask) task;
+            Map<Element, Set<Element>> solution = assignTask.solution();
+            float pointsPerAnswer = assignTask.points() / solution.values().size();
+            float reachedPoints = 0f;
+            // TODO Wie komm ich an die gegebene antort Map? Lösung: Signatur der BiFunction müsste
+            // für jeden aufgabentyp unterschiedlich sein dürfen
+            Map<Element, Set<Element>> givenAnswers = new HashMap<>();
+
+            for (Element container : givenAnswers.keySet()) {
+                Set<Element> correctSolSet = solution.get(container);
+                for (Element content : givenAnswers.get(container))
+                    if (correctSolSet.contains(content)) reachedPoints += pointsPerAnswer;
+                    else reachedPoints -= pointsPerAnswer;
+            }
+            return Math.max(0, reachedPoints);
         };
     }
 }

--- a/dungeon/src/reporting/GradingFunctions.java
+++ b/dungeon/src/reporting/GradingFunctions.java
@@ -20,6 +20,7 @@ public class GradingFunctions {
      */
     public static BiFunction<Task, Set<TaskContent>, Float> singleChoiceGrading() {
         return (task, answer) -> {
+            if (answer.size() != 1) return 0f;
             SingleChoice singleChoice = (SingleChoice) task;
             int index = singleChoice.correctAnswerIndices().get(0);
             TaskContent correctAnswer = singleChoice.contentByIndex(index);
@@ -46,22 +47,21 @@ public class GradingFunctions {
      * @return a BiFunction that can be used for {@link Task#scoringFunction(BiFunction)}
      */
     public static BiFunction<Task, Set<TaskContent>, Float> multipeChoiceGrading() {
-        return (BiFunction<Task, Set<TaskContent>, Float>)
-                (task, givenAnswers) -> {
-                    MultipleChoice multipleChoice = (MultipleChoice) task;
+        return (task, givenAnswers) -> {
+            MultipleChoice multipleChoice = (MultipleChoice) task;
 
-                    Set<TaskContent> correctAnswers = new HashSet<>();
-                    for (int index : multipleChoice.correctAnswerIndices())
-                        correctAnswers.add(multipleChoice.contentByIndex(index));
+            Set<TaskContent> correctAnswers = new HashSet<>();
+            for (int index : multipleChoice.correctAnswerIndices())
+                correctAnswers.add(multipleChoice.contentByIndex(index));
 
-                    float pointsPerAnswer = multipleChoice.points() / correctAnswers.size();
-                    float reachedPoints = 0f;
-                    for (TaskContent answer : givenAnswers) {
-                        if (correctAnswers.contains(answer)) reachedPoints += pointsPerAnswer;
-                        else reachedPoints -= pointsPerAnswer;
-                    }
-                    return Math.max(0, reachedPoints);
-                };
+            float pointsPerAnswer = multipleChoice.points() / correctAnswers.size();
+            float reachedPoints = 0f;
+            for (TaskContent answer : givenAnswers) {
+                if (correctAnswers.contains(answer)) reachedPoints += pointsPerAnswer;
+                else reachedPoints -= pointsPerAnswer;
+            }
+            return Math.max(0, reachedPoints);
+        };
     }
 
     /**
@@ -101,11 +101,12 @@ public class GradingFunctions {
         return (task, containers) -> {
             AssignTask assignTask = (AssignTask) task;
             Map<Element, Set<Element>> solution = assignTask.solution();
-            float pointsPerAnswer = assignTask.points() / solution.values().size();
+            int elementCount = solution.values().stream().mapToInt(Set::size).sum();
+            float pointsPerAnswer = assignTask.points() / elementCount;
             float reachedPoints = 0f;
-            // TODO Wie komm ich an die gegebene antort Map? Lösung: Signatur der BiFunction müsste
-            // für jeden aufgabentyp unterschiedlich sein dürfen
-            Map<Element, Set<Element>> givenAnswers = new HashMap<>();
+
+            Element wrap = (Element) containers.stream().findFirst().orElseThrow();
+            Map<Element, Set<Element>> givenAnswers = (Map<Element, Set<Element>>) wrap.content();
 
             for (Element container : givenAnswers.keySet()) {
                 Set<Element> correctSolSet = solution.get(container);
@@ -133,11 +134,13 @@ public class GradingFunctions {
         return (task, containers) -> {
             AssignTask assignTask = (AssignTask) task;
             Map<Element, Set<Element>> solution = assignTask.solution();
-            float pointsPerAnswer = assignTask.points() / solution.values().size();
+            int elementCount = solution.values().stream().mapToInt(Set::size).sum();
+            float pointsPerAnswer = assignTask.points() / elementCount;
+            System.out.println(pointsPerAnswer);
             float reachedPoints = 0f;
-            // TODO Wie komm ich an die gegebene antort Map? Lösung: Signatur der BiFunction müsste
-            // für jeden aufgabentyp unterschiedlich sein dürfen
-            Map<Element, Set<Element>> givenAnswers = new HashMap<>();
+
+            Element wrap = (Element) containers.stream().findFirst().orElseThrow();
+            Map<Element, Set<Element>> givenAnswers = (Map<Element, Set<Element>>) wrap.content();
 
             for (Element container : givenAnswers.keySet()) {
                 Set<Element> correctSolSet = solution.get(container);

--- a/dungeon/src/reporting/GradingFunctions.java
+++ b/dungeon/src/reporting/GradingFunctions.java
@@ -2,8 +2,10 @@ package reporting;
 
 import task.Task;
 import task.TaskContent;
+import task.quizquestion.MultipleChoice;
 import task.quizquestion.SingleChoice;
 
+import java.util.HashSet;
 import java.util.Set;
 import java.util.function.BiFunction;
 
@@ -19,20 +21,48 @@ public class GradingFunctions {
      * @return BiFunction that can be used for {@link Task#scoringFunction(BiFunction)}
      */
     public static BiFunction<Task, Set<TaskContent>, Float> singleChoiceGrading() {
-        return new BiFunction<Task, Set<TaskContent>, Float>() {
-            @Override
-            public Float apply(Task task, Set<TaskContent> contents) {
-                SingleChoice singleChoice = (SingleChoice) task;
-                int index = singleChoice.correctAnswerIndices().get(0);
-                TaskContent correctAnswer = singleChoice.contentByIndex(index);
-                TaskContent givenAnswer =
-                        contents.stream()
-                                .findFirst()
-                                .orElseThrow(
-                                        () -> new IllegalArgumentException("No answer was given"));
-                if (correctAnswer == givenAnswer) return singleChoice.points();
-                else return 0f;
-            }
+        return (task, answer) -> {
+            SingleChoice singleChoice = (SingleChoice) task;
+            int index = singleChoice.correctAnswerIndices().get(0);
+            TaskContent correctAnswer = singleChoice.contentByIndex(index);
+            TaskContent givenAnswer =
+                    answer.stream()
+                            .findFirst()
+                            .orElseThrow(() -> new IllegalArgumentException("No answer was given"));
+            if (correctAnswer == givenAnswer) return singleChoice.points();
+            else return 0f;
         };
+    }
+
+    /**
+     * A simple grading function for the {@link MultipleChoice} Task.
+     *
+     * <p>For each correct answer, points will be added; for each wrong answer, points will be
+     * removed.
+     *
+     * <p>The amount of points given/removed per answer is calculated by the number of points the
+     * Task is worth divided by the count of correct answers.
+     *
+     * <p>The return value cannot be lower than 0.
+     *
+     * @return a BiFunction that can be used for {@link Task#scoringFunction(BiFunction)}
+     */
+    public static BiFunction<Task, Set<TaskContent>, Float> multipeChoiceGrading() {
+        return (BiFunction<Task, Set<TaskContent>, Float>)
+                (task, givenAnswers) -> {
+                    MultipleChoice multipleChoice = (MultipleChoice) task;
+
+                    Set<TaskContent> correctAnswers = new HashSet<>();
+                    for (int index : multipleChoice.correctAnswerIndices())
+                        correctAnswers.add(multipleChoice.contentByIndex(index));
+
+                    float pointPerAnswer = multipleChoice.points() / correctAnswers.size();
+                    float reachedPoints = 0f;
+                    for (TaskContent answer : givenAnswers) {
+                        if (correctAnswers.contains(answer)) reachedPoints += pointPerAnswer;
+                        else reachedPoints -= pointPerAnswer;
+                    }
+                    return Math.max(0, reachedPoints);
+                };
     }
 }

--- a/dungeon/src/reporting/GradingFunctions.java
+++ b/dungeon/src/reporting/GradingFunctions.java
@@ -1,11 +1,14 @@
 package reporting;
 
+import task.Element;
+import task.ReplacementTask;
 import task.Task;
 import task.TaskContent;
 import task.quizquestion.MultipleChoice;
 import task.quizquestion.SingleChoice;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.function.BiFunction;
 
@@ -64,5 +67,28 @@ public class GradingFunctions {
                     }
                     return Math.max(0, reachedPoints);
                 };
+    }
+
+    /**
+     * A simple grading function for {@link ReplacementTask}.
+     *
+     * <p>Will give points for each correct answer.
+     *
+     * <p>The amount of points given per answer is calculated by the number of points the Task is
+     * worth divided by the count of correct answers.
+     *
+     * @return a BiFunction that can be used for {@link Task#scoringFunction(BiFunction)}
+     */
+    public static BiFunction<Task, Set<TaskContent>, Float> replacementGrading() {
+        return (task, answers) -> {
+            ReplacementTask replacementTask = (ReplacementTask) task;
+
+            List<Element> solution = replacementTask.solution();
+            float pointPerAnswer = replacementTask.points() / solution.size();
+            float reachedPoints = 0f;
+            for (TaskContent answer : answers)
+                if (solution.contains(answer)) reachedPoints += pointPerAnswer;
+            return reachedPoints;
+        };
     }
 }

--- a/dungeon/src/task/AssignTask.java
+++ b/dungeon/src/task/AssignTask.java
@@ -1,8 +1,11 @@
 package task;
 
+import reporting.GradingFunctions;
+
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.BiFunction;
 
 /**
  * Assignment Task.
@@ -11,6 +14,8 @@ import java.util.Set;
  * as values that should be assigned to the keys.
  */
 public class AssignTask extends Task {
+    private static final BiFunction<Task, Set<TaskContent>, Float> DEFAULT_SCORING_FUNCTION =
+            GradingFunctions.assignGradingEasy();
     private final Map<Element, Set<Element>> solution;
 
     /**
@@ -21,6 +26,7 @@ public class AssignTask extends Task {
     public AssignTask(Map<Element, Set<Element>> solution) {
         super();
         this.solution = solution;
+        scoringFunction(DEFAULT_SCORING_FUNCTION);
     }
 
     /**

--- a/dungeon/src/task/AssignTask.java
+++ b/dungeon/src/task/AssignTask.java
@@ -16,17 +16,22 @@ import java.util.function.BiFunction;
 public class AssignTask extends Task {
     private static final BiFunction<Task, Set<TaskContent>, Float> DEFAULT_SCORING_FUNCTION =
             GradingFunctions.assignGradingEasy();
-    private final Map<Element, Set<Element>> solution;
+    private Map<Element, Set<Element>> solution;
+
+    /** Create an Assignment Task with the given solution map. */
+    public AssignTask() {
+        super();
+        scoringFunction(DEFAULT_SCORING_FUNCTION);
+    }
 
     /**
-     * Create an Assignment Task with the given solution map.
+     * Add the solution to this task.
      *
-     * @param solution The map containing Elements as keys and Sets of Elements as values.
+     * @param solution A Map where the keys are the containers and the values are the elements that
+     *     must be matched to the containers.
      */
-    public AssignTask(Map<Element, Set<Element>> solution) {
-        super();
+    public void solution(Map<Element, Set<Element>> solution) {
         this.solution = solution;
-        scoringFunction(DEFAULT_SCORING_FUNCTION);
     }
 
     /**

--- a/dungeon/src/task/Element.java
+++ b/dungeon/src/task/Element.java
@@ -28,4 +28,9 @@ public class Element<T> extends TaskContent {
     public T content() {
         return content;
     }
+
+    @Override
+    public String toString() {
+        return content.toString();
+    }
 }

--- a/dungeon/src/task/ReplacementTask.java
+++ b/dungeon/src/task/ReplacementTask.java
@@ -1,5 +1,7 @@
 package task;
 
+import reporting.GradingFunctions;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -22,6 +24,7 @@ public class ReplacementTask extends Task {
         super();
         this.solution = solution;
         this.rules = rules;
+        scoringFunction(GradingFunctions.replacementGrading());
     }
 
     public List<Element> solution() {

--- a/dungeon/src/task/ReplacementTask.java
+++ b/dungeon/src/task/ReplacementTask.java
@@ -17,14 +17,17 @@ public class ReplacementTask extends Task {
     /**
      * Create a new Replacement Task.
      *
-     * @param solution This List contains the final Element-Set that is the solution of the task.
      * @param rules Rules that define which and how elements can be replaced.
      */
-    public ReplacementTask(List<Element> solution, List<Rule> rules) {
+    public ReplacementTask(List<Rule> rules) {
         super();
-        this.solution = solution;
+        this.solution = new ArrayList<>();
         this.rules = rules;
         scoringFunction(GradingFunctions.replacementGrading());
+    }
+
+    public void addSolution(Element e) {
+        solution.add(e);
     }
 
     public List<Element> solution() {

--- a/dungeon/src/task/Task.java
+++ b/dungeon/src/task/Task.java
@@ -241,6 +241,11 @@ public abstract class Task {
         return new HashSet<>(ALL_TASKS).stream();
     }
 
+    /** Clear the {@link #ALL_TASKS} Set. */
+    public static void cleanupAllTask() {
+        ALL_TASKS.clear();
+    }
+
     /**
      * Finds the entity that implements the TaskContentComponent linked to the given TaskContent.
      *

--- a/dungeon/src/task/Task.java
+++ b/dungeon/src/task/Task.java
@@ -1,6 +1,7 @@
 package task;
 
 import core.Entity;
+import core.utils.logging.CustomLogLevel;
 
 import petriNet.Place;
 
@@ -11,6 +12,7 @@ import task.components.TaskContentComponent;
 
 import java.util.*;
 import java.util.function.BiFunction;
+import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -35,11 +37,14 @@ import java.util.stream.Stream;
 @DSLType
 public abstract class Task {
 
+    private static final Logger LOGGER = Logger.getLogger(Task.class.getSimpleName());
+
     private static final Set<Task> ALL_TASKS = new HashSet<>();
     private static final String DEFAULT_TASK_TEXT = "No task description provided";
     private static final TaskState DEFAULT_TASK_STATE = TaskState.INACTIVE;
 
     private static final float DEFAULT_POINTS = 1f;
+    private static final float DEFAULT_POINTS_TO_SOLVE = DEFAULT_POINTS;
     private TaskState state;
     private String taskText;
     private final Set<Place> observer = new HashSet<>();
@@ -51,6 +56,7 @@ public abstract class Task {
     protected BiFunction<Task, Set<TaskContent>, Float> scoringFunction;
 
     protected float points;
+    private float pointsToSolve;
 
     /**
      * Create a new Task with the {@link #DEFAULT_TASK_TEXT} in the {@link #DEFAULT_TASK_STATE},
@@ -62,6 +68,7 @@ public abstract class Task {
         taskText = DEFAULT_TASK_TEXT;
         content = new LinkedList<>();
         points = DEFAULT_POINTS;
+        pointsToSolve = DEFAULT_POINTS_TO_SOLVE;
     }
     /**
      * Register a {@link Place} with this task.
@@ -208,11 +215,46 @@ public abstract class Task {
     /**
      * Execute the scoring function.
      *
+     * <p>This will mark the task as done.
+     *
+     * <p>This will change the task state.
+     *
+     * <p>This will inform the petri net about the task state changes.
+     *
+     * <p>This will log the result.
+     *
+     * <p>This will give the player a reward, if the task was solved correctly.
+     *
      * @param givenAnswers the given answers to the question of this tak.
      * @return reached points.
      */
-    public float executeScoringFunction(Set<TaskContent> givenAnswers) {
-        return scoringFunction.apply(this, givenAnswers);
+    public float gradeTask(Set<TaskContent> givenAnswers) {
+        float score = scoringFunction.apply(this, givenAnswers);
+        StringBuilder msgBuilder = new StringBuilder();
+        msgBuilder
+                .append("Task: ")
+                .append(taskText)
+                .append(" was solved with ")
+                .append(score)
+                .append("/")
+                .append(points)
+                .append(" Points");
+        msgBuilder.append("The task was solved");
+        if (score >= pointsToSolve) msgBuilder.append(" successfully");
+        else msgBuilder.append(" unsuccessfully");
+
+        msgBuilder.append(" Given answers: ");
+
+        for (TaskContent answer : givenAnswers) {
+            msgBuilder.append(answer.toString());
+        }
+        String msg = msgBuilder.toString();
+        LOGGER.log(CustomLogLevel.TASK, msg);
+
+        if (score >= pointsToSolve) state(TaskState.FINISHED_CORRECT);
+        else state(TaskState.FINISHED_WRONG);
+
+        return score;
     }
 
     /**
@@ -227,9 +269,11 @@ public abstract class Task {
      * Set the amount of points that this task is worth.
      *
      * @param points points that this task is worth.
+     * @param pointsToSolve amount of points that is needed to solve this task sucessfully.
      */
-    public void points(float points) {
+    public void points(float points, float pointsToSolve) {
         this.points = points;
+        this.pointsToSolve = pointsToSolve;
     }
 
     /**

--- a/dungeon/src/task/Task.java
+++ b/dungeon/src/task/Task.java
@@ -206,6 +206,16 @@ public abstract class Task {
     }
 
     /**
+     * Execute the scoring function.
+     *
+     * @param givenAnswers the given answers to the question of this tak.
+     * @return reached points.
+     */
+    public float executeScoringFunction(Set<TaskContent> givenAnswers) {
+        return scoringFunction.apply(this, givenAnswers);
+    }
+
+    /**
      * Get the amount of points that this task is worth.
      *
      * @return points that this task is worth.

--- a/dungeon/src/task/Task.java
+++ b/dungeon/src/task/Task.java
@@ -38,6 +38,8 @@ public abstract class Task {
     private static final Set<Task> ALL_TASKS = new HashSet<>();
     private static final String DEFAULT_TASK_TEXT = "No task description provided";
     private static final TaskState DEFAULT_TASK_STATE = TaskState.INACTIVE;
+
+    private static final float DEFAULT_POINTS = 1f;
     private TaskState state;
     private String taskText;
     private final Set<Place> observer = new HashSet<>();
@@ -48,6 +50,8 @@ public abstract class Task {
     protected List<TaskContent> content;
     protected BiFunction<Task, Set<TaskContent>, Float> scoringFunction;
 
+    protected float points;
+
     /**
      * Create a new Task with the {@link #DEFAULT_TASK_TEXT} in the {@link #DEFAULT_TASK_STATE},
      * with an empty content-collection and without an {@link TaskComponent}.
@@ -57,6 +61,7 @@ public abstract class Task {
         state = DEFAULT_TASK_STATE;
         taskText = DEFAULT_TASK_TEXT;
         content = new LinkedList<>();
+        points = DEFAULT_POINTS;
     }
     /**
      * Register a {@link Place} with this task.
@@ -143,6 +148,16 @@ public abstract class Task {
     }
 
     /**
+     * Get the TaskContent instance at the given index.
+     *
+     * @param index index of the wanted task content
+     * @return the task content at the given index.
+     */
+    public TaskContent contentByIndex(int index) {
+        return content.get(index);
+    }
+
+    /**
      * Add given element to the internal {@link #content} collection.
      *
      * @param content element to add to the internal collection
@@ -188,6 +203,23 @@ public abstract class Task {
      */
     public void scoringFunction(BiFunction<Task, Set<TaskContent>, Float> scoringFunction) {
         this.scoringFunction = scoringFunction;
+    }
+
+    /**
+     * Get the amount of points that this task is worth.
+     *
+     * @return points that this task is worth.
+     */
+    public float points() {
+        return points;
+    }
+    /**
+     * Set the amount of points that this task is worth.
+     *
+     * @param points points that this task is worth.
+     */
+    public void points(float points) {
+        this.points = points;
     }
 
     /**

--- a/dungeon/src/task/quizquestion/MultipleChoice.java
+++ b/dungeon/src/task/quizquestion/MultipleChoice.java
@@ -18,5 +18,6 @@ public class MultipleChoice extends Quiz {
 
     public MultipleChoice(String questionText) {
         super(questionText);
+        scoringFunction(GradingFunctions.multipeChoiceGrading());
     }
 }

--- a/dungeon/src/task/quizquestion/MultipleChoice.java
+++ b/dungeon/src/task/quizquestion/MultipleChoice.java
@@ -3,6 +3,7 @@ package task.quizquestion;
 import com.badlogic.gdx.scenes.scene2d.ui.Image;
 
 import reporting.GradingFunctions;
+
 import task.Quiz;
 
 /**

--- a/dungeon/src/task/quizquestion/MultipleChoice.java
+++ b/dungeon/src/task/quizquestion/MultipleChoice.java
@@ -2,6 +2,7 @@ package task.quizquestion;
 
 import com.badlogic.gdx.scenes.scene2d.ui.Image;
 
+import reporting.GradingFunctions;
 import task.Quiz;
 
 /**
@@ -11,6 +12,7 @@ import task.Quiz;
 public class MultipleChoice extends Quiz {
     public MultipleChoice(String questionText, Image image) {
         super(questionText, image);
+        scoringFunction(GradingFunctions.multipeChoiceGrading());
     }
 
     public MultipleChoice(String questionText) {

--- a/dungeon/src/task/quizquestion/SingleChoice.java
+++ b/dungeon/src/task/quizquestion/SingleChoice.java
@@ -15,5 +15,6 @@ public class SingleChoice extends Quiz {
 
     public SingleChoice(String questionText) {
         super(questionText);
+        scoringFunction(GradingFunctions.singleChoiceGrading());
     }
 }

--- a/dungeon/src/task/quizquestion/SingleChoice.java
+++ b/dungeon/src/task/quizquestion/SingleChoice.java
@@ -2,12 +2,15 @@ package task.quizquestion;
 
 import com.badlogic.gdx.scenes.scene2d.ui.Image;
 
+import reporting.GradingFunctions;
+
 import task.Quiz;
 
 /** A {@link Quiz} that needs the player to select one answer from a collection of possibilities. */
 public class SingleChoice extends Quiz {
     public SingleChoice(String questionText, Image image) {
         super(questionText, image);
+        scoringFunction(GradingFunctions.singleChoiceGrading());
     }
 
     public SingleChoice(String questionText) {

--- a/dungeon/test/reporting/GradingFunctionsTest.java
+++ b/dungeon/test/reporting/GradingFunctionsTest.java
@@ -5,14 +5,13 @@ import static org.junit.Assert.assertEquals;
 import org.junit.After;
 import org.junit.Test;
 
-import task.Element;
-import task.Quiz;
-import task.ReplacementTask;
-import task.Task;
+import task.*;
 import task.quizquestion.MultipleChoice;
 import task.quizquestion.SingleChoice;
 
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 
 public class GradingFunctionsTest {
@@ -57,6 +56,14 @@ public class GradingFunctionsTest {
         float points = 5f;
         sc.points(points, points);
         assertEquals(0, sc.gradeTask(Set.of(sc.contentByIndex(0))), 0.00001f);
+    }
+
+    @Test
+    public void singlechoice_multipleAnswers() {
+        SingleChoice sc = setupSingleChoiceTask();
+        float points = 5f;
+        sc.points(points, points);
+        assertEquals(0, sc.gradeTask(Set.of(sc.contentByIndex(0), sc.contentByIndex(1))), 0.00001f);
     }
 
     @Test
@@ -120,6 +127,200 @@ public class GradingFunctionsTest {
         float points = 4f;
         rt.points(points, points);
         assertEquals(2, rt.gradeTask(Set.of(a)), 0.00001f);
+    }
+
+    @Test
+    public void assign_correct_easy() {
+        AssignTask task = new AssignTask();
+        Element c = new Element(task, "container 1");
+        Element e1 = new Element(task, "e1");
+        Element e2 = new Element(task, "e2");
+        Element c2 = new Element(task, "container 2");
+        Element e3 = new Element(task, "e3");
+        Element e4 = new Element(task, "e4");
+        Map<Element, Set<Element>> sol = new HashMap<>();
+        sol.put(c, Set.of(e1, e2));
+        sol.put(c2, Set.of(e3, e4));
+
+        Map<Element, Set<Element>> solCopy = new HashMap<>(sol);
+        Element givenSol = new Element(task, solCopy);
+        task.solution(sol);
+        float points = 4f;
+        task.points(points, points);
+        task.scoringFunction(GradingFunctions.assignGradingEasy());
+        assertEquals(points, task.gradeTask(Set.of(givenSol)), 0.00001f);
+    }
+
+    @Test
+    public void assign_wrong_easy() {
+        AssignTask task = new AssignTask();
+        Element c = new Element(task, "container 1");
+        Element e1 = new Element(task, "e1");
+        Element e2 = new Element(task, "e2");
+        Element c2 = new Element(task, "container 2");
+        Element e3 = new Element(task, "e3");
+        Element e4 = new Element(task, "e4");
+        Map<Element, Set<Element>> sol = new HashMap<>();
+        sol.put(c, Set.of(e1, e2));
+        sol.put(c2, Set.of(e3, e4));
+
+        Map<Element, Set<Element>> wrongSol = new HashMap<>();
+        wrongSol.put(c, Set.of(e3, e4));
+        wrongSol.put(c2, Set.of(e1, e2));
+
+        Element givenSol = new Element(task, wrongSol);
+        task.solution(sol);
+        float points = 4f;
+        task.points(points, points);
+        task.scoringFunction(GradingFunctions.assignGradingEasy());
+        assertEquals(0, task.gradeTask(Set.of(givenSol)), 0.00001f);
+    }
+
+    @Test
+    public void assign_oneCorrectOneWrong_easy() {
+        AssignTask task = new AssignTask();
+        Element c = new Element(task, "container 1");
+        Element e1 = new Element(task, "e1");
+        Element e2 = new Element(task, "e2");
+        Element c2 = new Element(task, "container 2");
+        Element e3 = new Element(task, "e3");
+        Element e4 = new Element(task, "e4");
+        Map<Element, Set<Element>> sol = new HashMap<>();
+        sol.put(c, Set.of(e1, e2));
+        sol.put(c2, Set.of(e3, e4));
+
+        Map<Element, Set<Element>> wrongSol = new HashMap<>();
+        wrongSol.put(c, Set.of(e1, e2));
+        wrongSol.put(c2, Set.of(e1, e2));
+
+        Element givenSol = new Element(task, wrongSol);
+        task.solution(sol);
+        float points = 4f;
+        task.points(points, points);
+        task.scoringFunction(GradingFunctions.assignGradingEasy());
+        assertEquals(2, task.gradeTask(Set.of(givenSol)), 0.00001f);
+    }
+
+    @Test
+    public void assign_oneCorrectOneWrongPerContainer_easy() {
+        AssignTask task = new AssignTask();
+        Element c = new Element(task, "container 1");
+        Element e1 = new Element(task, "e1");
+        Element e2 = new Element(task, "e2");
+        Element c2 = new Element(task, "container 2");
+        Element e3 = new Element(task, "e3");
+        Element e4 = new Element(task, "e4");
+        Map<Element, Set<Element>> sol = new HashMap<>();
+        sol.put(c, Set.of(e1, e2));
+        sol.put(c2, Set.of(e3, e4));
+
+        Map<Element, Set<Element>> wrongSol = new HashMap<>();
+        wrongSol.put(c, Set.of(e1, e3));
+        wrongSol.put(c2, Set.of(e4, e2));
+
+        Element givenSol = new Element(task, wrongSol);
+        task.solution(sol);
+        float points = 4f;
+        task.points(points, points);
+        task.scoringFunction(GradingFunctions.assignGradingEasy());
+        assertEquals(2, task.gradeTask(Set.of(givenSol)), 0.00001f);
+    }
+
+    @Test
+    public void assign_correct_hard() {
+        AssignTask task = new AssignTask();
+        Element c = new Element(task, "container 1");
+        Element e1 = new Element(task, "e1");
+        Element e2 = new Element(task, "e2");
+        Element c2 = new Element(task, "container 2");
+        Element e3 = new Element(task, "e3");
+        Element e4 = new Element(task, "e4");
+        Map<Element, Set<Element>> sol = new HashMap<>();
+        sol.put(c, Set.of(e1, e2));
+        sol.put(c2, Set.of(e3, e4));
+
+        Map<Element, Set<Element>> solCopy = new HashMap<>(sol);
+        Element givenSol = new Element(task, solCopy);
+        task.solution(sol);
+        float points = 4f;
+        task.points(points, points);
+        task.scoringFunction(GradingFunctions.assignGradingHard());
+        assertEquals(points, task.gradeTask(Set.of(givenSol)), 0.00001f);
+    }
+
+    @Test
+    public void assign_wrong_hard() {
+        AssignTask task = new AssignTask();
+        Element c = new Element(task, "container 1");
+        Element e1 = new Element(task, "e1");
+        Element e2 = new Element(task, "e2");
+        Element c2 = new Element(task, "container 2");
+        Element e3 = new Element(task, "e3");
+        Element e4 = new Element(task, "e4");
+        Map<Element, Set<Element>> sol = new HashMap<>();
+        sol.put(c, Set.of(e1, e2));
+        sol.put(c2, Set.of(e3, e4));
+
+        Map<Element, Set<Element>> wrongSol = new HashMap<>();
+        wrongSol.put(c, Set.of(e3, e4));
+        wrongSol.put(c2, Set.of(e1, e2));
+
+        Element givenSol = new Element(task, wrongSol);
+        task.solution(sol);
+        float points = 4f;
+        task.points(points, points);
+        task.scoringFunction(GradingFunctions.assignGradingHard());
+        assertEquals(0, task.gradeTask(Set.of(givenSol)), 0.00001f);
+    }
+
+    @Test
+    public void assign_oneCorrectOneWrong_hard() {
+        AssignTask task = new AssignTask();
+        Element c = new Element(task, "container 1");
+        Element e1 = new Element(task, "e1");
+        Element e2 = new Element(task, "e2");
+        Element c2 = new Element(task, "container 2");
+        Element e3 = new Element(task, "e3");
+        Element e4 = new Element(task, "e4");
+        Map<Element, Set<Element>> sol = new HashMap<>();
+        sol.put(c, Set.of(e1, e2));
+        sol.put(c2, Set.of(e3, e4));
+
+        Map<Element, Set<Element>> wrongSol = new HashMap<>();
+        wrongSol.put(c, Set.of(e1, e2));
+        wrongSol.put(c2, Set.of(e1, e2));
+
+        Element givenSol = new Element(task, wrongSol);
+        task.solution(sol);
+        float points = 4f;
+        task.points(points, points);
+        task.scoringFunction(GradingFunctions.assignGradingHard());
+        assertEquals(0, task.gradeTask(Set.of(givenSol)), 0.00001f);
+    }
+
+    @Test
+    public void assign_oneCorrectOneWrongPerContainer_hard() {
+        AssignTask task = new AssignTask();
+        Element c = new Element(task, "container 1");
+        Element e1 = new Element(task, "e1");
+        Element e2 = new Element(task, "e2");
+        Element c2 = new Element(task, "container 2");
+        Element e3 = new Element(task, "e3");
+        Element e4 = new Element(task, "e4");
+        Map<Element, Set<Element>> sol = new HashMap<>();
+        sol.put(c, Set.of(e1, e2));
+        sol.put(c2, Set.of(e3, e4));
+
+        Map<Element, Set<Element>> wrongSol = new HashMap<>();
+        wrongSol.put(c, Set.of(e1, e3));
+        wrongSol.put(c2, Set.of(e4, e2));
+
+        Element givenSol = new Element(task, wrongSol);
+        task.solution(sol);
+        float points = 4f;
+        task.points(points, points);
+        task.scoringFunction(GradingFunctions.assignGradingHard());
+        assertEquals(0, task.gradeTask(Set.of(givenSol)), 0.00001f);
     }
 
     @Test

--- a/dungeon/test/reporting/GradingFunctionsTest.java
+++ b/dungeon/test/reporting/GradingFunctionsTest.java
@@ -47,58 +47,53 @@ public class GradingFunctionsTest {
     public void singlechoice_correctAnswer() {
         SingleChoice sc = setupSingleChoiceTask();
         float points = 5f;
-        sc.points(points);
-        assertEquals(points, sc.executeScoringFunction(Set.of(sc.contentByIndex(1))), 0.00001f);
+        sc.points(points, points);
+        assertEquals(points, sc.gradeTask(Set.of(sc.contentByIndex(1))), 0.00001f);
     }
 
     @Test
     public void singlechoice_wrongAnswer() {
         SingleChoice sc = setupSingleChoiceTask();
         float points = 5f;
-        sc.points(points);
-        assertEquals(0, sc.executeScoringFunction(Set.of(sc.contentByIndex(0))), 0.00001f);
+        sc.points(points, points);
+        assertEquals(0, sc.gradeTask(Set.of(sc.contentByIndex(0))), 0.00001f);
     }
 
     @Test
     public void multipechoice_correctAnswer() {
         MultipleChoice mc = setupMultipleChoiceTask();
         float points = 4f;
-        mc.points(points);
+        mc.points(points, points);
         assertEquals(
-                points,
-                mc.executeScoringFunction(Set.of(mc.contentByIndex(0), mc.contentByIndex(1))),
-                0.00001f);
+                points, mc.gradeTask(Set.of(mc.contentByIndex(0), mc.contentByIndex(1))), 0.00001f);
     }
 
     @Test
     public void multipechoice_wrongAnswer() {
         MultipleChoice mc = setupMultipleChoiceTask();
         float points = 4f;
-        mc.points(points);
-        assertEquals(
-                0,
-                mc.executeScoringFunction(Set.of(mc.contentByIndex(2), mc.contentByIndex(3))),
-                0.00001f);
+        mc.points(points, points);
+        assertEquals(0, mc.gradeTask(Set.of(mc.contentByIndex(2), mc.contentByIndex(3))), 0.00001f);
     }
 
     @Test
     public void multipechoice_someRightSomeWrongAnswer() {
         MultipleChoice mc = setupMultipleChoiceTask();
         float points = 4f;
-        mc.points(points);
+        mc.points(points, points);
         assertEquals(
                 2,
-                mc.executeScoringFunction(
+                mc.gradeTask(
                         Set.of(mc.contentByIndex(0), mc.contentByIndex(1), mc.contentByIndex(2))),
                 0.00001f);
     }
 
     @Test
-    public void multipechoice_oneRightAnswer() {
+    public void multiplechoice_oneRightAnswer() {
         MultipleChoice mc = setupMultipleChoiceTask();
         float points = 4f;
-        mc.points(points);
-        assertEquals(2, mc.executeScoringFunction(Set.of(mc.contentByIndex(0))), 0.00001f);
+        mc.points(points, points);
+        assertEquals(2, mc.gradeTask(Set.of(mc.contentByIndex(0))), 0.00001f);
     }
 
     @Test
@@ -110,8 +105,8 @@ public class GradingFunctionsTest {
         rt.addSolution(a);
         rt.addSolution(b);
         float points = 4f;
-        rt.points(points);
-        assertEquals(points, rt.executeScoringFunction(Set.of(a, b)), 0.00001f);
+        rt.points(points, points);
+        assertEquals(points, rt.gradeTask(Set.of(a, b)), 0.00001f);
     }
 
     @Test
@@ -123,7 +118,34 @@ public class GradingFunctionsTest {
         rt.addSolution(a);
         rt.addSolution(b);
         float points = 4f;
-        rt.points(points);
-        assertEquals(2, rt.executeScoringFunction(Set.of(a)), 0.00001f);
+        rt.points(points, points);
+        assertEquals(2, rt.gradeTask(Set.of(a)), 0.00001f);
+    }
+
+    @Test
+    public void changeState_correct() {
+        SingleChoice sc = setupSingleChoiceTask();
+        sc.points(1, 1);
+        sc.scoringFunction(GradingFunctions.singleChoiceGrading());
+        sc.gradeTask(Set.of(sc.contentByIndex(1)));
+        assertEquals(Task.TaskState.FINISHED_CORRECT, sc.state());
+    }
+
+    @Test
+    public void changeState_wrong() {
+        SingleChoice sc = setupSingleChoiceTask();
+        sc.points(1, 1);
+        sc.scoringFunction(GradingFunctions.singleChoiceGrading());
+        sc.gradeTask(Set.of(sc.contentByIndex(0)));
+        assertEquals(Task.TaskState.FINISHED_WRONG, sc.state());
+    }
+
+    @Test
+    public void changeState_notEnoughCorrect() {
+        MultipleChoice mc = setupMultipleChoiceTask();
+        float points = 4f;
+        mc.points(points, points);
+        mc.gradeTask(Set.of(mc.contentByIndex(0)));
+        assertEquals(Task.TaskState.FINISHED_WRONG, mc.state());
     }
 }

--- a/dungeon/test/reporting/GradingFunctionsTest.java
+++ b/dungeon/test/reporting/GradingFunctionsTest.java
@@ -2,15 +2,25 @@ package reporting;
 
 import static org.junit.Assert.assertEquals;
 
+import org.junit.After;
 import org.junit.Test;
 
+import task.Element;
 import task.Quiz;
+import task.ReplacementTask;
+import task.Task;
 import task.quizquestion.MultipleChoice;
 import task.quizquestion.SingleChoice;
 
+import java.util.ArrayList;
 import java.util.Set;
 
 public class GradingFunctionsTest {
+
+    @After
+    public void cleanup() {
+        Task.cleanupAllTask();
+    }
 
     private SingleChoice setupSingleChoiceTask() {
         SingleChoice sc = new SingleChoice("Dummy");
@@ -89,5 +99,31 @@ public class GradingFunctionsTest {
         float points = 4f;
         mc.points(points);
         assertEquals(2, mc.executeScoringFunction(Set.of(mc.contentByIndex(0))), 0.00001f);
+    }
+
+    @Test
+    public void replacement_correctAnswer() {
+        ReplacementTask rt = new ReplacementTask(new ArrayList<>());
+        rt.scoringFunction(GradingFunctions.replacementGrading());
+        Element a = new Element(rt, "Dummy A");
+        Element b = new Element(rt, "Dummy B");
+        rt.addSolution(a);
+        rt.addSolution(b);
+        float points = 4f;
+        rt.points(points);
+        assertEquals(points, rt.executeScoringFunction(Set.of(a, b)), 0.00001f);
+    }
+
+    @Test
+    public void replacement_oneRightAnswer() {
+        ReplacementTask rt = new ReplacementTask(new ArrayList<>());
+        rt.scoringFunction(GradingFunctions.replacementGrading());
+        Element a = new Element(rt, "Dummy A");
+        Element b = new Element(rt, "Dummy B");
+        rt.addSolution(a);
+        rt.addSolution(b);
+        float points = 4f;
+        rt.points(points);
+        assertEquals(2, rt.executeScoringFunction(Set.of(a)), 0.00001f);
     }
 }

--- a/dungeon/test/reporting/GradingFunctionsTest.java
+++ b/dungeon/test/reporting/GradingFunctionsTest.java
@@ -1,0 +1,38 @@
+package reporting;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import task.Quiz;
+import task.quizquestion.SingleChoice;
+
+import java.util.Set;
+
+public class GradingFunctionsTest {
+
+    private SingleChoice setupSingleChoiceTask() {
+        SingleChoice sc = new SingleChoice("Dummy");
+        sc.addAnswer(new Quiz.Content("A"));
+        sc.addAnswer(new Quiz.Content("B"));
+        sc.addCorrectAnswerIndex(1);
+        sc.scoringFunction(GradingFunctions.singleChoiceGrading());
+        return sc;
+    }
+
+    @Test
+    public void singlechoice_correctAnswer() {
+        SingleChoice sc = setupSingleChoiceTask();
+        float points = 5f;
+        sc.points(points);
+        assertEquals(points, sc.executeScoringFunction(Set.of(sc.contentByIndex(1))), 0.00001f);
+    }
+
+    @Test
+    public void singlechoice_wrongAnswer() {
+        SingleChoice sc = setupSingleChoiceTask();
+        float points = 5f;
+        sc.points(points);
+        assertEquals(0, sc.executeScoringFunction(Set.of(sc.contentByIndex(0))), 0.00001f);
+    }
+}

--- a/dungeon/test/reporting/GradingFunctionsTest.java
+++ b/dungeon/test/reporting/GradingFunctionsTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertEquals;
 import org.junit.Test;
 
 import task.Quiz;
+import task.quizquestion.MultipleChoice;
 import task.quizquestion.SingleChoice;
 
 import java.util.Set;
@@ -18,6 +19,18 @@ public class GradingFunctionsTest {
         sc.addCorrectAnswerIndex(1);
         sc.scoringFunction(GradingFunctions.singleChoiceGrading());
         return sc;
+    }
+
+    private MultipleChoice setupMultipleChoiceTask() {
+        MultipleChoice mc = new MultipleChoice("Dummy");
+        mc.addAnswer(new Quiz.Content("A"));
+        mc.addAnswer(new Quiz.Content("B"));
+        mc.addAnswer(new Quiz.Content("C"));
+        mc.addAnswer(new Quiz.Content("C"));
+        mc.addCorrectAnswerIndex(0);
+        mc.addCorrectAnswerIndex(1);
+        mc.scoringFunction(GradingFunctions.multipeChoiceGrading());
+        return mc;
     }
 
     @Test
@@ -34,5 +47,47 @@ public class GradingFunctionsTest {
         float points = 5f;
         sc.points(points);
         assertEquals(0, sc.executeScoringFunction(Set.of(sc.contentByIndex(0))), 0.00001f);
+    }
+
+    @Test
+    public void multipechoice_correctAnswer() {
+        MultipleChoice mc = setupMultipleChoiceTask();
+        float points = 4f;
+        mc.points(points);
+        assertEquals(
+                points,
+                mc.executeScoringFunction(Set.of(mc.contentByIndex(0), mc.contentByIndex(1))),
+                0.00001f);
+    }
+
+    @Test
+    public void multipechoice_wrongAnswer() {
+        MultipleChoice mc = setupMultipleChoiceTask();
+        float points = 4f;
+        mc.points(points);
+        assertEquals(
+                0,
+                mc.executeScoringFunction(Set.of(mc.contentByIndex(2), mc.contentByIndex(3))),
+                0.00001f);
+    }
+
+    @Test
+    public void multipechoice_someRightSomeWrongAnswer() {
+        MultipleChoice mc = setupMultipleChoiceTask();
+        float points = 4f;
+        mc.points(points);
+        assertEquals(
+                2,
+                mc.executeScoringFunction(
+                        Set.of(mc.contentByIndex(0), mc.contentByIndex(1), mc.contentByIndex(2))),
+                0.00001f);
+    }
+
+    @Test
+    public void multipechoice_oneRightAnswer() {
+        MultipleChoice mc = setupMultipleChoiceTask();
+        float points = 4f;
+        mc.points(points);
+        assertEquals(2, mc.executeScoringFunction(Set.of(mc.contentByIndex(0))), 0.00001f);
     }
 }

--- a/game/src/core/utils/logging/CustomLogLevel.java
+++ b/game/src/core/utils/logging/CustomLogLevel.java
@@ -8,6 +8,7 @@ public class CustomLogLevel extends Level {
     public static CustomLogLevel ERROR = new CustomLogLevel("ERROR", 950);
     public static CustomLogLevel DEBUG = new CustomLogLevel("DEBUG", 200);
     public static CustomLogLevel TRACE = new CustomLogLevel("TRACE", 100);
+    public static CustomLogLevel TASK = new CustomLogLevel("TASK", 500);
 
     protected CustomLogLevel(String name, int value) {
         super(name, value);


### PR DESCRIPTION
fixes #1059, fixes #1099 

Dieser PR fügt einfache Bewertungsfunktionen für verschiedene Task-Typen hinzu.
In diesem PR wird nicht das "Picken" der gegebenen Antworten aus dem Spiel implementiert.

Wir haben bereits in `Task` eine `BiFunction` als `scoringFunction` hinterlegt. Im Wesentlichen fügt dieser PR verschiedene `BiFunction`s hinzu, die dann je nach Aufgabentyp verwendet werden können.

Umgesetzte Grading-Funktionen
- [x] SingleChoice: Korrekte Antwort gibt volle Punkte, falsche Antwort gibt keine Punkte
- [x] MultipleChoice: Für jede richtige Antwort gibt es einen Punkt, für jede falsche Antwort wird ein Punkt abgezogen (min(0))
- [x] Zuordnung: Für jede richtige Zuordnung gibt es einen Punkt, falsche Zuordnungen werden nicht beachtet
- [x] Zuordnung: Für jede richtige Zuordnung gibt es einen Punkt, für jede falsche Zuordnung wird ein Punkt abgezogen (min(0))
- [x] Replacement: Jede korrekte Antworten gibt Punkte, falsche Antworten werden nicht beachtet. Teilschritte können nicht betrachtet werden. 

Anmerkung: Ein Punkt ist eher symbolisch zu verstehen. Die tatsächlich gegebenen/abgezogenen Punkte pro Antwort hängen von der Anzahl der Antworten und den zu erreichenden Punkten ab."


## Nötige anpassugen die gemacht wurden
- ´Task` speichert jetzt die Punkte die nötig sind um die Aufgabe "Erfolgreich" zu beenden. 
- `ReplacementTask` hatten eine Zirkel-Abhängigkeit welch es unmöglich gemacht hat, eine Instanz davon zu erzeugen (fixed) 