### PR TITLE
[DSL] Loop-Statements hinzufügen

### DIFF
--- a/dsl/src/antlr/DungeonDSL.g4
+++ b/dsl/src/antlr/DungeonDSL.g4
@@ -65,6 +65,13 @@ stmt
     | stmt_block
     | conditional_stmt
     | return_stmt
+    | loop_stmt
+    ;
+
+loop_stmt
+    : 'for' type_id=ID var_id=ID 'in' iteratable_id=ID stmt                         #for_loop
+    | 'for' type_id=ID var_id=ID 'in' iteratable_id=ID 'count' counter_id=ID stmt   #for_loop_counting
+    | 'while' expression stmt                                                       #while_loop
     ;
 
 var_decl

--- a/dsl/src/antlr/DungeonDSL.g4
+++ b/dsl/src/antlr/DungeonDSL.g4
@@ -68,6 +68,7 @@ stmt
     | loop_stmt
     ;
 
+// TODO: iterable should actually be an expression
 loop_stmt
     : 'for' type_id=ID var_id=ID 'in' iteratable_id=ID stmt                         #for_loop
     | 'for' type_id=ID var_id=ID 'in' iteratable_id=ID 'count' counter_id=ID stmt   #for_loop_counting

--- a/dsl/src/antlr/DungeonDSL.g4
+++ b/dsl/src/antlr/DungeonDSL.g4
@@ -68,11 +68,10 @@ stmt
     | loop_stmt
     ;
 
-// TODO: iterable should actually be an expression
 loop_stmt
-    : 'for' type_id=ID var_id=ID 'in' iteratable_id=ID stmt                         #for_loop
-    | 'for' type_id=ID var_id=ID 'in' iteratable_id=ID 'count' counter_id=ID stmt   #for_loop_counting
-    | 'while' expression stmt                                                       #while_loop
+    : 'for' type_id=ID var_id=ID 'in' iteratable_id=expression stmt                         #for_loop
+    | 'for' type_id=ID var_id=ID 'in' iteratable_id=expression 'count' counter_id=ID stmt   #for_loop_counting
+    | 'while' expression stmt                                                               #while_loop
     ;
 
 var_decl

--- a/dsl/src/interpreter/DSLInterpreter.java
+++ b/dsl/src/interpreter/DSLInterpreter.java
@@ -1102,6 +1102,54 @@ public class DSLInterpreter implements AstVisitor<Object> {
         }
         return true;
     }
+
+    @Override
+    public Object visit(WhileLoopStmtNode node) {
+        // TODO
+
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Object visit(CountingLoopStmtNode node) {
+        // TODO
+
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Object visit(ForLoopStmtNode node) {
+        // TODO
+        // evaluate iterable expression
+        Value iterableValue = (Value)node.getIterableIdNode().accept(this);
+        IType iterableType = iterableValue.getDataType();
+
+        Iterator internalIterator;
+        if (iterableType.getTypeKind().equals(IType.Kind.ListType)) {
+            var listValue = (ListValue)iterableValue;
+            List internalList = (List)listValue.getInternalValue();
+            internalIterator = internalList.iterator();
+        } else if (iterableType.getTypeKind().equals(IType.Kind.SetType)) {
+            var setValue = (SetValue)iterableValue;
+            Set internalSet = (Set)setValue.getInternalValue();
+            internalIterator = internalSet.iterator();
+        } else {
+            throw new RuntimeException("Non iterable type '" + iterableType + "' used in for loop!");
+        }
+
+        // create new loop-variable in surrounding memoryspace
+        // TODO!
+
+        // add some kind of loop-bottom-marker node for checking
+        // and updating the loop condition and variable(s)
+        // -> should store the internal iterator
+
+        // add stmt node on top of execution stack
+
+
+        throw new UnsupportedOperationException();
+    }
+
     // endregion
 
     // region user defined function execution

--- a/dsl/src/interpreter/DSLInterpreter.java
+++ b/dsl/src/interpreter/DSLInterpreter.java
@@ -878,8 +878,8 @@ public class DSLInterpreter implements AstVisitor<Object> {
                     "Assignment declaration currently not supported");
         } else {
             // get variable symbol
-            Node variableIdentifierNode = node.getIdentifier();
-            Symbol variableSymbol = symbolTable().getSymbolsForAstNode(variableIdentifierNode).get(0);
+            //Node variableIdentifierNode = node.getIdentifier();
+            Symbol variableSymbol = symbolTable().getSymbolsForAstNode(node).get(0);
             value = bindFromSymbol(variableSymbol, this.getCurrentMemorySpace());
         }
         return value;

--- a/dsl/src/interpreter/DSLInterpreter.java
+++ b/dsl/src/interpreter/DSLInterpreter.java
@@ -863,7 +863,7 @@ public class DSLInterpreter implements AstVisitor<Object> {
 
     @Override
     public Object visit(VarDeclNode node) {
-        String variableName = ((IdNode) node.getIdentifier()).getName();
+        String variableName = node.getVariableName();
 
         // check, if the current memory space already contains a value of the same name
         Value value = getCurrentMemorySpace().resolve(variableName, false);
@@ -877,8 +877,9 @@ public class DSLInterpreter implements AstVisitor<Object> {
             throw new UnsupportedOperationException(
                     "Assignment declaration currently not supported");
         } else {
-            // get datatype
-            Symbol variableSymbol = symbolTable().getSymbolsForAstNode(node).get(0);
+            // get variable symbol
+            Node variableIdentifierNode = node.getIdentifier();
+            Symbol variableSymbol = symbolTable().getSymbolsForAstNode(variableIdentifierNode).get(0);
             value = bindFromSymbol(variableSymbol, this.getCurrentMemorySpace());
         }
         return value;

--- a/dsl/src/interpreter/DSLInterpreter.java
+++ b/dsl/src/interpreter/DSLInterpreter.java
@@ -878,7 +878,7 @@ public class DSLInterpreter implements AstVisitor<Object> {
                     "Assignment declaration currently not supported");
         } else {
             // get variable symbol
-            //Node variableIdentifierNode = node.getIdentifier();
+            // Node variableIdentifierNode = node.getIdentifier();
             Symbol variableSymbol = symbolTable().getSymbolsForAstNode(node).get(0);
             value = bindFromSymbol(variableSymbol, this.getCurrentMemorySpace());
         }
@@ -1119,25 +1119,27 @@ public class DSLInterpreter implements AstVisitor<Object> {
 
     protected void setupForLoopExecution(LoopStmtNode node) {
         var loopType = node.loopType();
-        assert loopType.equals(LoopStmtNode.LoopType.forLoop) || loopType.equals(LoopStmtNode.LoopType.countingForLoop);
+        assert loopType.equals(LoopStmtNode.LoopType.forLoop)
+                || loopType.equals(LoopStmtNode.LoopType.countingForLoop);
 
         ForLoopStmtNode forLoopStmtNode = (ForLoopStmtNode) node;
 
         // evaluate iterable expression
-        Value iterableValue = (Value)forLoopStmtNode.getIterableIdNode().accept(this);
+        Value iterableValue = (Value) forLoopStmtNode.getIterableIdNode().accept(this);
         IType iterableType = iterableValue.getDataType();
 
         Iterator<Value> internalIterator;
         if (iterableType.getTypeKind().equals(IType.Kind.ListType)) {
-            var listValue = (ListValue)iterableValue;
+            var listValue = (ListValue) iterableValue;
             List<Value> internalList = listValue.internalList();
             internalIterator = internalList.iterator();
         } else if (iterableType.getTypeKind().equals(IType.Kind.SetType)) {
-            var setValue = (SetValue)iterableValue;
+            var setValue = (SetValue) iterableValue;
             Set<Value> internalSet = setValue.internalSet();
             internalIterator = internalSet.iterator();
         } else {
-            throw new RuntimeException("Non iterable type '" + iterableType + "' used in for loop!");
+            throw new RuntimeException(
+                    "Non iterable type '" + iterableType + "' used in for loop!");
         }
 
         // create new loop-variable in surrounding (or loops?) memoryspace
@@ -1151,7 +1153,7 @@ public class DSLInterpreter implements AstVisitor<Object> {
         Symbol counterVariableSymbol = Symbol.NULL;
         if (node.loopType().equals(LoopStmtNode.LoopType.countingForLoop)) {
             // get the symbol for the counter variable
-            Node counterIdNode = ((CountingLoopStmtNode)node).getCounterIdNode();
+            Node counterIdNode = ((CountingLoopStmtNode) node).getCounterIdNode();
             counterVariableSymbol = this.symbolTable().getSymbolsForAstNode(counterIdNode).get(0);
             // initialize counter variable
             Value counterValue = bindFromSymbol(counterVariableSymbol, loopMemorySpace);
@@ -1160,7 +1162,8 @@ public class DSLInterpreter implements AstVisitor<Object> {
 
         // add loop-bottom-mark node for checking
         // and updating the loop condition and variable(s)
-        LoopBottomMark loopBottomMark = new LoopBottomMark(node, internalIterator, variableSymbol, counterVariableSymbol);
+        LoopBottomMark loopBottomMark =
+                new LoopBottomMark(node, internalIterator, variableSymbol, counterVariableSymbol);
         this.statementStack.push(loopBottomMark);
     }
 
@@ -1170,17 +1173,18 @@ public class DSLInterpreter implements AstVisitor<Object> {
         return null;
     }
 
-
     @Override
     public Object visit(ForLoopStmtNode node) {
         setupForLoopExecution(node);
         return null;
     }
 
-    protected void updateForLoopState(IMemorySpace previosIterationsLoopMemorySpace, LoopBottomMark node) {
+    protected void updateForLoopState(
+            IMemorySpace previosIterationsLoopMemorySpace, LoopBottomMark node) {
         LoopStmtNode loopNode = node.getLoopStmtNode();
         var loopType = loopNode.loopType();
-        assert loopType.equals(LoopStmtNode.LoopType.forLoop) || loopType.equals(LoopStmtNode.LoopType.countingForLoop);
+        assert loopType.equals(LoopStmtNode.LoopType.forLoop)
+                || loopType.equals(LoopStmtNode.LoopType.countingForLoop);
 
         Iterator<Value> loopIterator = node.getInternalIterator();
         if (loopIterator.hasNext()) {
@@ -1189,14 +1193,16 @@ public class DSLInterpreter implements AstVisitor<Object> {
 
             // update loop variable
             Value nextIterationValue = loopIterator.next();
-            Value valueInMemorySpace = bindFromSymbol(node.getLoopVariableSymbol(), newLoopMemorySpace);
+            Value valueInMemorySpace =
+                    bindFromSymbol(node.getLoopVariableSymbol(), newLoopMemorySpace);
             setValue(valueInMemorySpace, nextIterationValue);
 
             if (loopType.equals(LoopStmtNode.LoopType.countingForLoop)) {
                 // update counter variable
                 Symbol counterSymbol = node.getCounterVariableSymbol();
-                Value counterValue = previosIterationsLoopMemorySpace.resolve(counterSymbol.getName());
-                counterValue.setInternalValue((Integer)counterValue.getInternalValue() + 1);
+                Value counterValue =
+                        previosIterationsLoopMemorySpace.resolve(counterSymbol.getName());
+                counterValue.setInternalValue((Integer) counterValue.getInternalValue() + 1);
                 newLoopMemorySpace.bindValue(counterSymbol.getName(), counterValue);
             }
 
@@ -1221,7 +1227,8 @@ public class DSLInterpreter implements AstVisitor<Object> {
                 Value conditionValue = (Value) whileLoopStmtNode.getExpressionNode().accept(this);
                 if (isBooleanTrue(conditionValue)) {
                     // setup memory space for next iteration
-                    MemorySpace newIterationMemorySpace = new MemorySpace(this.getCurrentMemorySpace());
+                    MemorySpace newIterationMemorySpace =
+                            new MemorySpace(this.getCurrentMemorySpace());
                     this.memoryStack.push(newIterationMemorySpace);
 
                     // prepare execution of next iteration
@@ -1230,13 +1237,13 @@ public class DSLInterpreter implements AstVisitor<Object> {
                 }
             }
             case forLoop, countingForLoop -> updateForLoopState(loopsMemorySpace, node);
-            default -> { }
+            default -> {}
         }
 
         return null;
     }
 
-// endregion
+    // endregion
 
     // region user defined function execution
 

--- a/dsl/src/parser/DungeonASTConverter.java
+++ b/dsl/src/parser/DungeonASTConverter.java
@@ -147,7 +147,8 @@ public class DungeonASTConverter implements antlr.main.DungeonDSLListener {
         Node varTypeIdNode = astStack.pop();
         assert varTypeIdNode.type.equals(Node.Type.Identifier);
 
-        ForLoopStmtNode loopStmtNode = new ForLoopStmtNode(varTypeIdNode, varIdNode, iterableNode, stmtNode);
+        ForLoopStmtNode loopStmtNode =
+                new ForLoopStmtNode(varTypeIdNode, varIdNode, iterableNode, stmtNode);
         astStack.push(loopStmtNode);
     }
 
@@ -169,7 +170,9 @@ public class DungeonASTConverter implements antlr.main.DungeonDSLListener {
         Node varTypeIdNode = astStack.pop();
         assert varTypeIdNode.type.equals(Node.Type.Identifier);
 
-        CountingLoopStmtNode loopStmtNode = new CountingLoopStmtNode(varTypeIdNode, varIdNode, iterableNode, counterIdNode, stmtNode);
+        CountingLoopStmtNode loopStmtNode =
+                new CountingLoopStmtNode(
+                        varTypeIdNode, varIdNode, iterableNode, counterIdNode, stmtNode);
         astStack.push(loopStmtNode);
     }
 
@@ -195,7 +198,8 @@ public class DungeonASTConverter implements antlr.main.DungeonDSLListener {
         assert identifier.type == Node.Type.Identifier;
 
         Node varDeclNode =
-                new VarDeclNode(VarDeclNode.DeclType.assignmentDecl, (IdNode)identifier, expression);
+                new VarDeclNode(
+                        VarDeclNode.DeclType.assignmentDecl, (IdNode) identifier, expression);
         astStack.push(varDeclNode);
     }
 
@@ -208,7 +212,8 @@ public class DungeonASTConverter implements antlr.main.DungeonDSLListener {
         Node identifier = astStack.pop();
         assert identifier.type == Node.Type.Identifier;
 
-        Node varDeclNode = new VarDeclNode(VarDeclNode.DeclType.typeDecl, (IdNode)identifier, typeDecl);
+        Node varDeclNode =
+                new VarDeclNode(VarDeclNode.DeclType.typeDecl, (IdNode) identifier, typeDecl);
         astStack.push(varDeclNode);
     }
 

--- a/dsl/src/parser/DungeonASTConverter.java
+++ b/dsl/src/parser/DungeonASTConverter.java
@@ -133,6 +133,30 @@ public class DungeonASTConverter implements antlr.main.DungeonDSLListener {
     }
 
     @Override
+    public void enterFor_loop(DungeonDSLParser.For_loopContext ctx) {}
+
+    @Override
+    public void exitFor_loop(DungeonDSLParser.For_loopContext ctx) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void enterFor_loop_counting(DungeonDSLParser.For_loop_countingContext ctx) {}
+
+    @Override
+    public void exitFor_loop_counting(DungeonDSLParser.For_loop_countingContext ctx) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void enterWhile_loop(DungeonDSLParser.While_loopContext ctx) {}
+
+    @Override
+    public void exitWhile_loop(DungeonDSLParser.While_loopContext ctx) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public void enterVar_decl_assignment(DungeonDSLParser.Var_decl_assignmentContext ctx) {}
 
     @Override

--- a/dsl/src/parser/DungeonASTConverter.java
+++ b/dsl/src/parser/DungeonASTConverter.java
@@ -197,7 +197,7 @@ public class DungeonASTConverter implements antlr.main.DungeonDSLListener {
         assert identifier.type == Node.Type.Identifier;
 
         Node varDeclNode =
-                new VarDeclNode(VarDeclNode.DeclType.assignmentDecl, identifier, expression);
+                new VarDeclNode(VarDeclNode.DeclType.assignmentDecl, (IdNode)identifier, expression);
         astStack.push(varDeclNode);
     }
 
@@ -210,7 +210,7 @@ public class DungeonASTConverter implements antlr.main.DungeonDSLListener {
         Node identifier = astStack.pop();
         assert identifier.type == Node.Type.Identifier;
 
-        Node varDeclNode = new VarDeclNode(VarDeclNode.DeclType.typeDecl, identifier, typeDecl);
+        Node varDeclNode = new VarDeclNode(VarDeclNode.DeclType.typeDecl, (IdNode)identifier, typeDecl);
         astStack.push(varDeclNode);
     }
 

--- a/dsl/src/parser/DungeonASTConverter.java
+++ b/dsl/src/parser/DungeonASTConverter.java
@@ -139,8 +139,7 @@ public class DungeonASTConverter implements antlr.main.DungeonDSLListener {
     public void exitFor_loop(DungeonDSLParser.For_loopContext ctx) {
         Node stmtNode = astStack.pop();
 
-        Node iterableIdNode = astStack.pop();
-        assert iterableIdNode.type.equals(Node.Type.Identifier);
+        Node iterableNode = astStack.pop();
 
         Node varIdNode = astStack.pop();
         assert varIdNode.type.equals(Node.Type.Identifier);
@@ -148,7 +147,7 @@ public class DungeonASTConverter implements antlr.main.DungeonDSLListener {
         Node varTypeIdNode = astStack.pop();
         assert varTypeIdNode.type.equals(Node.Type.Identifier);
 
-        ForLoopStmtNode loopStmtNode = new ForLoopStmtNode(varTypeIdNode, varIdNode, iterableIdNode, stmtNode);
+        ForLoopStmtNode loopStmtNode = new ForLoopStmtNode(varTypeIdNode, varIdNode, iterableNode, stmtNode);
         astStack.push(loopStmtNode);
     }
 
@@ -162,8 +161,7 @@ public class DungeonASTConverter implements antlr.main.DungeonDSLListener {
         Node counterIdNode = astStack.pop();
         assert counterIdNode.type.equals(Node.Type.Identifier);
 
-        Node iterableIdNode = astStack.pop();
-        assert iterableIdNode.type.equals(Node.Type.Identifier);
+        Node iterableNode = astStack.pop();
 
         Node varIdNode = astStack.pop();
         assert varIdNode.type.equals(Node.Type.Identifier);
@@ -171,7 +169,7 @@ public class DungeonASTConverter implements antlr.main.DungeonDSLListener {
         Node varTypeIdNode = astStack.pop();
         assert varTypeIdNode.type.equals(Node.Type.Identifier);
 
-        CountingLoopStmtNode loopStmtNode = new CountingLoopStmtNode(varTypeIdNode, varIdNode, iterableIdNode, counterIdNode, stmtNode);
+        CountingLoopStmtNode loopStmtNode = new CountingLoopStmtNode(varTypeIdNode, varIdNode, iterableNode, counterIdNode, stmtNode);
         astStack.push(loopStmtNode);
     }
 

--- a/dsl/src/parser/DungeonASTConverter.java
+++ b/dsl/src/parser/DungeonASTConverter.java
@@ -137,7 +137,19 @@ public class DungeonASTConverter implements antlr.main.DungeonDSLListener {
 
     @Override
     public void exitFor_loop(DungeonDSLParser.For_loopContext ctx) {
-        throw new UnsupportedOperationException();
+        Node stmtNode = astStack.pop();
+
+        Node iterableIdNode = astStack.pop();
+        assert iterableIdNode.type.equals(Node.Type.Identifier);
+
+        Node varIdNode = astStack.pop();
+        assert varIdNode.type.equals(Node.Type.Identifier);
+
+        Node varTypeIdNode = astStack.pop();
+        assert varTypeIdNode.type.equals(Node.Type.Identifier);
+
+        ForLoopStmtNode loopStmtNode = new ForLoopStmtNode(varTypeIdNode, varIdNode, iterableIdNode, stmtNode);
+        astStack.push(loopStmtNode);
     }
 
     @Override
@@ -145,7 +157,22 @@ public class DungeonASTConverter implements antlr.main.DungeonDSLListener {
 
     @Override
     public void exitFor_loop_counting(DungeonDSLParser.For_loop_countingContext ctx) {
-        throw new UnsupportedOperationException();
+        Node stmtNode = astStack.pop();
+
+        Node counterIdNode = astStack.pop();
+        assert counterIdNode.type.equals(Node.Type.Identifier);
+
+        Node iterableIdNode = astStack.pop();
+        assert iterableIdNode.type.equals(Node.Type.Identifier);
+
+        Node varIdNode = astStack.pop();
+        assert varIdNode.type.equals(Node.Type.Identifier);
+
+        Node varTypeIdNode = astStack.pop();
+        assert varTypeIdNode.type.equals(Node.Type.Identifier);
+
+        CountingLoopStmtNode loopStmtNode = new CountingLoopStmtNode(varTypeIdNode, varIdNode, iterableIdNode, counterIdNode, stmtNode);
+        astStack.push(loopStmtNode);
     }
 
     @Override
@@ -153,7 +180,11 @@ public class DungeonASTConverter implements antlr.main.DungeonDSLListener {
 
     @Override
     public void exitWhile_loop(DungeonDSLParser.While_loopContext ctx) {
-        throw new UnsupportedOperationException();
+        Node stmtNode = astStack.pop();
+        Node expressionNode = astStack.pop();
+
+        WhileLoopStmtNode loopStmtNode = new WhileLoopStmtNode(expressionNode, stmtNode);
+        astStack.push(loopStmtNode);
     }
 
     @Override

--- a/dsl/src/parser/ast/AstVisitor.java
+++ b/dsl/src/parser/ast/AstVisitor.java
@@ -456,6 +456,16 @@ public interface AstVisitor<T> {
     }
 
     /**
+     * Visitor method for LoopBottomMarks
+     *
+     * @param node Node to visit
+     * @return T
+     */
+    default T visit(LoopBottomMark node) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
      * Visitor method for VarDeclNodes
      *
      * @param node Node to visit

--- a/dsl/src/parser/ast/AstVisitor.java
+++ b/dsl/src/parser/ast/AstVisitor.java
@@ -416,6 +416,46 @@ public interface AstVisitor<T> {
     }
 
     /**
+     * Visitor method for LoopStmtNodes
+     *
+     * @param node Node to visit
+     * @return T
+     */
+    default T visit(LoopStmtNode node) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Visitor method for WhileLoopStmtNode
+     *
+     * @param node Node to visit
+     * @return T
+     */
+    default T visit(WhileLoopStmtNode node) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Visitor method for CountingForLoopStmtNodes
+     *
+     * @param node Node to visit
+     * @return T
+     */
+    default T visit(CountingLoopStmtNode node) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Visitor method for ForLoopStmtNodes
+     *
+     * @param node Node to visit
+     * @return T
+     */
+    default T visit(ForLoopStmtNode node) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
      * Visitor method for VarDeclNodes
      *
      * @param node Node to visit

--- a/dsl/src/parser/ast/CountingLoopStmtNode.java
+++ b/dsl/src/parser/ast/CountingLoopStmtNode.java
@@ -7,7 +7,7 @@ public class CountingLoopStmtNode extends ForLoopStmtNode {
         return this.getChild(counterIdIdx);
     }
 
-    public CountingLoopStmtNode(Node typeIdNode, Node varIdNode, Node iterableIdNode, Node stmtNode, Node counterIdNode) {
+    public CountingLoopStmtNode(Node typeIdNode, Node varIdNode, Node iterableIdNode, Node counterIdNode, Node stmtNode) {
         super(LoopType.countingForLoop, typeIdNode, varIdNode, iterableIdNode, stmtNode);
         this.addChild(counterIdNode);
     }

--- a/dsl/src/parser/ast/CountingLoopStmtNode.java
+++ b/dsl/src/parser/ast/CountingLoopStmtNode.java
@@ -7,8 +7,8 @@ public class CountingLoopStmtNode extends ForLoopStmtNode {
         return this.getChild(counterIdIdx);
     }
 
-    public CountingLoopStmtNode(Node typeIdNode, Node varIdNode, Node iterableIdNode, Node counterIdNode, Node stmtNode) {
-        super(LoopType.countingForLoop, typeIdNode, varIdNode, iterableIdNode, stmtNode);
+    public CountingLoopStmtNode(Node typeIdNode, Node varIdNode, Node iterableExpressionNode, Node counterIdNode, Node stmtNode) {
+        super(LoopType.countingForLoop, typeIdNode, varIdNode, iterableExpressionNode, stmtNode);
         this.addChild(counterIdNode);
     }
 

--- a/dsl/src/parser/ast/CountingLoopStmtNode.java
+++ b/dsl/src/parser/ast/CountingLoopStmtNode.java
@@ -7,7 +7,12 @@ public class CountingLoopStmtNode extends ForLoopStmtNode {
         return this.getChild(counterIdIdx);
     }
 
-    public CountingLoopStmtNode(Node typeIdNode, Node varIdNode, Node iterableExpressionNode, Node counterIdNode, Node stmtNode) {
+    public CountingLoopStmtNode(
+            Node typeIdNode,
+            Node varIdNode,
+            Node iterableExpressionNode,
+            Node counterIdNode,
+            Node stmtNode) {
         super(LoopType.countingForLoop, typeIdNode, varIdNode, iterableExpressionNode, stmtNode);
         this.addChild(counterIdNode);
     }

--- a/dsl/src/parser/ast/CountingLoopStmtNode.java
+++ b/dsl/src/parser/ast/CountingLoopStmtNode.java
@@ -1,0 +1,19 @@
+package parser.ast;
+
+public class CountingLoopStmtNode extends ForLoopStmtNode {
+    public final int counterIdIdx = 4;
+
+    public Node getCounterIdNode() {
+        return this.getChild(counterIdIdx);
+    }
+
+    public CountingLoopStmtNode(Node typeIdNode, Node varIdNode, Node iterableIdNode, Node stmtNode, Node counterIdNode) {
+        super(LoopType.countingForLoop, typeIdNode, varIdNode, iterableIdNode, stmtNode);
+        this.addChild(counterIdNode);
+    }
+
+    @Override
+    public <T> T accept(AstVisitor<T> visitor) {
+        return visitor.visit(this);
+    }
+}

--- a/dsl/src/parser/ast/ForLoopStmtNode.java
+++ b/dsl/src/parser/ast/ForLoopStmtNode.java
@@ -1,0 +1,40 @@
+package parser.ast;
+
+public class ForLoopStmtNode extends LoopStmtNode {
+    public final int typeIdIdx = 1;
+    public final int varIdIdx = 2;
+    public final int iterableIdIdx = 3;
+
+    public Node getTypeIdNode() {
+        return this.getChild(typeIdIdx);
+    }
+
+    public Node getVarIdNode() {
+        return this.getChild(varIdIdx);
+    }
+
+    public Node getIterableIdNode() {
+        return this.getChild(iterableIdIdx);
+    }
+
+    public ForLoopStmtNode(Node typeIdNode, Node varIdNode, Node iterableIdNode, Node stmtNode) {
+        super(LoopType.forLoop, stmtNode);
+        addChildren(typeIdNode, varIdNode, iterableIdNode);
+    }
+
+    protected ForLoopStmtNode(LoopType loopType, Node typeIdNode, Node varIdNode, Node iterableIdNode, Node stmtNode) {
+        super(loopType, stmtNode);
+        addChildren(typeIdNode, varIdNode, iterableIdNode);
+    }
+
+    private void addChildren(Node typeIdNode, Node varIdNode, Node iterableIdNode) {
+        this.addChild(typeIdNode);
+        this.addChild(varIdNode);
+        this.addChild(iterableIdNode);
+    }
+
+    @Override
+    public <T> T accept(AstVisitor<T> visitor) {
+        return visitor.visit(this);
+    }
+}

--- a/dsl/src/parser/ast/ForLoopStmtNode.java
+++ b/dsl/src/parser/ast/ForLoopStmtNode.java
@@ -17,12 +17,18 @@ public class ForLoopStmtNode extends LoopStmtNode {
         return this.getChild(iterableIdx);
     }
 
-    public ForLoopStmtNode(Node typeIdNode, Node varIdNode, Node iterabelExpressionNode, Node stmtNode) {
+    public ForLoopStmtNode(
+            Node typeIdNode, Node varIdNode, Node iterabelExpressionNode, Node stmtNode) {
         super(LoopType.forLoop, stmtNode);
         addChildren(typeIdNode, varIdNode, iterabelExpressionNode);
     }
 
-    protected ForLoopStmtNode(LoopType loopType, Node typeIdNode, Node varIdNode, Node iterableExpressionNode, Node stmtNode) {
+    protected ForLoopStmtNode(
+            LoopType loopType,
+            Node typeIdNode,
+            Node varIdNode,
+            Node iterableExpressionNode,
+            Node stmtNode) {
         super(loopType, stmtNode);
         addChildren(typeIdNode, varIdNode, iterableExpressionNode);
     }

--- a/dsl/src/parser/ast/ForLoopStmtNode.java
+++ b/dsl/src/parser/ast/ForLoopStmtNode.java
@@ -3,7 +3,7 @@ package parser.ast;
 public class ForLoopStmtNode extends LoopStmtNode {
     public final int typeIdIdx = 1;
     public final int varIdIdx = 2;
-    public final int iterableIdIdx = 3;
+    public final int iterableIdx = 3;
 
     public Node getTypeIdNode() {
         return this.getChild(typeIdIdx);
@@ -14,17 +14,17 @@ public class ForLoopStmtNode extends LoopStmtNode {
     }
 
     public Node getIterableIdNode() {
-        return this.getChild(iterableIdIdx);
+        return this.getChild(iterableIdx);
     }
 
-    public ForLoopStmtNode(Node typeIdNode, Node varIdNode, Node iterableIdNode, Node stmtNode) {
+    public ForLoopStmtNode(Node typeIdNode, Node varIdNode, Node iterabelExpressionNode, Node stmtNode) {
         super(LoopType.forLoop, stmtNode);
-        addChildren(typeIdNode, varIdNode, iterableIdNode);
+        addChildren(typeIdNode, varIdNode, iterabelExpressionNode);
     }
 
-    protected ForLoopStmtNode(LoopType loopType, Node typeIdNode, Node varIdNode, Node iterableIdNode, Node stmtNode) {
+    protected ForLoopStmtNode(LoopType loopType, Node typeIdNode, Node varIdNode, Node iterableExpressionNode, Node stmtNode) {
         super(loopType, stmtNode);
-        addChildren(typeIdNode, varIdNode, iterableIdNode);
+        addChildren(typeIdNode, varIdNode, iterableExpressionNode);
     }
 
     private void addChildren(Node typeIdNode, Node varIdNode, Node iterableIdNode) {

--- a/dsl/src/parser/ast/LoopBottomMark.java
+++ b/dsl/src/parser/ast/LoopBottomMark.java
@@ -5,12 +5,22 @@ import semanticanalysis.Symbol;
 
 import java.util.Iterator;
 
+/**
+ * This AST Node is used in the {@link interpreter.DSLInterpreter} to mark the end
+ * of the execution of one iteration of an {@link LoopStmtNode}. The {@link interpreter.DSLInterpreter}
+ * checks, if another iteration of the loop statement should be executed. This class stores the
+ * state of the loop (the iterator and the symbols corresponding to the loop and counter variable).
+ */
 public class LoopBottomMark extends Node {
     private final LoopStmtNode loopStmtNode;
     private final Iterator<Value> internalIterator;
     private final Symbol loopVariableSymbol;
     private final Symbol counterVariableSymbol;
 
+    /**
+     * Constructor for bottom mark of {@link LoopStmtNode}s, which have no internal iterator and no loop variables.
+     * @param loopStmtNode The {@link LoopStmtNode} of which the new instance will be the bottom mark.
+     */
     public LoopBottomMark(LoopStmtNode loopStmtNode) {
         super(Type.LoopBottomMark);
         this.loopStmtNode = loopStmtNode;
@@ -19,6 +29,13 @@ public class LoopBottomMark extends Node {
         counterVariableSymbol = Symbol.NULL;
     }
 
+    /**
+     * Constructor for bottom mark of {@link LoopStmtNode}s, which have an internal iterator and loop and/or counter variables.
+     * @param loopStmtNode The {@link LoopStmtNode} of which the new instance will be the bottom mark.
+     * @param internalIterator The {@link Iterator<Value>} for the iterable expression of the {@link LoopStmtNode}
+     * @param loopVariableSymbol The {@link Symbol} for the loop variable, which is used to iterate over the iterable expression
+     * @param counterVariableSymbol The {@link Symbol} for the counter variable, which will be used to count the iterations of the loop
+     */
     public LoopBottomMark(LoopStmtNode loopStmtNode, Iterator<Value> internalIterator, Symbol loopVariableSymbol, Symbol counterVariableSymbol) {
         super(Type.LoopBottomMark);
         this.loopStmtNode = loopStmtNode;

--- a/dsl/src/parser/ast/LoopBottomMark.java
+++ b/dsl/src/parser/ast/LoopBottomMark.java
@@ -1,0 +1,50 @@
+package parser.ast;
+
+import runtime.Value;
+import semanticanalysis.Symbol;
+
+import java.util.Iterator;
+
+public class LoopBottomMark extends Node {
+    private final LoopStmtNode loopStmtNode;
+    private final Iterator<Value> internalIterator;
+    private final Symbol loopVariableSymbol;
+    private final Symbol counterVariableSymbol;
+
+    public LoopBottomMark(LoopStmtNode loopStmtNode) {
+        super(Type.LoopBottomMark);
+        this.loopStmtNode = loopStmtNode;
+        internalIterator = null;
+        loopVariableSymbol = Symbol.NULL;
+        counterVariableSymbol = Symbol.NULL;
+    }
+
+    public LoopBottomMark(LoopStmtNode loopStmtNode, Iterator<Value> internalIterator, Symbol loopVariableSymbol, Symbol counterVariableSymbol) {
+        super(Type.LoopBottomMark);
+        this.loopStmtNode = loopStmtNode;
+        this.internalIterator = internalIterator;
+        this.loopVariableSymbol = loopVariableSymbol;
+        this.counterVariableSymbol = counterVariableSymbol;
+    }
+
+    public LoopStmtNode getLoopStmtNode() {
+        return loopStmtNode;
+    }
+
+    public Iterator<Value> getInternalIterator() {
+        return internalIterator;
+    }
+
+    public Symbol getLoopVariableSymbol () {
+        return loopVariableSymbol;
+    }
+
+    public Symbol getCounterVariableSymbol () {
+        return counterVariableSymbol;
+    }
+
+    @Override
+    public <T> T accept(AstVisitor<T> visitor) {
+        return visitor.visit(this);
+    }
+}

--- a/dsl/src/parser/ast/LoopBottomMark.java
+++ b/dsl/src/parser/ast/LoopBottomMark.java
@@ -1,15 +1,16 @@
 package parser.ast;
 
 import runtime.Value;
+
 import semanticanalysis.Symbol;
 
 import java.util.Iterator;
 
 /**
- * This AST Node is used in the {@link interpreter.DSLInterpreter} to mark the end
- * of the execution of one iteration of an {@link LoopStmtNode}. The {@link interpreter.DSLInterpreter}
- * checks, if another iteration of the loop statement should be executed. This class stores the
- * state of the loop (the iterator and the symbols corresponding to the loop and counter variable).
+ * This AST Node is used in the {@link interpreter.DSLInterpreter} to mark the end of the execution
+ * of one iteration of an {@link LoopStmtNode}. The {@link interpreter.DSLInterpreter} checks, if
+ * another iteration of the loop statement should be executed. This class stores the state of the
+ * loop (the iterator and the symbols corresponding to the loop and counter variable).
  */
 public class LoopBottomMark extends Node {
     private final LoopStmtNode loopStmtNode;
@@ -18,8 +19,11 @@ public class LoopBottomMark extends Node {
     private final Symbol counterVariableSymbol;
 
     /**
-     * Constructor for bottom mark of {@link LoopStmtNode}s, which have no internal iterator and no loop variables.
-     * @param loopStmtNode The {@link LoopStmtNode} of which the new instance will be the bottom mark.
+     * Constructor for bottom mark of {@link LoopStmtNode}s, which have no internal iterator and no
+     * loop variables.
+     *
+     * @param loopStmtNode The {@link LoopStmtNode} of which the new instance will be the bottom
+     *     mark.
      */
     public LoopBottomMark(LoopStmtNode loopStmtNode) {
         super(Type.LoopBottomMark);
@@ -30,13 +34,23 @@ public class LoopBottomMark extends Node {
     }
 
     /**
-     * Constructor for bottom mark of {@link LoopStmtNode}s, which have an internal iterator and loop and/or counter variables.
-     * @param loopStmtNode The {@link LoopStmtNode} of which the new instance will be the bottom mark.
-     * @param internalIterator The {@link Iterator<Value>} for the iterable expression of the {@link LoopStmtNode}
-     * @param loopVariableSymbol The {@link Symbol} for the loop variable, which is used to iterate over the iterable expression
-     * @param counterVariableSymbol The {@link Symbol} for the counter variable, which will be used to count the iterations of the loop
+     * Constructor for bottom mark of {@link LoopStmtNode}s, which have an internal iterator and
+     * loop and/or counter variables.
+     *
+     * @param loopStmtNode The {@link LoopStmtNode} of which the new instance will be the bottom
+     *     mark.
+     * @param internalIterator The {@link Iterator<Value>} for the iterable expression of the {@link
+     *     LoopStmtNode}
+     * @param loopVariableSymbol The {@link Symbol} for the loop variable, which is used to iterate
+     *     over the iterable expression
+     * @param counterVariableSymbol The {@link Symbol} for the counter variable, which will be used
+     *     to count the iterations of the loop
      */
-    public LoopBottomMark(LoopStmtNode loopStmtNode, Iterator<Value> internalIterator, Symbol loopVariableSymbol, Symbol counterVariableSymbol) {
+    public LoopBottomMark(
+            LoopStmtNode loopStmtNode,
+            Iterator<Value> internalIterator,
+            Symbol loopVariableSymbol,
+            Symbol counterVariableSymbol) {
         super(Type.LoopBottomMark);
         this.loopStmtNode = loopStmtNode;
         this.internalIterator = internalIterator;
@@ -52,11 +66,11 @@ public class LoopBottomMark extends Node {
         return internalIterator;
     }
 
-    public Symbol getLoopVariableSymbol () {
+    public Symbol getLoopVariableSymbol() {
         return loopVariableSymbol;
     }
 
-    public Symbol getCounterVariableSymbol () {
+    public Symbol getCounterVariableSymbol() {
         return counterVariableSymbol;
     }
 

--- a/dsl/src/parser/ast/LoopStmtNode.java
+++ b/dsl/src/parser/ast/LoopStmtNode.java
@@ -31,4 +31,3 @@ public abstract class LoopStmtNode extends Node {
         return visitor.visit(this);
     }
 }
-

--- a/dsl/src/parser/ast/LoopStmtNode.java
+++ b/dsl/src/parser/ast/LoopStmtNode.java
@@ -1,0 +1,34 @@
+package parser.ast;
+
+public abstract class LoopStmtNode extends Node {
+    public final int stmtIdx = 0;
+
+    public enum LoopType {
+        whileLoop,
+        forLoop,
+        countingForLoop
+    }
+
+    private final LoopType loopType;
+
+    public LoopType loopType() {
+        return this.loopType;
+    }
+
+    public Node getStmtNode() {
+        return this.getChild(this.stmtIdx);
+    }
+
+    public LoopStmtNode(LoopType loopType, Node stmtNode) {
+        super(Type.LoopStmtNode);
+        this.loopType = loopType;
+
+        addChild(stmtNode);
+    }
+
+    @Override
+    public <T> T accept(AstVisitor<T> visitor) {
+        return visitor.visit(this);
+    }
+}
+

--- a/dsl/src/parser/ast/Node.java
+++ b/dsl/src/parser/ast/Node.java
@@ -69,7 +69,8 @@ public class Node {
         SetDefinitionNode,
         ListTypeIdentifierNode,
         SetTypeIdentifierNode,
-        VarDeclNode
+        VarDeclNode,
+        LoopStmtNode
     }
 
     public static Node NONE = new Node(Type.NONE, new ArrayList<>());

--- a/dsl/src/parser/ast/Node.java
+++ b/dsl/src/parser/ast/Node.java
@@ -70,7 +70,8 @@ public class Node {
         ListTypeIdentifierNode,
         SetTypeIdentifierNode,
         VarDeclNode,
-        LoopStmtNode
+        LoopStmtNode,
+        LoopBottomMark
     }
 
     public static Node NONE = new Node(Type.NONE, new ArrayList<>());

--- a/dsl/src/parser/ast/VarDeclNode.java
+++ b/dsl/src/parser/ast/VarDeclNode.java
@@ -22,7 +22,7 @@ public class VarDeclNode extends BinaryNode {
     }
 
     public String getVariableName() {
-        return ((IdNode)this.getIdentifier()).getName();
+        return ((IdNode) this.getIdentifier()).getName();
     }
 
     @Override

--- a/dsl/src/parser/ast/VarDeclNode.java
+++ b/dsl/src/parser/ast/VarDeclNode.java
@@ -16,9 +16,13 @@ public class VarDeclNode extends BinaryNode {
         return declType;
     }
 
-    public VarDeclNode(VarDeclNode.DeclType type, Node identifier, Node rhs) {
+    public VarDeclNode(VarDeclNode.DeclType type, IdNode identifier, Node rhs) {
         super(Type.VarDeclNode, identifier, rhs);
         this.declType = type;
+    }
+
+    public String getVariableName() {
+        return ((IdNode)this.getIdentifier()).getName();
     }
 
     @Override

--- a/dsl/src/parser/ast/WhileLoopStmtNode.java
+++ b/dsl/src/parser/ast/WhileLoopStmtNode.java
@@ -1,0 +1,19 @@
+package parser.ast;
+
+public class WhileLoopStmtNode extends LoopStmtNode {
+    public final int expressionIdx = 1;
+
+    public Node getExpressionNode() {
+        return this.getChild(expressionIdx);
+    }
+
+    public WhileLoopStmtNode(Node expressionNode, Node stmtNode) {
+        super(LoopType.countingForLoop, stmtNode);
+        this.addChild(expressionNode);
+    }
+
+    @Override
+    public <T> T accept(AstVisitor<T> visitor) {
+        return visitor.visit(this);
+    }
+}

--- a/dsl/src/parser/ast/WhileLoopStmtNode.java
+++ b/dsl/src/parser/ast/WhileLoopStmtNode.java
@@ -8,7 +8,7 @@ public class WhileLoopStmtNode extends LoopStmtNode {
     }
 
     public WhileLoopStmtNode(Node expressionNode, Node stmtNode) {
-        super(LoopType.countingForLoop, stmtNode);
+        super(LoopType.whileLoop, stmtNode);
         this.addChild(expressionNode);
     }
 

--- a/dsl/src/runtime/ListValue.java
+++ b/dsl/src/runtime/ListValue.java
@@ -25,7 +25,7 @@ public class ListValue extends Value {
         return (ListType) this.dataType;
     }
 
-    protected ArrayList<Value> list() {
+    public ArrayList<Value> internalList() {
         return (ArrayList<Value>) this.object;
     }
 
@@ -35,7 +35,7 @@ public class ListValue extends Value {
      * @param value the value to add
      */
     public void addValue(Value value) {
-        list().add(value);
+        internalList().add(value);
     }
 
     /**
@@ -45,7 +45,7 @@ public class ListValue extends Value {
      * @return the Value at specified index
      */
     public Value getValue(int index) {
-        return list().get(index);
+        return internalList().get(index);
     }
 
     /**
@@ -54,11 +54,11 @@ public class ListValue extends Value {
      * @return the stored Values
      */
     public List<Value> getValues() {
-        return list();
+        return internalList();
     }
 
     public void clearList() {
-        list().clear();
+        internalList().clear();
     }
 
     // region native_methods
@@ -79,7 +79,7 @@ public class ListValue extends Value {
             Node paramNode = parameters.get(0);
             Value paramValue = (Value) paramNode.accept(interpreter);
 
-            listValue.list().add(paramValue);
+            listValue.internalList().add(paramValue);
             return null;
         }
     }
@@ -98,7 +98,7 @@ public class ListValue extends Value {
         public Object call(DSLInterpreter interpreter, Object instance, List<Node> parameters) {
             ListValue listValue = (ListValue) instance;
 
-            return listValue.list().size();
+            return listValue.internalList().size();
         }
     }
 
@@ -121,10 +121,10 @@ public class ListValue extends Value {
             Value indexValue = (Value) indexParameterNode.accept(interpreter);
             int index = (int) indexValue.getInternalValue();
 
-            if (index >= listValue.list().size()) {
+            if (index >= listValue.internalList().size()) {
                 return Value.NONE;
             } else {
-                return listValue.list().get(index);
+                return listValue.internalList().get(index);
             }
         }
     }

--- a/dsl/src/runtime/ListValue.java
+++ b/dsl/src/runtime/ListValue.java
@@ -26,7 +26,6 @@ public class ListValue extends Value {
     }
 
     /**
-     *
      * @return the internal ArrayList of this {@link ListValue}.
      */
     public ArrayList<Value> internalList() {

--- a/dsl/src/runtime/ListValue.java
+++ b/dsl/src/runtime/ListValue.java
@@ -25,6 +25,10 @@ public class ListValue extends Value {
         return (ListType) this.dataType;
     }
 
+    /**
+     *
+     * @return the internal ArrayList of this {@link ListValue}.
+     */
     public ArrayList<Value> internalList() {
         return (ArrayList<Value>) this.object;
     }

--- a/dsl/src/runtime/SetValue.java
+++ b/dsl/src/runtime/SetValue.java
@@ -31,7 +31,7 @@ public class SetValue extends Value {
         return (SetType) this.dataType;
     }
 
-    protected HashSet<Value> set() {
+    public HashSet<Value> internalSet() {
         return ((HashSet<Value>) this.object);
     }
     /**
@@ -47,7 +47,7 @@ public class SetValue extends Value {
             return false;
         }
         internalValueSet.add(internalValue);
-        set().add(value);
+        internalSet().add(value);
         return true;
     }
 
@@ -55,11 +55,11 @@ public class SetValue extends Value {
      * @return all stored values
      */
     public Set<Value> getValues() {
-        return set();
+        return internalSet();
     }
 
     public void clearSet() {
-        set().clear();
+        internalSet().clear();
     }
 
     // region native_methods
@@ -97,7 +97,7 @@ public class SetValue extends Value {
         public Object call(DSLInterpreter interpreter, Object instance, List<Node> parameters) {
             SetValue setValue = (SetValue) instance;
 
-            return setValue.set().size();
+            return setValue.internalSet().size();
         }
     }
 

--- a/dsl/src/runtime/SetValue.java
+++ b/dsl/src/runtime/SetValue.java
@@ -31,6 +31,9 @@ public class SetValue extends Value {
         return (SetType) this.dataType;
     }
 
+    /**
+     * @return the internal HashSet of this {@link SetValue}.
+     */
     public HashSet<Value> internalSet() {
         return ((HashSet<Value>) this.object);
     }

--- a/dsl/src/semanticanalysis/SemanticAnalyzer.java
+++ b/dsl/src/semanticanalysis/SemanticAnalyzer.java
@@ -721,11 +721,11 @@ public class SemanticAnalyzer implements AstVisitor<Void> {
         // create loop variable
         Node typeIdNode = node.getTypeIdNode();
         Node varIdNode = node.getVarIdNode();
-        createVariableSymbolInScope((IdNode)typeIdNode, (IdNode)varIdNode, loopScope);
+        createVariableSymbolInScope((IdNode) typeIdNode, (IdNode) varIdNode, loopScope);
 
         // create counter variable
         Node counterIdNode = node.getCounterIdNode();
-        createVariableSymbolInScope(BuiltInType.intType, (IdNode)counterIdNode, loopScope);
+        createVariableSymbolInScope(BuiltInType.intType, (IdNode) counterIdNode, loopScope);
 
         // visit stmt node of loop
         scopeStack.push(loopScope);
@@ -746,7 +746,7 @@ public class SemanticAnalyzer implements AstVisitor<Void> {
         // create loop variable
         Node typeIdNode = node.getTypeIdNode();
         Node varIdNode = node.getVarIdNode();
-        createVariableSymbolInScope((IdNode)typeIdNode, (IdNode)varIdNode, loopScope);
+        createVariableSymbolInScope((IdNode) typeIdNode, (IdNode) varIdNode, loopScope);
 
         // visit stmt node of loop
         scopeStack.push(loopScope);

--- a/dsl/src/semanticanalysis/SemanticAnalyzer.java
+++ b/dsl/src/semanticanalysis/SemanticAnalyzer.java
@@ -643,7 +643,7 @@ public class SemanticAnalyzer implements AstVisitor<Void> {
         return null;
     }
 
-    private Symbol createVariableSymbolInScope(IType type, IdNode nameIdNode, Node nodeToLinkToSymbol, IScope scope) {
+    private Symbol createVariableSymbolInScope(IType type, IdNode nameIdNode, IScope scope) {
         String name = nameIdNode.getName();
 
         // check if a variable is already defined in the current scope
@@ -655,12 +655,12 @@ public class SemanticAnalyzer implements AstVisitor<Void> {
         // create variable symbol
         Symbol variableSymbol = new Symbol(name, scope, type);
         scope.bind(variableSymbol);
-        this.symbolTable.addSymbolNodeRelation(variableSymbol, nodeToLinkToSymbol, true);
+        this.symbolTable.addSymbolNodeRelation(variableSymbol, nameIdNode, true);
 
         return variableSymbol;
     }
 
-    private Symbol createVariableSymbolInScope(IdNode typeIdNode, IdNode nameIdNode, Node nodeToLinkToSymbol, IScope scope) {
+    private Symbol createVariableSymbolInScope(IdNode typeIdNode, IdNode nameIdNode, IScope scope) {
         // resolve the type name
         String typeName = typeIdNode.getName();
         if (!typeIdNode.type.equals(Node.Type.Identifier)) {
@@ -673,7 +673,7 @@ public class SemanticAnalyzer implements AstVisitor<Void> {
             throw new RuntimeException("Type of name '" + typeName + "' cannot be resolved!");
         }
 
-        return createVariableSymbolInScope(variableType, nameIdNode, nodeToLinkToSymbol, scope);
+        return createVariableSymbolInScope(variableType, nameIdNode, scope);
     }
 
     @Override
@@ -686,7 +686,7 @@ public class SemanticAnalyzer implements AstVisitor<Void> {
 
         IdNode typeDeclNode = (IdNode) node.getRhs();
         IdNode nameIdNode = (IdNode) node.getIdentifier();
-        createVariableSymbolInScope(typeDeclNode, nameIdNode, node, this.currentScope());
+        Symbol symbol = createVariableSymbolInScope(typeDeclNode, nameIdNode, this.currentScope());
 
         return null;
     }
@@ -720,11 +720,11 @@ public class SemanticAnalyzer implements AstVisitor<Void> {
         // create loop variable
         Node typeIdNode = node.getTypeIdNode();
         Node varIdNode = node.getVarIdNode();
-        createVariableSymbolInScope((IdNode)typeIdNode, (IdNode)varIdNode, varIdNode, loopScope);
+        createVariableSymbolInScope((IdNode)typeIdNode, (IdNode)varIdNode, loopScope);
 
         // create counter variable
         Node counterIdNode = node.getCounterIdNode();
-        createVariableSymbolInScope(BuiltInType.intType, (IdNode)counterIdNode, counterIdNode, loopScope);
+        createVariableSymbolInScope(BuiltInType.intType, (IdNode)counterIdNode, loopScope);
 
         // visit stmt node of loop
         scopeStack.push(loopScope);
@@ -745,7 +745,7 @@ public class SemanticAnalyzer implements AstVisitor<Void> {
         // create loop variable
         Node typeIdNode = node.getTypeIdNode();
         Node varIdNode = node.getVarIdNode();
-        createVariableSymbolInScope((IdNode)typeIdNode, (IdNode)varIdNode, varIdNode, loopScope);
+        createVariableSymbolInScope((IdNode)typeIdNode, (IdNode)varIdNode, loopScope);
 
         // visit stmt node of loop
         scopeStack.push(loopScope);

--- a/dsl/src/semanticanalysis/SemanticAnalyzer.java
+++ b/dsl/src/semanticanalysis/SemanticAnalyzer.java
@@ -687,6 +687,7 @@ public class SemanticAnalyzer implements AstVisitor<Void> {
         IdNode typeDeclNode = (IdNode) node.getRhs();
         IdNode nameIdNode = (IdNode) node.getIdentifier();
         Symbol symbol = createVariableSymbolInScope(typeDeclNode, nameIdNode, this.currentScope());
+        this.symbolTable.addSymbolNodeRelation(symbol, node, true);
 
         return null;
     }

--- a/dsl/src/semanticanalysis/VariableBinder.java
+++ b/dsl/src/semanticanalysis/VariableBinder.java
@@ -288,5 +288,25 @@ public class VariableBinder implements AstVisitor<Void> {
         return null;
     }
 
+    @Override
+    public Void visit(LoopStmtNode node) {
+        return null;
+    }
+
+    @Override
+    public Void visit(WhileLoopStmtNode node) {
+        return null;
+    }
+
+    @Override
+    public Void visit(CountingLoopStmtNode node) {
+        return null;
+    }
+
+    @Override
+    public Void visit(ForLoopStmtNode node) {
+        return null;
+    }
+
     // endregion
 }

--- a/dsl/test/interpreter/TestDSLInterpreter.java
+++ b/dsl/test/interpreter/TestDSLInterpreter.java
@@ -3193,7 +3193,7 @@ public class TestDSLInterpreter {
     @Test
     public void testForLoop() {
         String program =
-            """
+                """
             entity_type my_type {
                 test_component1 {},
                 test_component_with_callback {
@@ -3225,34 +3225,41 @@ public class TestDSLInterpreter {
         DSLInterpreter interpreter = new DSLInterpreter();
         env.getTypeBuilder().createDSLTypeForJavaTypeInScope(env.getGlobalScope(), Entity.class);
         env.getTypeBuilder()
-            .createDSLTypeForJavaTypeInScope(
-                env.getGlobalScope(), TestComponentEntityConsumerCallback.class);
+                .createDSLTypeForJavaTypeInScope(
+                        env.getGlobalScope(), TestComponentEntityConsumerCallback.class);
         env.getTypeBuilder()
-            .createDSLTypeForJavaTypeInScope(env.getGlobalScope(), TestComponent1.class);
+                .createDSLTypeForJavaTypeInScope(env.getGlobalScope(), TestComponent1.class);
 
         var config =
-            (CustomQuestConfig)
-                Helpers.generateQuestConfigWithCustomTypes(program, env, interpreter);
+                (CustomQuestConfig)
+                        Helpers.generateQuestConfigWithCustomTypes(program, env, interpreter);
 
         var entity = config.entity();
 
         TestComponentEntityConsumerCallback componentWithConsumer =
-            (TestComponentEntityConsumerCallback)
-                entity.components.stream()
-                    .filter(c -> c instanceof TestComponentEntityConsumerCallback)
-                    .toList()
-                    .get(0);
+                (TestComponentEntityConsumerCallback)
+                        entity.components.stream()
+                                .filter(c -> c instanceof TestComponentEntityConsumerCallback)
+                                .toList()
+                                .get(0);
 
         componentWithConsumer.consumer.accept(entity);
 
         String output = outputStream.toString();
-        assertEquals("1" + System.lineSeparator() + "2" + System.lineSeparator() + "3" + System.lineSeparator(), output);
+        assertEquals(
+                "1"
+                        + System.lineSeparator()
+                        + "2"
+                        + System.lineSeparator()
+                        + "3"
+                        + System.lineSeparator(),
+                output);
     }
 
     @Test
     public void testForLoopIterableExpression() {
         String program =
-            """
+                """
             entity_type my_type {
                 test_component_with_callback {
                     consumer: func
@@ -3287,32 +3294,39 @@ public class TestDSLInterpreter {
         DSLInterpreter interpreter = new DSLInterpreter();
         env.getTypeBuilder().createDSLTypeForJavaTypeInScope(env.getGlobalScope(), Entity.class);
         env.getTypeBuilder()
-            .createDSLTypeForJavaTypeInScope(
-                env.getGlobalScope(), TestComponentEntityConsumerCallback.class);
+                .createDSLTypeForJavaTypeInScope(
+                        env.getGlobalScope(), TestComponentEntityConsumerCallback.class);
 
         var config =
-            (CustomQuestConfig)
-                Helpers.generateQuestConfigWithCustomTypes(program, env, interpreter);
+                (CustomQuestConfig)
+                        Helpers.generateQuestConfigWithCustomTypes(program, env, interpreter);
 
         var entity = config.entity();
 
         TestComponentEntityConsumerCallback componentWithConsumer =
-            (TestComponentEntityConsumerCallback)
-                entity.components.stream()
-                    .filter(c -> c instanceof TestComponentEntityConsumerCallback)
-                    .toList()
-                    .get(0);
+                (TestComponentEntityConsumerCallback)
+                        entity.components.stream()
+                                .filter(c -> c instanceof TestComponentEntityConsumerCallback)
+                                .toList()
+                                .get(0);
 
         componentWithConsumer.consumer.accept(entity);
 
         String output = outputStream.toString();
-        assertEquals("1" + System.lineSeparator() + "2" + System.lineSeparator() + "3" + System.lineSeparator(), output);
+        assertEquals(
+                "1"
+                        + System.lineSeparator()
+                        + "2"
+                        + System.lineSeparator()
+                        + "3"
+                        + System.lineSeparator(),
+                output);
     }
 
     @Test
     public void testCountingForLoop() {
         String program =
-            """
+                """
             entity_type my_type {
                 test_component1 {},
                 test_component_with_callback {
@@ -3345,47 +3359,47 @@ public class TestDSLInterpreter {
         DSLInterpreter interpreter = new DSLInterpreter();
         env.getTypeBuilder().createDSLTypeForJavaTypeInScope(env.getGlobalScope(), Entity.class);
         env.getTypeBuilder()
-            .createDSLTypeForJavaTypeInScope(
-                env.getGlobalScope(), TestComponentEntityConsumerCallback.class);
+                .createDSLTypeForJavaTypeInScope(
+                        env.getGlobalScope(), TestComponentEntityConsumerCallback.class);
         env.getTypeBuilder()
-            .createDSLTypeForJavaTypeInScope(env.getGlobalScope(), TestComponent1.class);
+                .createDSLTypeForJavaTypeInScope(env.getGlobalScope(), TestComponent1.class);
 
         var config =
-            (CustomQuestConfig)
-                Helpers.generateQuestConfigWithCustomTypes(program, env, interpreter);
+                (CustomQuestConfig)
+                        Helpers.generateQuestConfigWithCustomTypes(program, env, interpreter);
 
         var entity = config.entity();
 
         TestComponentEntityConsumerCallback componentWithConsumer =
-            (TestComponentEntityConsumerCallback)
-                entity.components.stream()
-                    .filter(c -> c instanceof TestComponentEntityConsumerCallback)
-                    .toList()
-                    .get(0);
+                (TestComponentEntityConsumerCallback)
+                        entity.components.stream()
+                                .filter(c -> c instanceof TestComponentEntityConsumerCallback)
+                                .toList()
+                                .get(0);
 
         componentWithConsumer.consumer.accept(entity);
 
         String output = outputStream.toString();
         assertEquals(
-            "0"
-                + System.lineSeparator()
-                + "Hello"
-                + System.lineSeparator()
-                + "1"
-                + System.lineSeparator()
-                + "World"
-                + System.lineSeparator()
-                + "2"
-                + System.lineSeparator()
-                + "!"
-                + System.lineSeparator(),
-            output);
+                "0"
+                        + System.lineSeparator()
+                        + "Hello"
+                        + System.lineSeparator()
+                        + "1"
+                        + System.lineSeparator()
+                        + "World"
+                        + System.lineSeparator()
+                        + "2"
+                        + System.lineSeparator()
+                        + "!"
+                        + System.lineSeparator(),
+                output);
     }
 
     @Test
     public void testWhileLoop() {
         String program =
-            """
+                """
             entity_type my_type {
                 test_component1 {},
                 test_component_with_callback {
@@ -3428,35 +3442,35 @@ public class TestDSLInterpreter {
         DSLInterpreter interpreter = new DSLInterpreter();
         env.getTypeBuilder().createDSLTypeForJavaTypeInScope(env.getGlobalScope(), Entity.class);
         env.getTypeBuilder()
-            .createDSLTypeForJavaTypeInScope(
-                env.getGlobalScope(), TestComponentEntityConsumerCallback.class);
+                .createDSLTypeForJavaTypeInScope(
+                        env.getGlobalScope(), TestComponentEntityConsumerCallback.class);
         env.getTypeBuilder()
-            .createDSLTypeForJavaTypeInScope(env.getGlobalScope(), TestComponent1.class);
+                .createDSLTypeForJavaTypeInScope(env.getGlobalScope(), TestComponent1.class);
 
         var config =
-            (CustomQuestConfig)
-                Helpers.generateQuestConfigWithCustomTypes(program, env, interpreter);
+                (CustomQuestConfig)
+                        Helpers.generateQuestConfigWithCustomTypes(program, env, interpreter);
 
         var entity = config.entity();
 
         TestComponentEntityConsumerCallback componentWithConsumer =
-            (TestComponentEntityConsumerCallback)
-                entity.components.stream()
-                    .filter(c -> c instanceof TestComponentEntityConsumerCallback)
-                    .toList()
-                    .get(0);
+                (TestComponentEntityConsumerCallback)
+                        entity.components.stream()
+                                .filter(c -> c instanceof TestComponentEntityConsumerCallback)
+                                .toList()
+                                .get(0);
 
         componentWithConsumer.consumer.accept(entity);
 
         String output = outputStream.toString();
         boolean b = true;
         assertEquals(
-            "1"
-                + System.lineSeparator()
-                + "2"
-                + System.lineSeparator()
-                + "3"
-                + System.lineSeparator(),
-            output);
+                "1"
+                        + System.lineSeparator()
+                        + "2"
+                        + System.lineSeparator()
+                        + "3"
+                        + System.lineSeparator(),
+                output);
     }
 }

--- a/dsl/test/interpreter/TestDSLInterpreter.java
+++ b/dsl/test/interpreter/TestDSLInterpreter.java
@@ -3250,6 +3250,66 @@ public class TestDSLInterpreter {
     }
 
     @Test
+    public void testForLoopIterableExpression() {
+        String program =
+            """
+            entity_type my_type {
+                test_component_with_callback {
+                    consumer: func
+                }
+            }
+
+            fn func(entity ent) {
+                var my_list_of_lists : int[][];
+
+                var my_list : int[];
+                my_list.add(1);
+                my_list.add(2);
+                my_list.add(3);
+
+                my_list_of_lists.add(my_list);
+                for int entry in my_list_of_lists.get(0) {
+                    print(entry);
+                }
+            }
+
+            quest_config c {
+                entity: instantiate(my_type)
+            }
+            """;
+
+        // print currently just prints to system.out, so we need to
+        // check the contents for the printed string
+        var outputStream = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(outputStream));
+
+        TestEnvironment env = new TestEnvironment();
+        DSLInterpreter interpreter = new DSLInterpreter();
+        env.getTypeBuilder().createDSLTypeForJavaTypeInScope(env.getGlobalScope(), Entity.class);
+        env.getTypeBuilder()
+            .createDSLTypeForJavaTypeInScope(
+                env.getGlobalScope(), TestComponentEntityConsumerCallback.class);
+
+        var config =
+            (CustomQuestConfig)
+                Helpers.generateQuestConfigWithCustomTypes(program, env, interpreter);
+
+        var entity = config.entity();
+
+        TestComponentEntityConsumerCallback componentWithConsumer =
+            (TestComponentEntityConsumerCallback)
+                entity.components.stream()
+                    .filter(c -> c instanceof TestComponentEntityConsumerCallback)
+                    .toList()
+                    .get(0);
+
+        componentWithConsumer.consumer.accept(entity);
+
+        String output = outputStream.toString();
+        assertEquals("1" + System.lineSeparator() + "2" + System.lineSeparator() + "3" + System.lineSeparator(), output);
+    }
+
+    @Test
     public void testCountingForLoop() {
         String program =
             """

--- a/dsl/test/parser/TestDungeonASTConverter.java
+++ b/dsl/test/parser/TestDungeonASTConverter.java
@@ -977,6 +977,93 @@ public class TestDungeonASTConverter {
     }
 
     @Test
+    public void testForLoop() {
+        String program =
+            """
+        fn test_func() {
+            for var_type var_name in iterable {
+                print(id);
+            }
+        }
+    """;
+
+        var ast = Helpers.getASTFromString(program);
+        var funcDefNode = (FuncDefNode) ast.getChild(0);
+        var stmts = funcDefNode.getStmts();
+
+        var loopStmt = stmts.get(0);
+        Assert.assertEquals(Node.Type.LoopStmtNode, loopStmt.type);
+        ForLoopStmtNode forLoopStmtNode = (ForLoopStmtNode) loopStmt;
+        Assert.assertEquals(LoopStmtNode.LoopType.forLoop, forLoopStmtNode.loopType());
+
+        IdNode typeIdNode = (IdNode) forLoopStmtNode.getTypeIdNode();
+        Assert.assertEquals("var_type", typeIdNode.getName());
+
+        IdNode varNameIdNode = (IdNode) forLoopStmtNode.getVarIdNode();
+        Assert.assertEquals("var_name", varNameIdNode.getName());
+
+        IdNode iterableIdNode = (IdNode) forLoopStmtNode.getIterableIdNode();
+        Assert.assertEquals("iterable", iterableIdNode.getName());
+    }
+
+    @Test
+    public void testCountingForLoop() {
+        String program =
+            """
+        fn test_func() {
+            for var_type var_name in iterable count i {
+                print(id);
+            }
+        }
+    """;
+
+        var ast = Helpers.getASTFromString(program);
+        var funcDefNode = (FuncDefNode) ast.getChild(0);
+        var stmts = funcDefNode.getStmts();
+
+        var loopStmt = stmts.get(0);
+        Assert.assertEquals(Node.Type.LoopStmtNode, loopStmt.type);
+        CountingLoopStmtNode forLoopStmtNode = (CountingLoopStmtNode) loopStmt;
+        Assert.assertEquals(LoopStmtNode.LoopType.countingForLoop, forLoopStmtNode.loopType());
+
+        IdNode typeIdNode = (IdNode) forLoopStmtNode.getTypeIdNode();
+        Assert.assertEquals("var_type", typeIdNode.getName());
+
+        IdNode varNameIdNode = (IdNode) forLoopStmtNode.getVarIdNode();
+        Assert.assertEquals("var_name", varNameIdNode.getName());
+
+        IdNode iterableIdNode = (IdNode) forLoopStmtNode.getIterableIdNode();
+        Assert.assertEquals("iterable", iterableIdNode.getName());
+
+        IdNode counterIdNode = (IdNode) forLoopStmtNode.getCounterIdNode();
+        Assert.assertEquals("i", counterIdNode.getName());
+    }
+
+    @Test
+    public void testWhileLoop() {
+        String program =
+            """
+        fn test_func() {
+            while expr {
+                print(id);
+            }
+        }
+    """;
+
+        var ast = Helpers.getASTFromString(program);
+        var funcDefNode = (FuncDefNode) ast.getChild(0);
+        var stmts = funcDefNode.getStmts();
+
+        var loopStmt = stmts.get(0);
+        Assert.assertEquals(Node.Type.LoopStmtNode, loopStmt.type);
+        WhileLoopStmtNode forLoopStmtNode = (WhileLoopStmtNode) loopStmt;
+        Assert.assertEquals(LoopStmtNode.LoopType.whileLoop, forLoopStmtNode.loopType());
+
+        IdNode counterIdNode = (IdNode) forLoopStmtNode.getExpressionNode();
+        Assert.assertEquals("expr", counterIdNode.getName());
+    }
+
+    @Test
     public void testGraphEdgeAttribute() {
         String program =
                 """

--- a/dsl/test/parser/TestDungeonASTConverter.java
+++ b/dsl/test/parser/TestDungeonASTConverter.java
@@ -979,7 +979,7 @@ public class TestDungeonASTConverter {
     @Test
     public void testForLoop() {
         String program =
-            """
+                """
         fn test_func() {
             for var_type var_name in iterable {
                 print(id);
@@ -1009,7 +1009,7 @@ public class TestDungeonASTConverter {
     @Test
     public void testCountingForLoop() {
         String program =
-            """
+                """
         fn test_func() {
             for var_type var_name in iterable count i {
                 print(id);
@@ -1042,7 +1042,7 @@ public class TestDungeonASTConverter {
     @Test
     public void testWhileLoop() {
         String program =
-            """
+                """
         fn test_func() {
             while expr {
                 print(id);

--- a/dsl/test/semanticanalysis/TestSemanticAnalyzer.java
+++ b/dsl/test/semanticanalysis/TestSemanticAnalyzer.java
@@ -1101,4 +1101,39 @@ public class TestSemanticAnalyzer {
         Symbol secondPrintParameterSymbol = symbolTable.getSymbolsForAstNode(secondPrintParameterIdNode).get(0);
         Assert.assertEquals(counterVariableSymbol, secondPrintParameterSymbol);
     }
+
+    @Test
+    public void testWhileLoop() {
+        String program =
+            """
+        fn test() {
+            var my_list : int[];
+            while my_list {
+                print(my_list);
+            }
+        }
+
+        """;
+
+        // setup
+        var ast = Helpers.getASTFromString(program);
+        SemanticAnalyzer symbolTableParser = new SemanticAnalyzer();
+
+        var env = new GameEnvironment();
+        symbolTableParser.setup(env);
+        var symbolTable = symbolTableParser.walk(ast).symbolTable;
+
+        // get variable declaration
+        FunctionSymbol funcSymbol =
+            (FunctionSymbol) symbolTable.globalScope.resolve("test");
+        FuncDefNode funcDefNode = (FuncDefNode) symbolTable.getCreationAstNode(funcSymbol);
+        VarDeclNode varDeclNode = (VarDeclNode) funcDefNode.getStmtBlock().getChild(0).getChild(0);
+        Symbol myListSymbol = symbolTable.getSymbolsForAstNode(varDeclNode).get(0);
+
+        // get iterableIdNode and check, that it references the variable symbol
+        WhileLoopStmtNode loopNode = (WhileLoopStmtNode) funcDefNode.getStmtBlock().getChild(0).getChild(1);
+        Node expressionIdNode = loopNode.getExpressionNode();
+        Symbol expressionRefNode = symbolTable.getSymbolsForAstNode(expressionIdNode).get(0);
+        Assert.assertEquals(myListSymbol, expressionRefNode);
+    }
 }

--- a/dsl/test/semanticanalysis/TestSemanticAnalyzer.java
+++ b/dsl/test/semanticanalysis/TestSemanticAnalyzer.java
@@ -1001,7 +1001,7 @@ public class TestSemanticAnalyzer {
     @Test
     public void testForLoopVariableBinding() {
         String program =
-            """
+                """
         fn test() {
             var my_list : int[];
             for int entry in my_list {
@@ -1020,14 +1020,14 @@ public class TestSemanticAnalyzer {
         var symbolTable = symbolTableParser.walk(ast).symbolTable;
 
         // get variable declaration
-        FunctionSymbol funcSymbol =
-            (FunctionSymbol) symbolTable.globalScope.resolve("test");
+        FunctionSymbol funcSymbol = (FunctionSymbol) symbolTable.globalScope.resolve("test");
         FuncDefNode funcDefNode = (FuncDefNode) symbolTable.getCreationAstNode(funcSymbol);
         VarDeclNode varDeclNode = (VarDeclNode) funcDefNode.getStmtBlock().getChild(0).getChild(0);
         Symbol myListSymbol = symbolTable.getSymbolsForAstNode(varDeclNode).get(0);
 
         // get iterableIdNode and check, that it references the variable symbol
-        ForLoopStmtNode loopNode = (ForLoopStmtNode) funcDefNode.getStmtBlock().getChild(0).getChild(1);
+        ForLoopStmtNode loopNode =
+                (ForLoopStmtNode) funcDefNode.getStmtBlock().getChild(0).getChild(1);
         Node iterableIdNode = loopNode.getIterableIdNode();
         Symbol iterableIdNodeRefSymbol = symbolTable.getSymbolsForAstNode(iterableIdNode).get(0);
         Assert.assertEquals(myListSymbol, iterableIdNodeRefSymbol);
@@ -1038,7 +1038,7 @@ public class TestSemanticAnalyzer {
         Assert.assertNotEquals(Symbol.NULL, loopVariableSymbol);
 
         // get the print call and check, that the parameter references the loop variable symbol
-        FuncCallNode printCallNode = (FuncCallNode)loopNode.getStmtNode().getChild(0).getChild(0);
+        FuncCallNode printCallNode = (FuncCallNode) loopNode.getStmtNode().getChild(0).getChild(0);
         IdNode parameterIdNode = (IdNode) printCallNode.getParameters().get(0);
         Symbol parameterSymbol = symbolTable.getSymbolsForAstNode(parameterIdNode).get(0);
         Assert.assertEquals(loopVariableSymbol, parameterSymbol);
@@ -1047,7 +1047,7 @@ public class TestSemanticAnalyzer {
     @Test
     public void testCountingLoopVariableBinding() {
         String program =
-            """
+                """
         fn test() {
             var my_list : int[];
             for int entry in my_list count i{
@@ -1067,14 +1067,14 @@ public class TestSemanticAnalyzer {
         var symbolTable = symbolTableParser.walk(ast).symbolTable;
 
         // get variable declaration
-        FunctionSymbol funcSymbol =
-            (FunctionSymbol) symbolTable.globalScope.resolve("test");
+        FunctionSymbol funcSymbol = (FunctionSymbol) symbolTable.globalScope.resolve("test");
         FuncDefNode funcDefNode = (FuncDefNode) symbolTable.getCreationAstNode(funcSymbol);
         VarDeclNode varDeclNode = (VarDeclNode) funcDefNode.getStmtBlock().getChild(0).getChild(0);
         Symbol myListSymbol = symbolTable.getSymbolsForAstNode(varDeclNode).get(0);
 
         // get iterableIdNode and check, that it references the variable symbol
-        CountingLoopStmtNode loopNode = (CountingLoopStmtNode) funcDefNode.getStmtBlock().getChild(0).getChild(1);
+        CountingLoopStmtNode loopNode =
+                (CountingLoopStmtNode) funcDefNode.getStmtBlock().getChild(0).getChild(1);
         Node iterableIdNode = loopNode.getIterableIdNode();
         Symbol iterableIdNodeRefSymbol = symbolTable.getSymbolsForAstNode(iterableIdNode).get(0);
         Assert.assertEquals(myListSymbol, iterableIdNodeRefSymbol);
@@ -1085,27 +1085,31 @@ public class TestSemanticAnalyzer {
         Assert.assertNotEquals(Symbol.NULL, loopVariableSymbol);
 
         // get the print call and check, that the parameter references the loop variable symbol
-        FuncCallNode printCallNode = (FuncCallNode)loopNode.getStmtNode().getChild(0).getChild(0);
+        FuncCallNode printCallNode = (FuncCallNode) loopNode.getStmtNode().getChild(0).getChild(0);
         IdNode parameterIdNode = (IdNode) printCallNode.getParameters().get(0);
         Symbol parameterSymbol = symbolTable.getSymbolsForAstNode(parameterIdNode).get(0);
         Assert.assertEquals(loopVariableSymbol, parameterSymbol);
 
         // get the loop variable id node and the linked symbol
         Node counterVariableIdNode = loopNode.getCounterIdNode();
-        Symbol counterVariableSymbol = symbolTable.getSymbolsForAstNode(counterVariableIdNode).get(0);
+        Symbol counterVariableSymbol =
+                symbolTable.getSymbolsForAstNode(counterVariableIdNode).get(0);
         Assert.assertNotEquals(Symbol.NULL, counterVariableSymbol);
 
-        // get the second print call and check, that the parameter references the counter variable symbol
-        FuncCallNode secondPrintCall = (FuncCallNode)loopNode.getStmtNode().getChild(0).getChild(1);
+        // get the second print call and check, that the parameter references the counter variable
+        // symbol
+        FuncCallNode secondPrintCall =
+                (FuncCallNode) loopNode.getStmtNode().getChild(0).getChild(1);
         IdNode secondPrintParameterIdNode = (IdNode) secondPrintCall.getParameters().get(0);
-        Symbol secondPrintParameterSymbol = symbolTable.getSymbolsForAstNode(secondPrintParameterIdNode).get(0);
+        Symbol secondPrintParameterSymbol =
+                symbolTable.getSymbolsForAstNode(secondPrintParameterIdNode).get(0);
         Assert.assertEquals(counterVariableSymbol, secondPrintParameterSymbol);
     }
 
     @Test
     public void testWhileLoop() {
         String program =
-            """
+                """
         fn test() {
             var my_list : int[];
             while my_list {
@@ -1124,14 +1128,14 @@ public class TestSemanticAnalyzer {
         var symbolTable = symbolTableParser.walk(ast).symbolTable;
 
         // get variable declaration
-        FunctionSymbol funcSymbol =
-            (FunctionSymbol) symbolTable.globalScope.resolve("test");
+        FunctionSymbol funcSymbol = (FunctionSymbol) symbolTable.globalScope.resolve("test");
         FuncDefNode funcDefNode = (FuncDefNode) symbolTable.getCreationAstNode(funcSymbol);
         VarDeclNode varDeclNode = (VarDeclNode) funcDefNode.getStmtBlock().getChild(0).getChild(0);
         Symbol myListSymbol = symbolTable.getSymbolsForAstNode(varDeclNode).get(0);
 
         // get iterableIdNode and check, that it references the variable symbol
-        WhileLoopStmtNode loopNode = (WhileLoopStmtNode) funcDefNode.getStmtBlock().getChild(0).getChild(1);
+        WhileLoopStmtNode loopNode =
+                (WhileLoopStmtNode) funcDefNode.getStmtBlock().getChild(0).getChild(1);
         Node expressionIdNode = loopNode.getExpressionNode();
         Symbol expressionRefNode = symbolTable.getSymbolsForAstNode(expressionIdNode).get(0);
         Assert.assertEquals(myListSymbol, expressionRefNode);

--- a/dsl/test/semanticanalysis/TestSemanticAnalyzer.java
+++ b/dsl/test/semanticanalysis/TestSemanticAnalyzer.java
@@ -999,7 +999,7 @@ public class TestSemanticAnalyzer {
     }
 
     @Test
-    public void testLoopVariableBinding() {
+    public void testForLoopVariableBinding() {
         String program =
             """
         fn test() {
@@ -1042,5 +1042,63 @@ public class TestSemanticAnalyzer {
         IdNode parameterIdNode = (IdNode) printCallNode.getParameters().get(0);
         Symbol parameterSymbol = symbolTable.getSymbolsForAstNode(parameterIdNode).get(0);
         Assert.assertEquals(loopVariableSymbol, parameterSymbol);
+    }
+
+    @Test
+    public void testCountingLoopVariableBinding() {
+        String program =
+            """
+        fn test() {
+            var my_list : int[];
+            for int entry in my_list count i{
+                print(entry);
+                print(i);
+            }
+        }
+
+        """;
+
+        // setup
+        var ast = Helpers.getASTFromString(program);
+        SemanticAnalyzer symbolTableParser = new SemanticAnalyzer();
+
+        var env = new GameEnvironment();
+        symbolTableParser.setup(env);
+        var symbolTable = symbolTableParser.walk(ast).symbolTable;
+
+        // get variable declaration
+        FunctionSymbol funcSymbol =
+            (FunctionSymbol) symbolTable.globalScope.resolve("test");
+        FuncDefNode funcDefNode = (FuncDefNode) symbolTable.getCreationAstNode(funcSymbol);
+        VarDeclNode varDeclNode = (VarDeclNode) funcDefNode.getStmtBlock().getChild(0).getChild(0);
+        Symbol myListSymbol = symbolTable.getSymbolsForAstNode(varDeclNode).get(0);
+
+        // get iterableIdNode and check, that it references the variable symbol
+        CountingLoopStmtNode loopNode = (CountingLoopStmtNode) funcDefNode.getStmtBlock().getChild(0).getChild(1);
+        Node iterableIdNode = loopNode.getIterableIdNode();
+        Symbol iterableIdNodeRefSymbol = symbolTable.getSymbolsForAstNode(iterableIdNode).get(0);
+        Assert.assertEquals(myListSymbol, iterableIdNodeRefSymbol);
+
+        // get the loop variable id node and the linked symbol
+        Node loopVariableIdNode = loopNode.getVarIdNode();
+        Symbol loopVariableSymbol = symbolTable.getSymbolsForAstNode(loopVariableIdNode).get(0);
+        Assert.assertNotEquals(Symbol.NULL, loopVariableSymbol);
+
+        // get the print call and check, that the parameter references the loop variable symbol
+        FuncCallNode printCallNode = (FuncCallNode)loopNode.getStmtNode().getChild(0).getChild(0);
+        IdNode parameterIdNode = (IdNode) printCallNode.getParameters().get(0);
+        Symbol parameterSymbol = symbolTable.getSymbolsForAstNode(parameterIdNode).get(0);
+        Assert.assertEquals(loopVariableSymbol, parameterSymbol);
+
+        // get the loop variable id node and the linked symbol
+        Node counterVariableIdNode = loopNode.getCounterIdNode();
+        Symbol counterVariableSymbol = symbolTable.getSymbolsForAstNode(counterVariableIdNode).get(0);
+        Assert.assertNotEquals(Symbol.NULL, counterVariableSymbol);
+
+        // get the second print call and check, that the parameter references the counter variable symbol
+        FuncCallNode secondPrintCall = (FuncCallNode)loopNode.getStmtNode().getChild(0).getChild(1);
+        IdNode secondPrintParameterIdNode = (IdNode) secondPrintCall.getParameters().get(0);
+        Symbol secondPrintParameterSymbol = symbolTable.getSymbolsForAstNode(secondPrintParameterIdNode).get(0);
+        Assert.assertEquals(counterVariableSymbol, secondPrintParameterSymbol);
     }
 }

--- a/dsl/test/semanticanalysis/TestSemanticAnalyzer.java
+++ b/dsl/test/semanticanalysis/TestSemanticAnalyzer.java
@@ -699,7 +699,7 @@ public class TestSemanticAnalyzer {
                 (FunctionSymbol) symbolTable.globalScope.resolve("get_property");
         FuncDefNode funcDefNode = (FuncDefNode) symbolTable.getCreationAstNode(funcSymbol);
         VarDeclNode declNode = (VarDeclNode) funcDefNode.getStmtBlock().getChild(0).getChild(0);
-        Symbol testVariableSymbol = symbolTable.getSymbolsForAstNode(declNode).get(0);
+        Symbol testVariableSymbol = symbolTable.getSymbolsForAstNode(declNode.getIdentifier()).get(0);
 
         Assert.assertNotEquals(Symbol.NULL, testVariableSymbol);
         Assert.assertEquals(BuiltInType.stringType, testVariableSymbol.dataType);
@@ -750,7 +750,7 @@ public class TestSemanticAnalyzer {
         VarDeclNode ifStmtDeclNode = (VarDeclNode) conditional.getIfStmt();
         VarDeclNode elseStmtDeclNode = (VarDeclNode) conditional.getElseStmt();
 
-        Symbol ifStmtDeclSymbol = symbolTable.getSymbolsForAstNode(ifStmtDeclNode).get(0);
+        Symbol ifStmtDeclSymbol = symbolTable.getSymbolsForAstNode(ifStmtDeclNode.getIdentifier()).get(0);
         Assert.assertNotEquals(Symbol.NULL, ifStmtDeclSymbol);
 
         // test correct scope relation
@@ -762,7 +762,7 @@ public class TestSemanticAnalyzer {
         var expectedToBeFunctionScope = declScope.getParent().getParent();
         Assert.assertEquals(funcSymbol, expectedToBeFunctionScope);
 
-        Symbol elseStmtDeclSymbol = symbolTable.getSymbolsForAstNode(elseStmtDeclNode).get(0);
+        Symbol elseStmtDeclSymbol = symbolTable.getSymbolsForAstNode(elseStmtDeclNode.getIdentifier()).get(0);
         Assert.assertNotEquals(Symbol.NULL, ifStmtDeclSymbol);
         // test correct scope relation
         declScope = elseStmtDeclSymbol.getScope();
@@ -1024,7 +1024,7 @@ public class TestSemanticAnalyzer {
             (FunctionSymbol) symbolTable.globalScope.resolve("test");
         FuncDefNode funcDefNode = (FuncDefNode) symbolTable.getCreationAstNode(funcSymbol);
         VarDeclNode varDeclNode = (VarDeclNode) funcDefNode.getStmtBlock().getChild(0).getChild(0);
-        Symbol myListSymbol = symbolTable.getSymbolsForAstNode(varDeclNode).get(0);
+        Symbol myListSymbol = symbolTable.getSymbolsForAstNode(varDeclNode.getIdentifier()).get(0);
 
         // get iterableIdNode and check, that it references the variable symbol
         ForLoopStmtNode loopNode = (ForLoopStmtNode) funcDefNode.getStmtBlock().getChild(0).getChild(1);
@@ -1071,7 +1071,7 @@ public class TestSemanticAnalyzer {
             (FunctionSymbol) symbolTable.globalScope.resolve("test");
         FuncDefNode funcDefNode = (FuncDefNode) symbolTable.getCreationAstNode(funcSymbol);
         VarDeclNode varDeclNode = (VarDeclNode) funcDefNode.getStmtBlock().getChild(0).getChild(0);
-        Symbol myListSymbol = symbolTable.getSymbolsForAstNode(varDeclNode).get(0);
+        Symbol myListSymbol = symbolTable.getSymbolsForAstNode(varDeclNode.getIdentifier()).get(0);
 
         // get iterableIdNode and check, that it references the variable symbol
         CountingLoopStmtNode loopNode = (CountingLoopStmtNode) funcDefNode.getStmtBlock().getChild(0).getChild(1);
@@ -1128,7 +1128,7 @@ public class TestSemanticAnalyzer {
             (FunctionSymbol) symbolTable.globalScope.resolve("test");
         FuncDefNode funcDefNode = (FuncDefNode) symbolTable.getCreationAstNode(funcSymbol);
         VarDeclNode varDeclNode = (VarDeclNode) funcDefNode.getStmtBlock().getChild(0).getChild(0);
-        Symbol myListSymbol = symbolTable.getSymbolsForAstNode(varDeclNode).get(0);
+        Symbol myListSymbol = symbolTable.getSymbolsForAstNode(varDeclNode.getIdentifier()).get(0);
 
         // get iterableIdNode and check, that it references the variable symbol
         WhileLoopStmtNode loopNode = (WhileLoopStmtNode) funcDefNode.getStmtBlock().getChild(0).getChild(1);

--- a/dsl/test/semanticanalysis/TestSemanticAnalyzer.java
+++ b/dsl/test/semanticanalysis/TestSemanticAnalyzer.java
@@ -699,7 +699,7 @@ public class TestSemanticAnalyzer {
                 (FunctionSymbol) symbolTable.globalScope.resolve("get_property");
         FuncDefNode funcDefNode = (FuncDefNode) symbolTable.getCreationAstNode(funcSymbol);
         VarDeclNode declNode = (VarDeclNode) funcDefNode.getStmtBlock().getChild(0).getChild(0);
-        Symbol testVariableSymbol = symbolTable.getSymbolsForAstNode(declNode.getIdentifier()).get(0);
+        Symbol testVariableSymbol = symbolTable.getSymbolsForAstNode(declNode).get(0);
 
         Assert.assertNotEquals(Symbol.NULL, testVariableSymbol);
         Assert.assertEquals(BuiltInType.stringType, testVariableSymbol.dataType);
@@ -750,7 +750,7 @@ public class TestSemanticAnalyzer {
         VarDeclNode ifStmtDeclNode = (VarDeclNode) conditional.getIfStmt();
         VarDeclNode elseStmtDeclNode = (VarDeclNode) conditional.getElseStmt();
 
-        Symbol ifStmtDeclSymbol = symbolTable.getSymbolsForAstNode(ifStmtDeclNode.getIdentifier()).get(0);
+        Symbol ifStmtDeclSymbol = symbolTable.getSymbolsForAstNode(ifStmtDeclNode).get(0);
         Assert.assertNotEquals(Symbol.NULL, ifStmtDeclSymbol);
 
         // test correct scope relation
@@ -762,7 +762,7 @@ public class TestSemanticAnalyzer {
         var expectedToBeFunctionScope = declScope.getParent().getParent();
         Assert.assertEquals(funcSymbol, expectedToBeFunctionScope);
 
-        Symbol elseStmtDeclSymbol = symbolTable.getSymbolsForAstNode(elseStmtDeclNode.getIdentifier()).get(0);
+        Symbol elseStmtDeclSymbol = symbolTable.getSymbolsForAstNode(elseStmtDeclNode).get(0);
         Assert.assertNotEquals(Symbol.NULL, ifStmtDeclSymbol);
         // test correct scope relation
         declScope = elseStmtDeclSymbol.getScope();
@@ -1024,7 +1024,7 @@ public class TestSemanticAnalyzer {
             (FunctionSymbol) symbolTable.globalScope.resolve("test");
         FuncDefNode funcDefNode = (FuncDefNode) symbolTable.getCreationAstNode(funcSymbol);
         VarDeclNode varDeclNode = (VarDeclNode) funcDefNode.getStmtBlock().getChild(0).getChild(0);
-        Symbol myListSymbol = symbolTable.getSymbolsForAstNode(varDeclNode.getIdentifier()).get(0);
+        Symbol myListSymbol = symbolTable.getSymbolsForAstNode(varDeclNode).get(0);
 
         // get iterableIdNode and check, that it references the variable symbol
         ForLoopStmtNode loopNode = (ForLoopStmtNode) funcDefNode.getStmtBlock().getChild(0).getChild(1);
@@ -1071,7 +1071,7 @@ public class TestSemanticAnalyzer {
             (FunctionSymbol) symbolTable.globalScope.resolve("test");
         FuncDefNode funcDefNode = (FuncDefNode) symbolTable.getCreationAstNode(funcSymbol);
         VarDeclNode varDeclNode = (VarDeclNode) funcDefNode.getStmtBlock().getChild(0).getChild(0);
-        Symbol myListSymbol = symbolTable.getSymbolsForAstNode(varDeclNode.getIdentifier()).get(0);
+        Symbol myListSymbol = symbolTable.getSymbolsForAstNode(varDeclNode).get(0);
 
         // get iterableIdNode and check, that it references the variable symbol
         CountingLoopStmtNode loopNode = (CountingLoopStmtNode) funcDefNode.getStmtBlock().getChild(0).getChild(1);
@@ -1128,7 +1128,7 @@ public class TestSemanticAnalyzer {
             (FunctionSymbol) symbolTable.globalScope.resolve("test");
         FuncDefNode funcDefNode = (FuncDefNode) symbolTable.getCreationAstNode(funcSymbol);
         VarDeclNode varDeclNode = (VarDeclNode) funcDefNode.getStmtBlock().getChild(0).getChild(0);
-        Symbol myListSymbol = symbolTable.getSymbolsForAstNode(varDeclNode.getIdentifier()).get(0);
+        Symbol myListSymbol = symbolTable.getSymbolsForAstNode(varDeclNode).get(0);
 
         // get iterableIdNode and check, that it references the variable symbol
         WhileLoopStmtNode loopNode = (WhileLoopStmtNode) funcDefNode.getStmtBlock().getChild(0).getChild(1);


### PR DESCRIPTION
Fixes #795 

Fügt Schleifen-Statements zur DSL hinzu (`for`-Schleife, die über einen iterierbaren `Value` iteriert, `counting for`-Schleife, die zusätzlich einen Counter für die Iterationen hat und eine `while`-Schleife). Erweitert die Grammatik entsprechend. Implementiert die semantische Analyse von Schleifen-Statements. Fügt `LoopBottomMark`-AST-Knoten hinzu, in dessen visit-Implementierung durch den `DSLInterpreter` die Schleifenbedingung überprüft wird und der interne Zustand der Schleife geupdatet wird. 
Refactored die Erzeugung von Variablensymbolen, da das in der semantischen Analyse für `for`- und `counting for`-Schleifen und für Variablendeklarations-Statements verwendet wird.

~TODO:~
- [x] Variablenerzeugung refactoren (siehe TODO in DSLInterpreter dazu)
- [x] `iterable` in grammatik von `ID` auf `expr` ändern
- [x] Javadoc