### PR TITLE
[DUNGEON] add Answerpicking-Functions

### DIFF
--- a/dungeon/src/reporting/AnswerPickingFunctions.java
+++ b/dungeon/src/reporting/AnswerPickingFunctions.java
@@ -1,22 +1,70 @@
 package reporting;
 
+import contrib.components.InventoryComponent;
+import contrib.item.Item;
+
+import core.Entity;
+import core.utils.components.MissingComponentException;
+
 import task.Element;
+import task.QuestItem;
 import task.Task;
 import task.TaskContent;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 
+/**
+ * Contains different Functions to create a Callback-Function for {@link
+ * Task#answerPickingFunction(Function)}.
+ *
+ * <p>The Functions will find the given answers to a task in the game.
+ *
+ * <p>Note that it is important to choose the correct function. The correct function varies based on
+ * the Task-Type and the game scenario.
+ */
 public class AnswerPickingFunctions {
 
+    /**
+     * This Callback will check the first container of the given {@link Task} and will return a
+     * Collection that contains each TaskContent in the container.
+     *
+     * <p>This function assumes that the container is an Entity that has an {@link
+     * InventoryComponent}
+     *
+     * <p>This function assumes that the given Answers are {@link QuestItem}s
+     *
+     * <p>This function ignores other Items in the container.
+     *
+     * <p>Use this function as a callback for {@link task.quizquestion.SingleChoice} and {@link
+     * task.quizquestion.MultipleChoice} Tasks.
+     *
+     * @return Function that can be used as a callback for {@link
+     *     Task#answerPickingFunction(Function)}
+     */
     public static Function<Task, Set<TaskContent>> singleChestPicker() {
-        // todo
         return new Function<Task, Set<TaskContent>>() {
             @Override
             public Set<TaskContent> apply(Task task) {
-                return null;
+                TaskContent containerContent =
+                        (TaskContent) task.containerStream().findFirst().orElseThrow();
+                Entity container = task.find(containerContent);
+                InventoryComponent ic =
+                        container
+                                .fetch(InventoryComponent.class)
+                                .orElseThrow(
+                                        () ->
+                                                MissingComponentException.build(
+                                                        container, InventoryComponent.class));
+                Item[] answerItems = ic.items(QuestItem.class);
+                Set<TaskContent> res = new HashSet<>();
+                for (Item i : answerItems) {
+                    res.add(((QuestItem) i).taskContentComponent().content());
+                }
+                return res;
             }
         };
     }

--- a/dungeon/src/reporting/AnswerPickingFunctions.java
+++ b/dungeon/src/reporting/AnswerPickingFunctions.java
@@ -49,7 +49,12 @@ public class AnswerPickingFunctions {
         return task -> {
             TaskContent containerContent =
                     (TaskContent) task.containerStream().findFirst().orElseThrow();
-            Entity container = task.find(containerContent);
+            Entity container =
+                    task.find((TaskContent) containerContent)
+                            .orElseThrow(
+                                    () ->
+                                            new NullPointerException(
+                                                    "The container does not exist in the game."));
             InventoryComponent ic =
                     container
                             .fetch(InventoryComponent.class)
@@ -57,7 +62,7 @@ public class AnswerPickingFunctions {
                                     () ->
                                             MissingComponentException.build(
                                                     container, InventoryComponent.class));
-            Item[] answerItems = ic.items(QuestItem.class);
+            Set<Item> answerItems = ic.items(QuestItem.class);
             Set<TaskContent> res = new HashSet<>();
             for (Item i : answerItems) {
                 res.add(((QuestItem) i).taskContentComponent().content());
@@ -91,7 +96,12 @@ public class AnswerPickingFunctions {
             task.containerStream()
                     .forEach(
                             containerContent -> {
-                                Entity container = task.find((TaskContent) containerContent);
+                                Entity container =
+                                        task.find((TaskContent) containerContent)
+                                                .orElseThrow(
+                                                        () ->
+                                                                new NullPointerException(
+                                                                        "The container does not exist in the game."));
                                 InventoryComponent ic =
                                         container
                                                 .fetch(InventoryComponent.class)
@@ -100,7 +110,7 @@ public class AnswerPickingFunctions {
                                                                 MissingComponentException.build(
                                                                         container,
                                                                         InventoryComponent.class));
-                                Item[] answerItems = ic.items(QuestItem.class);
+                                Set<Item> answerItems = ic.items(QuestItem.class);
                                 Set<TaskContent> res = new HashSet<>();
                                 for (Item i : answerItems) {
                                     res.add(((QuestItem) i).taskContentComponent().content());

--- a/dungeon/src/reporting/AnswerPickingFunctions.java
+++ b/dungeon/src/reporting/AnswerPickingFunctions.java
@@ -1,0 +1,24 @@
+package reporting;
+
+import task.Element;
+import task.Task;
+import task.TaskContent;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+public class AnswerPickingFunctions {
+
+    public static Set<TaskContent> singleChestPicker(Task task) {
+        // todo
+        return new HashSet<>();
+    }
+
+    public static Set<TaskContent> multipleChestPicker(Task task) {
+        // todo
+        Map<Element, Set<Element>> givenSolution = new HashMap<>();
+        return Set.of(new Element<>(task, givenSolution));
+    }
+}

--- a/dungeon/src/reporting/AnswerPickingFunctions.java
+++ b/dungeon/src/reporting/AnswerPickingFunctions.java
@@ -5,20 +5,30 @@ import task.Task;
 import task.TaskContent;
 
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 
 public class AnswerPickingFunctions {
 
-    public static Set<TaskContent> singleChestPicker(Task task) {
+    public static Function<Task, Set<TaskContent>> singleChestPicker() {
         // todo
-        return new HashSet<>();
+        return new Function<Task, Set<TaskContent>>() {
+            @Override
+            public Set<TaskContent> apply(Task task) {
+                return null;
+            }
+        };
     }
 
-    public static Set<TaskContent> multipleChestPicker(Task task) {
-        // todo
-        Map<Element, Set<Element>> givenSolution = new HashMap<>();
-        return Set.of(new Element<>(task, givenSolution));
+    public static Function<Task, Set<TaskContent>> multipleChestPicker() {
+        return new Function<Task, Set<TaskContent>>() {
+            @Override
+            public Set<TaskContent> apply(Task task) {
+                Map<Element, Set<Element>> givenSolution = new HashMap<>();
+                // todo
+                return Set.of(new Element<>(task, givenSolution));
+            }
+        };
     }
 }

--- a/dungeon/src/task/Task.java
+++ b/dungeon/src/task/Task.java
@@ -11,6 +11,7 @@ import task.components.TaskComponent;
 
 import java.util.*;
 import java.util.function.BiFunction;
+import java.util.function.Function;
 import java.util.logging.Logger;
 import java.util.stream.Stream;
 
@@ -54,6 +55,7 @@ public abstract class Task {
 
     protected List<TaskContent> content;
     protected BiFunction<Task, Set<TaskContent>, Float> scoringFunction;
+    protected Function<Task, Set<TaskContent>> answerPickingFunction;
 
     protected float points;
     private float pointsToSolve;
@@ -205,6 +207,24 @@ public abstract class Task {
     }
 
     /**
+     * Set the function to pick the given answers out of the game.
+     *
+     * @param answerPickingFunction the answer picking function to set.
+     */
+    public void answerPickingFunction(Function<Task, Set<TaskContent>> answerPickingFunction) {
+        this.scoringFunction = scoringFunction;
+    }
+
+    /**
+     * Callback function to pick the given answers out of the game.
+     *
+     * @return the callback function
+     */
+    public Function<Task, Set<TaskContent>> answerPickingFunction() {
+        return answerPickingFunction;
+    }
+
+    /**
      * Set the scoring function for this Task.
      *
      * @param scoringFunction the scoring function to set.
@@ -213,6 +233,24 @@ public abstract class Task {
         this.scoringFunction = scoringFunction;
     }
 
+    /**
+     * Execute the scoring function.
+     *
+     * <p>This will mark the task as done.
+     *
+     * <p>This will change the task state.
+     *
+     * <p>This will inform the petri net about the task state changes.
+     *
+     * <p>This will log the result.
+     *
+     * <p>This will give the player a reward, if the task was solved correctly.
+     *
+     * @return reached points.
+     */
+    public float gradeTask() {
+        return gradeTask(answerPickingFunction.apply(this));
+    }
     /**
      * Execute the scoring function.
      *

--- a/dungeon/src/task/Task.java
+++ b/dungeon/src/task/Task.java
@@ -351,6 +351,12 @@ public abstract class Task {
         this.pointsToSolve = pointsToSolve;
     }
 
+    /**
+     * Find the entity that stores the given content.
+     *
+     * @param taskContent Content we are looking for.
+     * @return the entity that stores the given content, empty if no entity stores the content.
+     */
     public Optional<Entity> find(TaskContent taskContent) {
         return Game.allEntities()
                 .filter(e -> e.isPresent(TaskContentComponent.class))

--- a/dungeon/src/task/Task.java
+++ b/dungeon/src/task/Task.java
@@ -1,6 +1,7 @@
 package task;
 
 import core.Entity;
+import core.Game;
 import core.utils.logging.CustomLogLevel;
 
 import petriNet.Place;
@@ -8,6 +9,7 @@ import petriNet.Place;
 import semanticanalysis.types.DSLType;
 
 import task.components.TaskComponent;
+import task.components.TaskContentComponent;
 
 import java.util.*;
 import java.util.function.BiFunction;
@@ -347,6 +349,18 @@ public abstract class Task {
     public void points(float points, float pointsToSolve) {
         this.points = points;
         this.pointsToSolve = pointsToSolve;
+    }
+
+    public Optional<Entity> find(TaskContent taskContent) {
+        return Game.allEntities()
+                .filter(e -> e.isPresent(TaskContentComponent.class))
+                .filter(
+                        e -> {
+                            TaskContentComponent taskContentComponent =
+                                    e.fetch(TaskContentComponent.class).get();
+                            return taskContentComponent.content().equals(taskContent);
+                        })
+                .findFirst();
     }
 
     public int id() {

--- a/dungeon/src/task/Task.java
+++ b/dungeon/src/task/Task.java
@@ -1,6 +1,7 @@
 package task;
 
 import core.Entity;
+import core.Game;
 import core.utils.logging.CustomLogLevel;
 
 import petriNet.Place;
@@ -348,7 +349,6 @@ public abstract class Task {
         this.points = points;
         this.pointsToSolve = pointsToSolve;
     }
-
     public int id() {
         return id;
     }

--- a/dungeon/src/task/Task.java
+++ b/dungeon/src/task/Task.java
@@ -1,7 +1,6 @@
 package task;
 
 import core.Entity;
-import core.Game;
 import core.utils.logging.CustomLogLevel;
 
 import petriNet.Place;
@@ -349,6 +348,7 @@ public abstract class Task {
         this.points = points;
         this.pointsToSolve = pointsToSolve;
     }
+
     public int id() {
         return id;
     }

--- a/dungeon/src/task/Task.java
+++ b/dungeon/src/task/Task.java
@@ -37,27 +37,23 @@ import java.util.stream.Stream;
 public abstract class Task {
 
     private static final Logger LOGGER = Logger.getLogger(Task.class.getSimpleName());
-
-    private static int _id = 0;
     private static final Set<Task> ALL_TASKS = new HashSet<>();
     private static final String DEFAULT_TASK_TEXT = "No task description provided";
     private static final TaskState DEFAULT_TASK_STATE = TaskState.INACTIVE;
-
     private static final float DEFAULT_POINTS = 1f;
     private static final float DEFAULT_POINTS_TO_SOLVE = DEFAULT_POINTS;
+    private static int _id = 0;
     private final int id;
-    private TaskState state;
-    private String taskText;
     private final Set<Place> observer = new HashSet<>();
-    private Entity managementEntity;
-
-    private Set<Set<Entity>> entitySets = new HashSet<>();
-
     protected List<TaskContent> content;
     protected BiFunction<Task, Set<TaskContent>, Float> scoringFunction;
     protected Function<Task, Set<TaskContent>> answerPickingFunction;
-
     protected float points;
+    protected Set<TaskContent> container;
+    private TaskState state;
+    private String taskText;
+    private Entity managementEntity;
+    private Set<Set<Entity>> entitySets = new HashSet<>();
     private float pointsToSolve;
 
     /**
@@ -72,7 +68,23 @@ public abstract class Task {
         content = new LinkedList<>();
         points = DEFAULT_POINTS;
         pointsToSolve = DEFAULT_POINTS_TO_SOLVE;
+        container = new HashSet<>();
     }
+
+    /**
+     * Get a stream of all Task-Objects that exist.
+     *
+     * @return Stream of all Task-Objects that ever exist.
+     */
+    public static Stream<Task> allTasks() {
+        return new HashSet<>(ALL_TASKS).stream();
+    }
+
+    /** Clear the {@link #ALL_TASKS} Set. */
+    public static void cleanupAllTask() {
+        ALL_TASKS.clear();
+    }
+
     /**
      * Register a {@link Place} with this task.
      *
@@ -83,6 +95,26 @@ public abstract class Task {
      */
     public void registerPlace(Place place) {
         observer.add(place);
+    }
+
+    /**
+     * Add a {@link TaskContent} as container to this task.
+     *
+     * <p>A container (like a chest) will be used to find the given answers of a player in the game.
+     *
+     * @param container container to add.
+     */
+    public void addContainer(TaskContent container) {
+        this.container.add(container);
+    }
+
+    /**
+     * Get the Container of this task.
+     *
+     * @return Container of this task as stream.
+     */
+    public Stream containerStream() {
+        return new HashSet<>(container).stream();
     }
 
     /**
@@ -251,6 +283,7 @@ public abstract class Task {
     public float gradeTask() {
         return gradeTask(answerPickingFunction.apply(this));
     }
+
     /**
      * Execute the scoring function.
      *
@@ -304,6 +337,7 @@ public abstract class Task {
     public float points() {
         return points;
     }
+
     /**
      * Set the amount of points that this task is worth.
      *
@@ -313,20 +347,6 @@ public abstract class Task {
     public void points(float points, float pointsToSolve) {
         this.points = points;
         this.pointsToSolve = pointsToSolve;
-    }
-
-    /**
-     * Get a stream of all Task-Objects that exist.
-     *
-     * @return Stream of all Task-Objects that ever exist.
-     */
-    public static Stream<Task> allTasks() {
-        return new HashSet<>(ALL_TASKS).stream();
-    }
-
-    /** Clear the {@link #ALL_TASKS} Set. */
-    public static void cleanupAllTask() {
-        ALL_TASKS.clear();
     }
 
     public int id() {

--- a/dungeon/test/reporting/AnswerPickingFunctionsTest.java
+++ b/dungeon/test/reporting/AnswerPickingFunctionsTest.java
@@ -3,12 +3,14 @@ package reporting;
 import static org.junit.Assert.assertEquals;
 
 import contrib.components.InventoryComponent;
+import contrib.item.Item;
 
 import core.Entity;
 import core.Game;
 
 import org.junit.After;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import task.*;
 import task.components.TaskContentComponent;
@@ -26,7 +28,8 @@ public class AnswerPickingFunctionsTest {
     }
 
     @Test
-    public void singlechestpicker() {
+    public void singlechestpicker_twoQuestItems() {
+        // setup question
         SingleChoice sc = new SingleChoice("Dummy");
         Quiz.Content answerA = new Quiz.Content("A");
         Quiz.Content answerB = new Quiz.Content("B");
@@ -36,14 +39,150 @@ public class AnswerPickingFunctionsTest {
         sc.scoringFunction(GradingFunctions.singleChoiceGrading());
         sc.answerPickingFunction(AnswerPickingFunctions.singleChestPicker());
 
-        // Chest
+        // setup Chest
         Entity chest = new Entity("Chest");
-        chest.addComponent(new InventoryComponent(3));
+        InventoryComponent ic = new InventoryComponent(3);
+        chest.addComponent(ic);
         TaskContent containerTaskContent = new Element<>(sc, "Chest");
         sc.addContainer(containerTaskContent);
         chest.addComponent(new TaskContentComponent(containerTaskContent));
+        Game.add(chest);
 
-        // QuestItems
+        // setup quest items
+        TaskContentComponent answerAComponent = new TaskContentComponent(answerA);
+        TaskContentComponent answerBComponent = new TaskContentComponent(answerB);
+        QuestItem answerAItem = new QuestItem(null, null, null, answerAComponent);
+        QuestItem answerBItem = new QuestItem(null, null, null, answerBComponent);
+
+        Function<Task, Set<TaskContent>> callback = AnswerPickingFunctions.singleChestPicker();
+        // add answer to chest
+        ic.add(answerAItem);
+        ic.add(answerBItem);
+        assertEquals(2, callback.apply(sc).size());
+    }
+
+    @Test
+    public void singlechestpicker_twoQuestItemsOneItem() {
+        // setup question
+        SingleChoice sc = new SingleChoice("Dummy");
+        Quiz.Content answerA = new Quiz.Content("A");
+        Quiz.Content answerB = new Quiz.Content("B");
+        sc.addAnswer(answerA);
+        sc.addAnswer(answerB);
+        sc.addCorrectAnswerIndex(1);
+        sc.scoringFunction(GradingFunctions.singleChoiceGrading());
+        sc.answerPickingFunction(AnswerPickingFunctions.singleChestPicker());
+
+        // setup Chest
+        Entity chest = new Entity("Chest");
+        InventoryComponent ic = new InventoryComponent(3);
+        chest.addComponent(ic);
+        TaskContent containerTaskContent = new Element<>(sc, "Chest");
+        sc.addContainer(containerTaskContent);
+        chest.addComponent(new TaskContentComponent(containerTaskContent));
+        Game.add(chest);
+
+        // setup quest items
+        TaskContentComponent answerAComponent = new TaskContentComponent(answerA);
+        TaskContentComponent answerBComponent = new TaskContentComponent(answerB);
+        QuestItem answerAItem = new QuestItem(null, null, null, answerAComponent);
+        QuestItem answerBItem = new QuestItem(null, null, null, answerBComponent);
+
+        Function<Task, Set<TaskContent>> callback = AnswerPickingFunctions.singleChestPicker();
+        // add answer to chest
+        ic.add(answerAItem);
+        ic.add(answerBItem);
+        ic.add(Mockito.mock(Item.class));
+        assertEquals(2, callback.apply(sc).size());
+    }
+
+    @Test
+    public void singlechestpicker_zeroQuestItems() {
+        // setup question
+        SingleChoice sc = new SingleChoice("Dummy");
+        Quiz.Content answerA = new Quiz.Content("A");
+        Quiz.Content answerB = new Quiz.Content("B");
+        sc.addAnswer(answerA);
+        sc.addAnswer(answerB);
+        sc.addCorrectAnswerIndex(1);
+        sc.scoringFunction(GradingFunctions.singleChoiceGrading());
+        sc.answerPickingFunction(AnswerPickingFunctions.singleChestPicker());
+
+        // setup Chest
+        Entity chest = new Entity("Chest");
+        InventoryComponent ic = new InventoryComponent(3);
+        chest.addComponent(ic);
+        TaskContent containerTaskContent = new Element<>(sc, "Chest");
+        sc.addContainer(containerTaskContent);
+        chest.addComponent(new TaskContentComponent(containerTaskContent));
+        Game.add(chest);
+
+        // setup quest items
+        TaskContentComponent answerAComponent = new TaskContentComponent(answerA);
+        TaskContentComponent answerBComponent = new TaskContentComponent(answerB);
+        QuestItem answerAItem = new QuestItem(null, null, null, answerAComponent);
+        QuestItem answerBItem = new QuestItem(null, null, null, answerBComponent);
+
+        Function<Task, Set<TaskContent>> callback = AnswerPickingFunctions.singleChestPicker();
+
+        assertEquals(0, callback.apply(sc).size());
+    }
+
+    @Test
+    public void singlechestpicker_zeroQuestItemsTwoItems() {
+        // setup question
+        SingleChoice sc = new SingleChoice("Dummy");
+        Quiz.Content answerA = new Quiz.Content("A");
+        Quiz.Content answerB = new Quiz.Content("B");
+        sc.addAnswer(answerA);
+        sc.addAnswer(answerB);
+        sc.addCorrectAnswerIndex(1);
+        sc.scoringFunction(GradingFunctions.singleChoiceGrading());
+        sc.answerPickingFunction(AnswerPickingFunctions.singleChestPicker());
+
+        // setup Chest
+        Entity chest = new Entity("Chest");
+        InventoryComponent ic = new InventoryComponent(3);
+        chest.addComponent(ic);
+        TaskContent containerTaskContent = new Element<>(sc, "Chest");
+        sc.addContainer(containerTaskContent);
+        chest.addComponent(new TaskContentComponent(containerTaskContent));
+        Game.add(chest);
+
+        // setup quest items
+        TaskContentComponent answerAComponent = new TaskContentComponent(answerA);
+        TaskContentComponent answerBComponent = new TaskContentComponent(answerB);
+        QuestItem answerAItem = new QuestItem(null, null, null, answerAComponent);
+        QuestItem answerBItem = new QuestItem(null, null, null, answerBComponent);
+
+        Function<Task, Set<TaskContent>> callback = AnswerPickingFunctions.singleChestPicker();
+        ic.add(Mockito.mock(Item.class));
+        ic.add(Mockito.mock(Item.class));
+        assertEquals(0, callback.apply(sc).size());
+    }
+
+    @Test
+    public void singlechestpicker_empty() {
+        // setup question
+        SingleChoice sc = new SingleChoice("Dummy");
+        Quiz.Content answerA = new Quiz.Content("A");
+        Quiz.Content answerB = new Quiz.Content("B");
+        sc.addAnswer(answerA);
+        sc.addAnswer(answerB);
+        sc.addCorrectAnswerIndex(1);
+        sc.scoringFunction(GradingFunctions.singleChoiceGrading());
+        sc.answerPickingFunction(AnswerPickingFunctions.singleChestPicker());
+
+        // setup Chest
+        Entity chest = new Entity("Chest");
+        InventoryComponent ic = new InventoryComponent(3);
+        chest.addComponent(ic);
+        TaskContent containerTaskContent = new Element<>(sc, "Chest");
+        sc.addContainer(containerTaskContent);
+        chest.addComponent(new TaskContentComponent(containerTaskContent));
+        Game.add(chest);
+
+        // setup quest items
         TaskContentComponent answerAComponent = new TaskContentComponent(answerA);
         TaskContentComponent answerBComponent = new TaskContentComponent(answerB);
         QuestItem answerAItem = new QuestItem(null, null, null, answerAComponent);

--- a/dungeon/test/reporting/AnswerPickingFunctionsTest.java
+++ b/dungeon/test/reporting/AnswerPickingFunctionsTest.java
@@ -16,6 +16,9 @@ import task.*;
 import task.components.TaskContentComponent;
 import task.quizquestion.SingleChoice;
 
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 
@@ -43,7 +46,7 @@ public class AnswerPickingFunctionsTest {
         Entity chest = new Entity("Chest");
         InventoryComponent ic = new InventoryComponent(3);
         chest.addComponent(ic);
-        TaskContent containerTaskContent = new Element<>(sc, "Chest");
+        TaskContent containerTaskContent = new Element<>(sc, chest);
         sc.addContainer(containerTaskContent);
         chest.addComponent(new TaskContentComponent(containerTaskContent));
         Game.add(chest);
@@ -77,7 +80,7 @@ public class AnswerPickingFunctionsTest {
         Entity chest = new Entity("Chest");
         InventoryComponent ic = new InventoryComponent(3);
         chest.addComponent(ic);
-        TaskContent containerTaskContent = new Element<>(sc, "Chest");
+        TaskContent containerTaskContent = new Element<>(sc, chest);
         sc.addContainer(containerTaskContent);
         chest.addComponent(new TaskContentComponent(containerTaskContent));
         Game.add(chest);
@@ -112,7 +115,7 @@ public class AnswerPickingFunctionsTest {
         Entity chest = new Entity("Chest");
         InventoryComponent ic = new InventoryComponent(3);
         chest.addComponent(ic);
-        TaskContent containerTaskContent = new Element<>(sc, "Chest");
+        TaskContent containerTaskContent = new Element<>(sc, chest);
         sc.addContainer(containerTaskContent);
         chest.addComponent(new TaskContentComponent(containerTaskContent));
         Game.add(chest);
@@ -144,7 +147,7 @@ public class AnswerPickingFunctionsTest {
         Entity chest = new Entity("Chest");
         InventoryComponent ic = new InventoryComponent(3);
         chest.addComponent(ic);
-        TaskContent containerTaskContent = new Element<>(sc, "Chest");
+        TaskContent containerTaskContent = new Element<>(sc, chest);
         sc.addContainer(containerTaskContent);
         chest.addComponent(new TaskContentComponent(containerTaskContent));
         Game.add(chest);
@@ -177,7 +180,7 @@ public class AnswerPickingFunctionsTest {
         Entity chest = new Entity("Chest");
         InventoryComponent ic = new InventoryComponent(3);
         chest.addComponent(ic);
-        TaskContent containerTaskContent = new Element<>(sc, "Chest");
+        TaskContent containerTaskContent = new Element<>(sc, chest);
         sc.addContainer(containerTaskContent);
         chest.addComponent(new TaskContentComponent(containerTaskContent));
         Game.add(chest);
@@ -190,5 +193,268 @@ public class AnswerPickingFunctionsTest {
 
         Function<Task, Set<TaskContent>> callback = AnswerPickingFunctions.singleChestPicker();
         assertEquals(0, callback.apply(sc).size());
+    }
+
+    @Test
+    public void multiplechestpicker_questItemAnswers() {
+        // setup question
+        AssignTask ag = new AssignTask();
+
+        Element answerA = new Element(ag, "A");
+        Element answerB = new Element(ag, "B");
+        Element answerC = new Element(ag, "C");
+        Element answerD = new Element(ag, "D");
+
+        HashSet<Element> containerASet = new HashSet<>();
+        Element containerA = new Element(ag, containerASet);
+        containerASet.add(answerA);
+        containerASet.add(answerB);
+        ag.addContainer(containerA);
+
+        HashSet<Element> containerBSet = new HashSet<>();
+        Element containerB = new Element(ag, containerBSet);
+        containerBSet.add(answerC);
+        containerBSet.add(answerD);
+        ag.addContainer(containerB);
+
+        Map<Element, Set<Element>> sol = new HashMap<>();
+        sol.put(containerA, (Set<Element>) containerA.content());
+        sol.put(containerB, (Set<Element>) containerB.content());
+        ag.solution(sol);
+
+        // setup Chests
+        Entity chestA = new Entity("Chest A");
+        InventoryComponent icA = new InventoryComponent(3);
+        chestA.addComponent(icA);
+        chestA.addComponent(new TaskContentComponent(containerA));
+        Game.add(chestA);
+
+        Entity chestB = new Entity("Chest B");
+        InventoryComponent icB = new InventoryComponent(3);
+        chestB.addComponent(icB);
+        chestB.addComponent(new TaskContentComponent(containerB));
+        Game.add(chestB);
+
+        // setup quest items
+        TaskContentComponent answerAComponent = new TaskContentComponent(answerA);
+        TaskContentComponent answerBComponent = new TaskContentComponent(answerB);
+        TaskContentComponent answerCComponent = new TaskContentComponent(answerC);
+        TaskContentComponent answerDComponent = new TaskContentComponent(answerD);
+        QuestItem answerAItem = new QuestItem(null, null, null, answerAComponent);
+        QuestItem answerBItem = new QuestItem(null, null, null, answerBComponent);
+        QuestItem answerCItem = new QuestItem(null, null, null, answerCComponent);
+        QuestItem answerDItem = new QuestItem(null, null, null, answerDComponent);
+
+        Function<Task, Set<TaskContent>> callback = AnswerPickingFunctions.multipleChestPicker();
+        // add answer to chest
+        icA.add(answerAItem);
+        icA.add(answerBItem);
+        icB.add(answerCItem);
+        icB.add(answerDItem);
+
+        Set<TaskContent> answer = callback.apply(ag);
+        // wrapper
+        assertEquals(1, answer.size());
+        Element wrap = (Element) answer.stream().findFirst().get();
+        Map<Element, Set<Element>> givenSol = (Map<Element, Set<Element>>) wrap.content();
+        assertEquals(givenSol, sol);
+    }
+
+    @Test
+    public void multiplechestpicker_emtpy() {
+        // setup question
+        AssignTask ag = new AssignTask();
+
+        Element answerA = new Element(ag, "A");
+        Element answerB = new Element(ag, "B");
+        Element answerC = new Element(ag, "C");
+        Element answerD = new Element(ag, "D");
+
+        HashSet<Element> containerASet = new HashSet<>();
+        Element containerA = new Element(ag, containerASet);
+        containerASet.add(answerA);
+        containerASet.add(answerB);
+        ag.addContainer(containerA);
+
+        HashSet<Element> containerBSet = new HashSet<>();
+        Element containerB = new Element(ag, containerBSet);
+        containerBSet.add(answerC);
+        containerBSet.add(answerD);
+        ag.addContainer(containerB);
+
+        Map<Element, Set<Element>> sol = new HashMap<>();
+        sol.put(containerA, (Set<Element>) containerA.content());
+        sol.put(containerB, (Set<Element>) containerB.content());
+        ag.solution(sol);
+
+        // setup Chests
+        Entity chestA = new Entity("Chest A");
+        InventoryComponent icA = new InventoryComponent(3);
+        chestA.addComponent(icA);
+        chestA.addComponent(new TaskContentComponent(containerA));
+        Game.add(chestA);
+
+        Entity chestB = new Entity("Chest B");
+        InventoryComponent icB = new InventoryComponent(3);
+        chestB.addComponent(icB);
+        chestB.addComponent(new TaskContentComponent(containerB));
+        Game.add(chestB);
+
+        // setup quest items
+        TaskContentComponent answerAComponent = new TaskContentComponent(answerA);
+        TaskContentComponent answerBComponent = new TaskContentComponent(answerB);
+        TaskContentComponent answerCComponent = new TaskContentComponent(answerC);
+        TaskContentComponent answerDComponent = new TaskContentComponent(answerD);
+        QuestItem answerAItem = new QuestItem(null, null, null, answerAComponent);
+        QuestItem answerBItem = new QuestItem(null, null, null, answerBComponent);
+        QuestItem answerCItem = new QuestItem(null, null, null, answerCComponent);
+        QuestItem answerDItem = new QuestItem(null, null, null, answerDComponent);
+
+        Function<Task, Set<TaskContent>> callback = AnswerPickingFunctions.multipleChestPicker();
+
+        Set<TaskContent> answer = callback.apply(ag);
+        // wrapper
+        assertEquals(1, answer.size());
+        Element wrap = (Element) answer.stream().findFirst().get();
+        Map<Element, Set<Element>> givenSol = (Map<Element, Set<Element>>) wrap.content();
+        Map<Element, Set<Element>> expectedSol = new HashMap<>();
+        expectedSol.put(containerA, new HashSet<>());
+        expectedSol.put(containerB, new HashSet<>());
+        assertEquals(expectedSol, givenSol);
+    }
+
+    @Test
+    public void multiplechestpicker_normalItems() {
+        // setup question
+        AssignTask ag = new AssignTask();
+
+        Element answerA = new Element(ag, "A");
+        Element answerB = new Element(ag, "B");
+        Element answerC = new Element(ag, "C");
+        Element answerD = new Element(ag, "D");
+
+        HashSet<Element> containerASet = new HashSet<>();
+        Element containerA = new Element(ag, containerASet);
+        containerASet.add(answerA);
+        containerASet.add(answerB);
+        ag.addContainer(containerA);
+
+        HashSet<Element> containerBSet = new HashSet<>();
+        Element containerB = new Element(ag, containerBSet);
+        containerBSet.add(answerC);
+        containerBSet.add(answerD);
+        ag.addContainer(containerB);
+
+        Map<Element, Set<Element>> sol = new HashMap<>();
+        sol.put(containerA, (Set<Element>) containerA.content());
+        sol.put(containerB, (Set<Element>) containerB.content());
+        ag.solution(sol);
+
+        // setup Chests
+        Entity chestA = new Entity("Chest A");
+        InventoryComponent icA = new InventoryComponent(3);
+        chestA.addComponent(icA);
+        chestA.addComponent(new TaskContentComponent(containerA));
+        Game.add(chestA);
+
+        Entity chestB = new Entity("Chest B");
+        InventoryComponent icB = new InventoryComponent(3);
+        chestB.addComponent(icB);
+        chestB.addComponent(new TaskContentComponent(containerB));
+        Game.add(chestB);
+
+        // setup quest items
+        TaskContentComponent answerAComponent = new TaskContentComponent(answerA);
+        TaskContentComponent answerBComponent = new TaskContentComponent(answerB);
+        TaskContentComponent answerCComponent = new TaskContentComponent(answerC);
+        TaskContentComponent answerDComponent = new TaskContentComponent(answerD);
+        QuestItem answerAItem = new QuestItem(null, null, null, answerAComponent);
+        QuestItem answerBItem = new QuestItem(null, null, null, answerBComponent);
+        QuestItem answerCItem = new QuestItem(null, null, null, answerCComponent);
+        QuestItem answerDItem = new QuestItem(null, null, null, answerDComponent);
+
+        Function<Task, Set<TaskContent>> callback = AnswerPickingFunctions.multipleChestPicker();
+
+        // add items
+        icA.add(Mockito.mock(Item.class));
+        icA.add(Mockito.mock(Item.class));
+        icB.add(Mockito.mock(Item.class));
+        icB.add(Mockito.mock(Item.class));
+        Set<TaskContent> answer = callback.apply(ag);
+        // wrapper
+        assertEquals(1, answer.size());
+        Element wrap = (Element) answer.stream().findFirst().get();
+        Map<Element, Set<Element>> givenSol = (Map<Element, Set<Element>>) wrap.content();
+        Map<Element, Set<Element>> expectedSol = new HashMap<>();
+        expectedSol.put(containerA, new HashSet<>());
+        expectedSol.put(containerB, new HashSet<>());
+        assertEquals(expectedSol, givenSol);
+    }
+
+    @Test
+    public void multiplechestpicker_QuestItemAndNormalItemMix() {
+        // setup question
+        AssignTask ag = new AssignTask();
+
+        Element answerA = new Element(ag, "A");
+        Element answerB = new Element(ag, "B");
+        Element answerC = new Element(ag, "C");
+        Element answerD = new Element(ag, "D");
+
+        HashSet<Element> containerASet = new HashSet<>();
+        Element containerA = new Element(ag, containerASet);
+        containerASet.add(answerA);
+        containerASet.add(answerB);
+        ag.addContainer(containerA);
+
+        HashSet<Element> containerBSet = new HashSet<>();
+        Element containerB = new Element(ag, containerBSet);
+        containerBSet.add(answerC);
+        containerBSet.add(answerD);
+        ag.addContainer(containerB);
+
+        Map<Element, Set<Element>> sol = new HashMap<>();
+        sol.put(containerA, (Set<Element>) containerA.content());
+        sol.put(containerB, (Set<Element>) containerB.content());
+        ag.solution(sol);
+
+        // setup Chests
+        Entity chestA = new Entity("Chest A");
+        InventoryComponent icA = new InventoryComponent(3);
+        chestA.addComponent(icA);
+        chestA.addComponent(new TaskContentComponent(containerA));
+        Game.add(chestA);
+
+        Entity chestB = new Entity("Chest B");
+        InventoryComponent icB = new InventoryComponent(3);
+        chestB.addComponent(icB);
+        chestB.addComponent(new TaskContentComponent(containerB));
+        Game.add(chestB);
+
+        // setup quest items
+        TaskContentComponent answerAComponent = new TaskContentComponent(answerA);
+        TaskContentComponent answerBComponent = new TaskContentComponent(answerB);
+        TaskContentComponent answerCComponent = new TaskContentComponent(answerC);
+        TaskContentComponent answerDComponent = new TaskContentComponent(answerD);
+        QuestItem answerAItem = new QuestItem(null, null, null, answerAComponent);
+        QuestItem answerBItem = new QuestItem(null, null, null, answerBComponent);
+        QuestItem answerCItem = new QuestItem(null, null, null, answerCComponent);
+        QuestItem answerDItem = new QuestItem(null, null, null, answerDComponent);
+
+        Function<Task, Set<TaskContent>> callback = AnswerPickingFunctions.multipleChestPicker();
+        // add answer to chest
+        icA.add(answerAItem);
+        icA.add(answerBItem);
+        icA.add(Mockito.mock(Item.class));
+        icB.add(answerCItem);
+        icB.add(answerDItem);
+        icB.add(Mockito.mock(Item.class));
+        Set<TaskContent> answer = callback.apply(ag);
+        // wrapper
+        assertEquals(1, answer.size());
+        Element wrap = (Element) answer.stream().findFirst().get();
+        Map<Element, Set<Element>> givenSol = (Map<Element, Set<Element>>) wrap.content();
+        Map<Element, Set<Element>> expectedSol = new HashMap<>();
+        assertEquals(sol, givenSol);
     }
 }

--- a/dungeon/test/reporting/AnswerPickingFunctionsTest.java
+++ b/dungeon/test/reporting/AnswerPickingFunctionsTest.java
@@ -1,11 +1,15 @@
 package reporting;
 
+import static org.junit.Assert.assertEquals;
+
 import contrib.components.InventoryComponent;
-import contrib.entities.EntityFactory;
+
 import core.Entity;
 import core.Game;
+
 import org.junit.After;
 import org.junit.Test;
+
 import task.*;
 import task.components.TaskContentComponent;
 import task.quizquestion.SingleChoice;
@@ -13,10 +17,7 @@ import task.quizquestion.SingleChoice;
 import java.util.Set;
 import java.util.function.Function;
 
-import static org.junit.Assert.assertEquals;
-
 public class AnswerPickingFunctionsTest {
-
 
     @After
     public void cleanup() {
@@ -24,33 +25,31 @@ public class AnswerPickingFunctionsTest {
         Game.removeAllEntities();
     }
 
-
     @Test
     public void singlechestpicker() {
         SingleChoice sc = new SingleChoice("Dummy");
-        Quiz.Content answerA= new Quiz.Content("A");
-        Quiz.Content answerB= new Quiz.Content("B");
+        Quiz.Content answerA = new Quiz.Content("A");
+        Quiz.Content answerB = new Quiz.Content("B");
         sc.addAnswer(answerA);
         sc.addAnswer(answerB);
         sc.addCorrectAnswerIndex(1);
         sc.scoringFunction(GradingFunctions.singleChoiceGrading());
         sc.answerPickingFunction(AnswerPickingFunctions.singleChestPicker());
 
-
-        //Chest
+        // Chest
         Entity chest = new Entity("Chest");
         chest.addComponent(new InventoryComponent(3));
-        TaskContent containerTaskContent= new Element<>(sc,"Chest");
+        TaskContent containerTaskContent = new Element<>(sc, "Chest");
         sc.addContainer(containerTaskContent);
         chest.addComponent(new TaskContentComponent(containerTaskContent));
 
-        //QuestItems
-        TaskContentComponent answerAComponent=new TaskContentComponent(answerA);
-        TaskContentComponent answerBComponent=new TaskContentComponent(answerB);
-        QuestItem answerAItem= new QuestItem(null,null,null,answerAComponent);
-        QuestItem answerBItem= new QuestItem(null,null,null,answerBComponent);
+        // QuestItems
+        TaskContentComponent answerAComponent = new TaskContentComponent(answerA);
+        TaskContentComponent answerBComponent = new TaskContentComponent(answerB);
+        QuestItem answerAItem = new QuestItem(null, null, null, answerAComponent);
+        QuestItem answerBItem = new QuestItem(null, null, null, answerBComponent);
 
-        Function<Task, Set<TaskContent>> callback=AnswerPickingFunctions.singleChestPicker();
-        assertEquals(0,callback.apply(sc).size());
+        Function<Task, Set<TaskContent>> callback = AnswerPickingFunctions.singleChestPicker();
+        assertEquals(0, callback.apply(sc).size());
     }
 }

--- a/dungeon/test/reporting/AnswerPickingFunctionsTest.java
+++ b/dungeon/test/reporting/AnswerPickingFunctionsTest.java
@@ -1,0 +1,56 @@
+package reporting;
+
+import contrib.components.InventoryComponent;
+import contrib.entities.EntityFactory;
+import core.Entity;
+import core.Game;
+import org.junit.After;
+import org.junit.Test;
+import task.*;
+import task.components.TaskContentComponent;
+import task.quizquestion.SingleChoice;
+
+import java.util.Set;
+import java.util.function.Function;
+
+import static org.junit.Assert.assertEquals;
+
+public class AnswerPickingFunctionsTest {
+
+
+    @After
+    public void cleanup() {
+        Task.cleanupAllTask();
+        Game.removeAllEntities();
+    }
+
+
+    @Test
+    public void singlechestpicker() {
+        SingleChoice sc = new SingleChoice("Dummy");
+        Quiz.Content answerA= new Quiz.Content("A");
+        Quiz.Content answerB= new Quiz.Content("B");
+        sc.addAnswer(answerA);
+        sc.addAnswer(answerB);
+        sc.addCorrectAnswerIndex(1);
+        sc.scoringFunction(GradingFunctions.singleChoiceGrading());
+        sc.answerPickingFunction(AnswerPickingFunctions.singleChestPicker());
+
+
+        //Chest
+        Entity chest = new Entity("Chest");
+        chest.addComponent(new InventoryComponent(3));
+        TaskContent containerTaskContent= new Element<>(sc,"Chest");
+        sc.addContainer(containerTaskContent);
+        chest.addComponent(new TaskContentComponent(containerTaskContent));
+
+        //QuestItems
+        TaskContentComponent answerAComponent=new TaskContentComponent(answerA);
+        TaskContentComponent answerBComponent=new TaskContentComponent(answerB);
+        QuestItem answerAItem= new QuestItem(null,null,null,answerAComponent);
+        QuestItem answerBItem= new QuestItem(null,null,null,answerBComponent);
+
+        Function<Task, Set<TaskContent>> callback=AnswerPickingFunctions.singleChestPicker();
+        assertEquals(0,callback.apply(sc).size());
+    }
+}

--- a/game/src/contrib/components/InventoryComponent.java
+++ b/game/src/contrib/components/InventoryComponent.java
@@ -9,7 +9,9 @@ import core.utils.logging.CustomLogLevel;
 
 import java.util.Arrays;
 import java.util.Objects;
+import java.util.Set;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
 /**
  * Allows the entity to collect items in an inventory.
@@ -153,16 +155,15 @@ public final class InventoryComponent implements Component {
     }
 
     /**
-     * Get an array of items stored in this component that are an instance of the given class.
+     * Get an Set of items stored in this component that are an instance of the given class.
      *
      * @param klass Only return items that are an instance of this class.
-     * @return An array of items that are in this Inventory and are an instance of the given class.
+     * @return An Set of items that are in this Inventory and are an instance of the given class.
      */
-    public Item[] items(Class<? extends Item> klass) {
-        return (Item[])
-                Arrays.stream(this.inventory.clone())
-                        .filter(item -> klass.isInstance(item))
-                        .toArray();
+    public Set<Item> items(Class<? extends Item> klass) {
+        return Arrays.stream(this.inventory.clone())
+                .filter(item -> klass.isInstance(item))
+                .collect(Collectors.toSet());
     }
 
     /**


### PR DESCRIPTION
fixes #1117, fixes #1116

- 
- `Task` speichert jetzt ein `Set` an `TaskContent` als container (so müssen dem Task TaskContent bekannt gemacht werden, welche im Spiel durch eine Chest o.ä dargestellt werden) incl. getter/setter
- readd `Task#find`, die funktion durchsucht jetzt alle Entitäten im Spiel
- `InventoryComponent` gibt jetzt ein `Stream` und kein `Array` mehr zurück, wenn man nach Items einer spezifischen Klasse fragt (das konnte sonst class-cast-exceptions verursachen) 
- Fügt die Answer-Picker hinzu
  - `singleChestPicker` durchsucht den ersten Container im `Task` und gibt alle (von den `QuestItem`s gespeicherten) `TaskContent`s zurück. Oder in einfach: Guckt in die Kiste und gibt die Antworten zurück
  - `multipleChestPicker` durchsucht alle Container im `Task` und gibt eine Set mit einem `Element` (damit die Signatur gleich bleibt, auch hier ein Set trotz nur ein Element),  welches ein Wrapper ist (das hatte ich schon paar mal angespochen, ist tricky aber effektiv). Das `Element` speichert als `content` die Map mit den gegebenen Antworten `Map<TaskContent,Set<TaskContent>`
  - Test cases