### PR TITLE
[GAME/DUNGEON] fix bugs in Game entity management, add `Game#find(Component)`

### DIFF
--- a/dungeon/src/task/Task.java
+++ b/dungeon/src/task/Task.java
@@ -8,7 +8,6 @@ import petriNet.Place;
 import semanticanalysis.types.DSLType;
 
 import task.components.TaskComponent;
-import task.components.TaskContentComponent;
 
 import java.util.*;
 import java.util.function.BiFunction;
@@ -290,31 +289,6 @@ public abstract class Task {
     /** Clear the {@link #ALL_TASKS} Set. */
     public static void cleanupAllTask() {
         ALL_TASKS.clear();
-    }
-
-    /**
-     * Finds the entity that implements the TaskContentComponent linked to the given TaskContent.
-     *
-     * @param content The task content to find the entity for.
-     * @return The entity that implements the TaskContentComponent linked to the given content.
-     */
-    public Entity find(TaskContent content) {
-        final Entity[] found = {null};
-        entitySets.forEach(
-                set ->
-                        set.forEach(
-                                entity ->
-                                        entity.fetch(TaskContentComponent.class)
-                                                .ifPresent(
-                                                        taskContentComponent -> {
-                                                            if (taskContentComponent
-                                                                    .content()
-                                                                    .equals(content)) {
-                                                                found[0] = entity;
-                                                            }
-                                                        })));
-
-        return found[0];
     }
 
     public int id() {

--- a/game/src/core/Game.java
+++ b/game/src/core/Game.java
@@ -1,5 +1,7 @@
 package core;
 
+import static com.badlogic.gdx.graphics.GL20.GL_COLOR_BUFFER_BIT;
+
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input;
 import com.badlogic.gdx.ScreenAdapter;
@@ -10,6 +12,7 @@ import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.scenes.scene2d.Stage;
 import com.badlogic.gdx.utils.Scaling;
 import com.badlogic.gdx.utils.viewport.ScalingViewport;
+
 import core.components.PositionComponent;
 import core.configuration.Configuration;
 import core.level.Tile;
@@ -33,11 +36,7 @@ import java.util.function.Consumer;
 import java.util.logging.Logger;
 import java.util.stream.Stream;
 
-import static com.badlogic.gdx.graphics.GL20.GL_COLOR_BUFFER_BIT;
-
-/**
- * The heart of the framework. From here all strings are pulled.
- */
+/** The heart of the framework. From here all strings are pulled. */
 public final class Game extends ScreenAdapter {
 
     /**
@@ -46,9 +45,7 @@ public final class Game extends ScreenAdapter {
      * <p>The Key-Value is the Class of the system
      */
     private static final Map<Class<? extends System>, System> systems = new LinkedHashMap<>();
-    /**
-     * Maps the level with the different {@link EntitySystemMapper} for that level.
-     */
+    /** Maps the level with the different {@link EntitySystemMapper} for that level. */
     private static final Map<ILevel, Set<EntitySystemMapper>> levelStorageMap = new HashMap<>();
 
     private static final Logger LOGGER = Logger.getLogger("Game");
@@ -100,15 +97,13 @@ public final class Game extends ScreenAdapter {
      * <p> Use this, if you want to execute some logic outside of a system.</p>
      * <p> Will not replace {@link #onFrame )</p>
      */
-    private static IVoidFunction userOnFrame = () -> {
-    };
+    private static IVoidFunction userOnFrame = () -> {};
     /**
      * Part of the pre-run configuration. This function will be called after the libgdx-setup once.
      *
      * <p>Will not replace {@link #onSetup()}
      */
-    private static IVoidFunction userOnSetup = () -> {
-    };
+    private static IVoidFunction userOnSetup = () -> {};
     /**
      * Part of the pre-run configuration. This function will be called after a level was loaded.
      *
@@ -121,8 +116,7 @@ public final class Game extends ScreenAdapter {
      *
      * <p>Will not replace {@link #onLevelLoad}
      */
-    private static Consumer<Boolean> userOnLevelLoad = (b) -> {
-    };
+    private static Consumer<Boolean> userOnLevelLoad = (b) -> {};
     /**
      * Part of the pre-run configuration. If this value is true, the audio for the game will be
      * disabled.
@@ -130,12 +124,14 @@ public final class Game extends ScreenAdapter {
      * <p>Manipulating this value will only result in changes before {@link Game#run} was executed.
      */
     private static boolean DISABLE_AUDIO = false;
+
     private static Entity hero;
     private static Stage stage;
 
-    //initial entityStorage has no level
+    // initial entityStorage has no level
     static {
         levelStorageMap.put(null, activeEntityStorage);
+        activeEntityStorage.add(new EntitySystemMapper());
     }
 
     private boolean doSetup = true;
@@ -176,8 +172,7 @@ public final class Game extends ScreenAdapter {
             };
 
     // for singleton
-    private Game() {
-    }
+    private Game() {}
 
     /**
      * @return the currently loaded level
@@ -366,7 +361,7 @@ public final class Game extends ScreenAdapter {
      * some Monsters.
      *
      * @param userOnLevelLoad the function that will be executed after a new level was loaded
-     *                        <p>Will not replace {@link #onLevelLoad}
+     *     <p>Will not replace {@link #onLevelLoad}
      */
     public static void userOnLevelLoad(Consumer<Boolean> userOnLevelLoad) {
         Game.userOnLevelLoad = userOnLevelLoad;
@@ -449,7 +444,7 @@ public final class Game extends ScreenAdapter {
      * Components to be processed by the given system.
      *
      * @return a stream of all entities currently in the game that should be processed by the given
-     * system.
+     *     system.
      */
     public static Stream<Entity> entityStream(System system) {
         return entityStream(system.filterRules());
@@ -519,16 +514,14 @@ public final class Game extends ScreenAdapter {
      * cached version will be used.
      *
      * @param pathAsString the path to the config file as a string
-     * @param klass        the class where the ConfigKey fields are located
+     * @param klass the class where the ConfigKey fields are located
      * @throws IOException if the file could not be read
      */
     public static void loadConfig(String pathAsString, Class<?>... klass) throws IOException {
         Configuration.loadAndGetConfiguration(pathAsString, klass);
     }
 
-    /**
-     * Starts the dungeon and requires a {@link Game}.
-     */
+    /** Starts the dungeon and requires a {@link Game}. */
     public static void run() {
         Lwjgl3ApplicationConfiguration config = new Lwjgl3ApplicationConfiguration();
         config.setWindowSizeLimits(WINDOW_WIDTH, WINDOW_HEIGHT, 9999, 9999);
@@ -571,7 +564,7 @@ public final class Game extends ScreenAdapter {
      *
      * @param system the System to add
      * @return an optional that contains the previous existing system of the given system class, if
-     * one exists
+     *     one exists
      * @see System
      * @see Optional
      */
@@ -621,7 +614,6 @@ public final class Game extends ScreenAdapter {
      */
     public static Stream<Entity> allEntities() {
         Set<Entity> allEntities = new HashSet<>();
-        java.lang.System.out.println(levelStorageMap.values().size());
         levelStorageMap
                 .values()
                 .forEach(
@@ -631,7 +623,6 @@ public final class Game extends ScreenAdapter {
                                                 entitySystemMapper.stream()
                                                         .forEach(e -> allEntities.add(e))));
 
-        java.lang.System.out.println(allEntities.size());
         return allEntities.stream();
     }
 
@@ -752,7 +743,7 @@ public final class Game extends ScreenAdapter {
      * <p>Throws an IllegalArgumentException if start or end is non-accessible.
      *
      * @param start Start tile
-     * @param end   End tile
+     * @param end End tile
      * @return Generated path
      */
     public static GraphPath<Tile> findPath(Tile start, Tile end) {
@@ -841,9 +832,7 @@ public final class Game extends ScreenAdapter {
         userOnFrame.execute();
     }
 
-    /**
-     * Just for debugging, remove later.
-     */
+    /** Just for debugging, remove later. */
     private void debugKeys() {
         if (Gdx.input.isKeyJustPressed(Input.Keys.UP)) {
             // toggle UI "debug rendering"
@@ -890,9 +879,7 @@ public final class Game extends ScreenAdapter {
         Gdx.gl.glClear(GL_COLOR_BUFFER_BIT);
     }
 
-    /**
-     * Create the systems.
-     */
+    /** Create the systems. */
     private void createSystems() {
         add(new PositionSystem());
         add(new CameraSystem());
@@ -910,9 +897,9 @@ public final class Game extends ScreenAdapter {
     public void resize(int width, int height) {
         super.resize(width, height);
         stage().ifPresent(
-                x -> {
-                    x.getViewport().setWorldSize(width, height);
-                    x.getViewport().update(width, height, true);
-                });
+                        x -> {
+                            x.getViewport().setWorldSize(width, height);
+                            x.getViewport().update(width, height, true);
+                        });
     }
 }

--- a/game/src/core/Game.java
+++ b/game/src/core/Game.java
@@ -1,7 +1,5 @@
 package core;
 
-import static com.badlogic.gdx.graphics.GL20.GL_COLOR_BUFFER_BIT;
-
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input;
 import com.badlogic.gdx.ScreenAdapter;
@@ -12,7 +10,6 @@ import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.scenes.scene2d.Stage;
 import com.badlogic.gdx.utils.Scaling;
 import com.badlogic.gdx.utils.viewport.ScalingViewport;
-
 import core.components.PositionComponent;
 import core.configuration.Configuration;
 import core.level.Tile;
@@ -36,7 +33,11 @@ import java.util.function.Consumer;
 import java.util.logging.Logger;
 import java.util.stream.Stream;
 
-/** The heart of the framework. From here all strings are pulled. */
+import static com.badlogic.gdx.graphics.GL20.GL_COLOR_BUFFER_BIT;
+
+/**
+ * The heart of the framework. From here all strings are pulled.
+ */
 public final class Game extends ScreenAdapter {
 
     /**
@@ -45,7 +46,9 @@ public final class Game extends ScreenAdapter {
      * <p>The Key-Value is the Class of the system
      */
     private static final Map<Class<? extends System>, System> systems = new LinkedHashMap<>();
-    /** Maps the level with the different {@link EntitySystemMapper} for that level. */
+    /**
+     * Maps the level with the different {@link EntitySystemMapper} for that level.
+     */
     private static final Map<ILevel, Set<EntitySystemMapper>> levelStorageMap = new HashMap<>();
 
     private static final Logger LOGGER = Logger.getLogger("Game");
@@ -72,7 +75,6 @@ public final class Game extends ScreenAdapter {
      * <p>Manipulating this value will only result in changes before {@link Game#run} was executed.
      */
     private static int FRAME_RATE = 30;
-
     /**
      * Part of the pre-run configuration. If this value is true, the game will be started in full
      * screen mode.
@@ -80,7 +82,6 @@ public final class Game extends ScreenAdapter {
      * <p>Manipulating this value will only result in changes before {@link Game#run} was executed.
      */
     private static boolean FULL_SCREEN = false;
-
     /**
      * Part of the pre-run configuration. The title of the Game-Window.
      *
@@ -99,14 +100,15 @@ public final class Game extends ScreenAdapter {
      * <p> Use this, if you want to execute some logic outside of a system.</p>
      * <p> Will not replace {@link #onFrame )</p>
      */
-    private static IVoidFunction userOnFrame = () -> {};
-
+    private static IVoidFunction userOnFrame = () -> {
+    };
     /**
      * Part of the pre-run configuration. This function will be called after the libgdx-setup once.
      *
-     * <p>Will not replace {@link #onSetup()} )
+     * <p>Will not replace {@link #onSetup()}
      */
-    private static IVoidFunction userOnSetup = () -> {};
+    private static IVoidFunction userOnSetup = () -> {
+    };
     /**
      * Part of the pre-run configuration. This function will be called after a level was loaded.
      *
@@ -119,7 +121,8 @@ public final class Game extends ScreenAdapter {
      *
      * <p>Will not replace {@link #onLevelLoad}
      */
-    private static Consumer<Boolean> userOnLevelLoad = (b) -> {};
+    private static Consumer<Boolean> userOnLevelLoad = (b) -> {
+    };
     /**
      * Part of the pre-run configuration. If this value is true, the audio for the game will be
      * disabled.
@@ -127,10 +130,14 @@ public final class Game extends ScreenAdapter {
      * <p>Manipulating this value will only result in changes before {@link Game#run} was executed.
      */
     private static boolean DISABLE_AUDIO = false;
-
     private static Entity hero;
-
     private static Stage stage;
+
+    //initial entityStorage has no level
+    static {
+        levelStorageMap.put(null, activeEntityStorage);
+    }
+
     private boolean doSetup = true;
     private boolean uiDebugFlag = false;
     private boolean newLevelWasLoadedInThisLoop = false;
@@ -154,7 +161,7 @@ public final class Game extends ScreenAdapter {
                 removeAllSystems();
                 activeEntityStorage =
                         levelStorageMap.computeIfAbsent(currentLevel(), k -> new HashSet<>());
-                // Readd the systems so that each triggerOnAdd(entity) will be called (basically
+                // readd the systems so that each triggerOnAdd(entity) will be called (basically
                 // setup). This will also create new EntitySystemMapper if needed.
                 s.values().forEach(Game::add);
 
@@ -169,7 +176,8 @@ public final class Game extends ScreenAdapter {
             };
 
     // for singleton
-    private Game() {}
+    private Game() {
+    }
 
     /**
      * @return the currently loaded level
@@ -338,7 +346,7 @@ public final class Game extends ScreenAdapter {
     /**
      * Set the function that will be executed once after the libgdx-setup.
      *
-     * <p>Will not replace {@link #onSetup()} )
+     * <p>Will not replace {@link #onSetup()}
      *
      * @param userOnSetup function that will be once after the libgdx-setup.
      * @see IVoidFunction
@@ -358,7 +366,7 @@ public final class Game extends ScreenAdapter {
      * some Monsters.
      *
      * @param userOnLevelLoad the function that will be executed after a new level was loaded
-     *     <p>Will not replace {@link #onLevelLoad}
+     *                        <p>Will not replace {@link #onLevelLoad}
      */
     public static void userOnLevelLoad(Consumer<Boolean> userOnLevelLoad) {
         Game.userOnLevelLoad = userOnLevelLoad;
@@ -441,7 +449,7 @@ public final class Game extends ScreenAdapter {
      * Components to be processed by the given system.
      *
      * @return a stream of all entities currently in the game that should be processed by the given
-     *     system.
+     * system.
      */
     public static Stream<Entity> entityStream(System system) {
         return entityStream(system.filterRules());
@@ -511,14 +519,16 @@ public final class Game extends ScreenAdapter {
      * cached version will be used.
      *
      * @param pathAsString the path to the config file as a string
-     * @param klass the class where the ConfigKey fields are located
+     * @param klass        the class where the ConfigKey fields are located
      * @throws IOException if the file could not be read
      */
     public static void loadConfig(String pathAsString, Class<?>... klass) throws IOException {
         Configuration.loadAndGetConfiguration(pathAsString, klass);
     }
 
-    /** Starts the dungeon and requires a {@link Game}. */
+    /**
+     * Starts the dungeon and requires a {@link Game}.
+     */
     public static void run() {
         Lwjgl3ApplicationConfiguration config = new Lwjgl3ApplicationConfiguration();
         config.setWindowSizeLimits(WINDOW_WIDTH, WINDOW_HEIGHT, 9999, 9999);
@@ -561,7 +571,7 @@ public final class Game extends ScreenAdapter {
      *
      * @param system the System to add
      * @return an optional that contains the previous existing system of the given system class, if
-     *     one exists
+     * one exists
      * @see System
      * @see Optional
      */
@@ -598,8 +608,47 @@ public final class Game extends ScreenAdapter {
      * <p>This will also remove all entities from each system.
      */
     public static void removeAllEntities() {
-        Game.entityStream().forEach(Game::remove);
+        allEntities().forEach(Game::remove);
         LOGGER.info("All entities will be removed from the game.");
+    }
+
+    /**
+     * Use this stream if you want to iterate over all active entities.
+     *
+     * <p>Use {@link #entityStream()} if you want to iterate over all active entities.
+     *
+     * @return a stream of all entities currently in the game
+     */
+    public static Stream<Entity> allEntities() {
+        Set<Entity> allEntities = new HashSet<>();
+        java.lang.System.out.println(levelStorageMap.values().size());
+        levelStorageMap
+                .values()
+                .forEach(
+                        entitySystemMappers ->
+                                entitySystemMappers.forEach(
+                                        entitySystemMapper ->
+                                                entitySystemMapper.stream()
+                                                        .forEach(e -> allEntities.add(e))));
+
+        java.lang.System.out.println(allEntities.size());
+        return allEntities.stream();
+    }
+
+    /**
+     * Find the entity that contains the given component instance.
+     *
+     * @param component Component instance where the entity is searched for.
+     * @return An Optional containing the found Entity, or an empty Optional if not found.
+     */
+    public static Optional<Entity> find(Component component) {
+        return allEntities()
+                .filter(
+                        entity ->
+                                entity.fetch(component.getClass())
+                                        .map(component::equals)
+                                        .orElse(false))
+                .findFirst();
     }
 
     public static Optional<Stage> stage() {
@@ -703,7 +752,7 @@ public final class Game extends ScreenAdapter {
      * <p>Throws an IllegalArgumentException if start or end is non-accessible.
      *
      * @param start Start tile
-     * @param end End tile
+     * @param end   End tile
      * @return Generated path
      */
     public static GraphPath<Tile> findPath(Tile start, Tile end) {
@@ -792,7 +841,9 @@ public final class Game extends ScreenAdapter {
         userOnFrame.execute();
     }
 
-    /** Just for debugging, remove later. */
+    /**
+     * Just for debugging, remove later.
+     */
     private void debugKeys() {
         if (Gdx.input.isKeyJustPressed(Input.Keys.UP)) {
             // toggle UI "debug rendering"
@@ -839,7 +890,9 @@ public final class Game extends ScreenAdapter {
         Gdx.gl.glClear(GL_COLOR_BUFFER_BIT);
     }
 
-    /** Create the systems. */
+    /**
+     * Create the systems.
+     */
     private void createSystems() {
         add(new PositionSystem());
         add(new CameraSystem());
@@ -857,9 +910,9 @@ public final class Game extends ScreenAdapter {
     public void resize(int width, int height) {
         super.resize(width, height);
         stage().ifPresent(
-                        x -> {
-                            x.getViewport().setWorldSize(width, height);
-                            x.getViewport().update(width, height, true);
-                        });
+                x -> {
+                    x.getViewport().setWorldSize(width, height);
+                    x.getViewport().update(width, height, true);
+                });
     }
 }

--- a/game/test/core/GameTest.java
+++ b/game/test/core/GameTest.java
@@ -1,0 +1,72 @@
+package core;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import core.level.elements.ILevel;
+
+import org.junit.After;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class GameTest {
+
+    @After
+    public void cleanup() {
+        Game.removeAllEntities();
+        Game.removeAllSystems();
+        Game.currentLevel(null);
+    }
+
+    @Test
+    public void allEntites() {
+        Game.add(new Entity());
+        Game.add(new Entity());
+        Game.add(new Entity());
+        Game.add(new Entity());
+        ILevel level = Mockito.mock(ILevel.class);
+        Game.currentLevel(level);
+        Game.add(new Entity());
+        Game.add(new Entity());
+        Game.add(new Entity());
+        Game.add(new Entity());
+        assertEquals(8, Game.allEntities().count());
+    }
+
+    @Test
+    public void removeAllEntites() {
+        Game.add(new Entity());
+        Game.add(new Entity());
+        Game.add(new Entity());
+        Game.add(new Entity());
+        ILevel level = Mockito.mock(ILevel.class);
+        Game.currentLevel(level);
+        Game.add(new Entity());
+        Game.add(new Entity());
+        Game.add(new Entity());
+        Game.add(new Entity());
+        assertEquals(8, Game.allEntities().count());
+        Game.removeAllEntities();
+        assertEquals(0, Game.allEntities().count());
+    }
+
+    @Test
+    public void find_exisiting() {
+        Entity e = new Entity();
+        DummyComponent dc = new DummyComponent();
+        e.addComponent(dc);
+        Game.add(e);
+        assertEquals(e, Game.find(dc).get());
+        // load ne level to check if it still works
+        ILevel level = Mockito.mock(ILevel.class);
+        assertEquals(e, Game.find(dc).get());
+    }
+
+    @Test
+    public void find_nonExisting() {
+        DummyComponent dc = new DummyComponent();
+        assertTrue(Game.find(dc).isEmpty());
+    }
+
+    private class DummyComponent implements Component {}
+}


### PR DESCRIPTION
fixes #1125 

- Zuerst wurde der Initiale EntityMapper richtig konfiguriert. Dieser existiert bereits vor jedem Level und wird zwar im richtigen Spiel nicht verwendet, aber in vielen unserer Test-Szenarien (da wir hier kein Level erzeugen). Früher wurde er nicht der `levelStorageMap` in `Game` hinzugefügt. das wurde jetzt geändert (Key-Value ist `null`).
- Fügt die Methode `Game#allEntites` hinzu, welche JEDE Entität im Spiel (nicht nur die im aktuellen Level) zurückliefert.
- Die Methode `removeAllEntites` hat früher nur alle Entitäten im aktuellen Level gelöscht, dieser bug wurde behoben
- Fügt die Methode `Game#find(Component)` hinzu, welche einen die Entität zurückliefert, welche das konkret übergebene Component implementiert (also die Instanz)
- Entfernt die Methode `Task#find` (wurde von `Game#find` abgelöst)
- Fügt rudimentäre Tests hinzu