### PR TITLE
[DUNGEON] add abort button to quest ui, add yes no dialog

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -134,6 +134,19 @@ task runManualQuizTest(dependsOn: classes, type: JavaExec) {
     }
 }
 
+task runYesNoDialogTest(dependsOn: classes, type: JavaExec) {
+    mainClass = "manual.YesNoDialogTest"
+    classpath = sourceSets.test.runtimeClasspath
+    standardInput = System.in
+    ignoreExitValue = true
+    if (DefaultNativePlatform.currentOperatingSystem.isMacOsX()) {
+        allJvmArgs += ["-XstartOnFirstThread"]
+    }
+    doFirst {
+        println(DefaultNativePlatform.currentOperatingSystem)
+    }
+}
+
 task runCallbackTest(dependsOn: classes, type: JavaExec) {
     mainClass = "manual.quizquestion.CallbackTest"
     classpath = sourceSets.test.runtimeClasspath

--- a/dungeon/src/task/YesNoDialog.java
+++ b/dungeon/src/task/YesNoDialog.java
@@ -2,63 +2,70 @@ package task;
 
 import com.badlogic.gdx.scenes.scene2d.ui.Dialog;
 import com.badlogic.gdx.scenes.scene2d.ui.Skin;
+
 import contrib.hud.DialogDesign;
 import contrib.hud.TextDialog;
 import contrib.hud.UITools;
+
 import core.Entity;
 import core.Game;
 import core.utils.IVoidFunction;
+
 import task.quizquestion.QuizUI;
 
 import java.util.Objects;
 import java.util.function.BiFunction;
 
 public class YesNoDialog {
-    public static Entity showYesNoDialog(
-        String text,
-        String title,
-        IVoidFunction onYes,
-        IVoidFunction onNo) {
 
-        Entity entity =
-            showYesNoDialog(
-                UITools.DEFAULT_SKIN,
-                text,
-                title,
-                onYes,
-                onNo);
+    public static Entity showYesNoDialog(Task t) {
+        return showYesNoDialog();
+    }
+
+    public static Entity showYesNoDialog(
+            String text, String title, IVoidFunction onYes, IVoidFunction onNo) {
+
+        Entity entity = showYesNoDialog(UITools.DEFAULT_SKIN, text, title, onYes, onNo);
         Game.add(entity);
         return entity;
     }
 
     public static Entity showYesNoDialog(
-        Skin skin, String text, String title, IVoidFunction onYes,
-        IVoidFunction onNo) {
+            Skin skin, String text, String title, IVoidFunction onYes, IVoidFunction onNo) {
         Entity entity = new Entity();
 
         UITools.show(
-            () -> {
-                Dialog dialog =
-                    createYesNoDialog(
-                        skin,
-                        text,
-                        title,
-                        createResultHandlerYesNo(entity, UITools.DEFAULT_DIALOG_YES, UITools.DEFAULT_DIALOG_NO, onYes, onNo));
-                UITools.centerActor(dialog);
-                return dialog;
-            },
-            entity);
+                () -> {
+                    Dialog dialog =
+                            createYesNoDialog(
+                                    skin,
+                                    text,
+                                    title,
+                                    createResultHandlerYesNo(
+                                            entity,
+                                            UITools.DEFAULT_DIALOG_YES,
+                                            UITools.DEFAULT_DIALOG_NO,
+                                            onYes,
+                                            onNo));
+                    UITools.centerActor(dialog);
+                    return dialog;
+                },
+                entity);
         Game.add(entity);
         return entity;
     }
 
-    private static Dialog createYesNoDialog(Skin skin, String text, String title, BiFunction<TextDialog, String, Boolean> resultHandler) {
+    private static Dialog createYesNoDialog(
+            Skin skin,
+            String text,
+            String title,
+            BiFunction<TextDialog, String, Boolean> resultHandler) {
         Dialog textDialog = new TextDialog(title, skin, "Letter", resultHandler);
         textDialog
-            .getContentTable()
-            .add(DialogDesign.createTextDialog(skin, QuizUI.formatStringForDialogWindow(text)))
-            .center()
-            .grow();
+                .getContentTable()
+                .add(DialogDesign.createTextDialog(skin, QuizUI.formatStringForDialogWindow(text)))
+                .center()
+                .grow();
         textDialog.button(UITools.DEFAULT_DIALOG_NO, UITools.DEFAULT_DIALOG_NO);
         textDialog.button(UITools.DEFAULT_DIALOG_YES, UITools.DEFAULT_DIALOG_YES);
         textDialog.pack(); // resizes to size
@@ -66,7 +73,11 @@ public class YesNoDialog {
     }
 
     public static BiFunction<TextDialog, String, Boolean> createResultHandlerYesNo(
-        final Entity entity, final String yesButtonID, String noButtonID, IVoidFunction onYes, IVoidFunction onNo) {
+            final Entity entity,
+            final String yesButtonID,
+            String noButtonID,
+            IVoidFunction onYes,
+            IVoidFunction onNo) {
         return (d, id) -> {
             if (Objects.equals(id, yesButtonID)) {
                 onYes.execute();
@@ -81,7 +92,6 @@ public class YesNoDialog {
             return false;
         };
     }
-
 
     public static IVoidFunction gradeOn(Task t) {
         return t::gradeTask;

--- a/dungeon/src/task/YesNoDialog.java
+++ b/dungeon/src/task/YesNoDialog.java
@@ -1,0 +1,89 @@
+package task;
+
+import com.badlogic.gdx.scenes.scene2d.ui.Dialog;
+import com.badlogic.gdx.scenes.scene2d.ui.Skin;
+import contrib.hud.DialogDesign;
+import contrib.hud.TextDialog;
+import contrib.hud.UITools;
+import core.Entity;
+import core.Game;
+import core.utils.IVoidFunction;
+import task.quizquestion.QuizUI;
+
+import java.util.Objects;
+import java.util.function.BiFunction;
+
+public class YesNoDialog {
+    public static Entity showYesNoDialog(
+        String text,
+        String title,
+        IVoidFunction onYes,
+        IVoidFunction onNo) {
+
+        Entity entity =
+            showYesNoDialog(
+                UITools.DEFAULT_SKIN,
+                text,
+                title,
+                onYes,
+                onNo);
+        Game.add(entity);
+        return entity;
+    }
+
+    public static Entity showYesNoDialog(
+        Skin skin, String text, String title, IVoidFunction onYes,
+        IVoidFunction onNo) {
+        Entity entity = new Entity();
+
+        UITools.show(
+            () -> {
+                Dialog dialog =
+                    createYesNoDialog(
+                        skin,
+                        text,
+                        title,
+                        createResultHandlerYesNo(entity, UITools.DEFAULT_DIALOG_YES, UITools.DEFAULT_DIALOG_NO, onYes, onNo));
+                UITools.centerActor(dialog);
+                return dialog;
+            },
+            entity);
+        Game.add(entity);
+        return entity;
+    }
+
+    private static Dialog createYesNoDialog(Skin skin, String text, String title, BiFunction<TextDialog, String, Boolean> resultHandler) {
+        Dialog textDialog = new TextDialog(title, skin, "Letter", resultHandler);
+        textDialog
+            .getContentTable()
+            .add(DialogDesign.createTextDialog(skin, QuizUI.formatStringForDialogWindow(text)))
+            .center()
+            .grow();
+        textDialog.button(UITools.DEFAULT_DIALOG_NO, UITools.DEFAULT_DIALOG_NO);
+        textDialog.button(UITools.DEFAULT_DIALOG_YES, UITools.DEFAULT_DIALOG_YES);
+        textDialog.pack(); // resizes to size
+        return textDialog;
+    }
+
+    public static BiFunction<TextDialog, String, Boolean> createResultHandlerYesNo(
+        final Entity entity, final String yesButtonID, String noButtonID, IVoidFunction onYes, IVoidFunction onNo) {
+        return (d, id) -> {
+            if (Objects.equals(id, yesButtonID)) {
+                onYes.execute();
+                Game.remove(entity);
+                return true;
+            }
+            if (Objects.equals(id, noButtonID)) {
+                onNo.execute();
+                Game.remove(entity);
+                return true;
+            }
+            return false;
+        };
+    }
+
+
+    public static IVoidFunction gradeOn(Task t) {
+        return t::gradeTask;
+    }
+}

--- a/dungeon/src/task/YesNoDialog.java
+++ b/dungeon/src/task/YesNoDialog.java
@@ -16,22 +16,64 @@ import task.quizquestion.QuizUI;
 import java.util.Objects;
 import java.util.function.BiFunction;
 
+/**
+ * A Dialog with a "yes" and "no" Button on the Bottom.
+ *
+ * <p>Use {@link #showYesNoDialog(String, String, IVoidFunction, IVoidFunction)} to create a simple
+ * dialog.
+ *
+ * <p>Use {@link #showYesNoDialog(Task)} to create a dialog that will execute the grading function
+ * of the given task.
+ */
 public class YesNoDialog {
 
-    public static Entity showYesNoDialog(Task t) {
-        return showYesNoDialog();
+    /**
+     * Open a dialog window that shows the given task's text and will execute the {@link
+     * Task#gradeTask()} if "yes" is pressed.
+     *
+     * @param task task that should be graded if the player presses "yes" on the dialog HUD.
+     * @return The Entity that stores the HUD components.
+     */
+    public static Entity showYesNoDialog(final Task task) {
+        return showYesNoDialog(task.taskText(), task.taskName(), gradeOn(task), () -> {});
     }
 
+    /**
+     * Show a Yes or No Dialog.
+     *
+     * @param text text to show in the dialog
+     * @param title title of the dialog window
+     * @param onYes function to execute if "yes" is pressed
+     * @param onNo function to execute if "no" is pressed
+     * @return Entity that stores the HUD components.
+     */
     public static Entity showYesNoDialog(
-            String text, String title, IVoidFunction onYes, IVoidFunction onNo) {
+            final String text,
+            final String title,
+            final IVoidFunction onYes,
+            final IVoidFunction onNo) {
 
         Entity entity = showYesNoDialog(UITools.DEFAULT_SKIN, text, title, onYes, onNo);
         Game.add(entity);
         return entity;
     }
 
+    /**
+     * Show a Yes or No Dialog.
+     *
+     * @param skin UI skin to use
+     * @param text text to show in the dialog
+     * @param title title of the dialog window
+     * @param onYes function to execute if "yes" is pressed
+     * @param onNo function to execute if "no" is pressed
+     * @return Entity that stores the HUD components.
+     */
     public static Entity showYesNoDialog(
-            Skin skin, String text, String title, IVoidFunction onYes, IVoidFunction onNo) {
+            final Skin skin,
+            final String text,
+            final String title,
+            final IVoidFunction onYes,
+            final IVoidFunction onNo) {
         Entity entity = new Entity();
 
         UITools.show(
@@ -56,10 +98,10 @@ public class YesNoDialog {
     }
 
     private static Dialog createYesNoDialog(
-            Skin skin,
-            String text,
-            String title,
-            BiFunction<TextDialog, String, Boolean> resultHandler) {
+            final Skin skin,
+            final String text,
+            final String title,
+            final BiFunction<TextDialog, String, Boolean> resultHandler) {
         Dialog textDialog = new TextDialog(title, skin, "Letter", resultHandler);
         textDialog
                 .getContentTable()
@@ -72,12 +114,12 @@ public class YesNoDialog {
         return textDialog;
     }
 
-    public static BiFunction<TextDialog, String, Boolean> createResultHandlerYesNo(
+    private static BiFunction<TextDialog, String, Boolean> createResultHandlerYesNo(
             final Entity entity,
             final String yesButtonID,
-            String noButtonID,
-            IVoidFunction onYes,
-            IVoidFunction onNo) {
+            final String noButtonID,
+            final IVoidFunction onYes,
+            final IVoidFunction onNo) {
         return (d, id) -> {
             if (Objects.equals(id, yesButtonID)) {
                 onYes.execute();
@@ -93,7 +135,7 @@ public class YesNoDialog {
         };
     }
 
-    public static IVoidFunction gradeOn(Task t) {
+    private static IVoidFunction gradeOn(final Task t) {
         return t::gradeTask;
     }
 }

--- a/dungeon/src/task/quizquestion/QuizUI.java
+++ b/dungeon/src/task/quizquestion/QuizUI.java
@@ -64,7 +64,11 @@ public class QuizUI {
     public static Entity showQuizDialog(Quiz question) {
         return showQuizDialog(
                 question,
-                (entity) -> createResultHandlerQuiz(entity, UITools.DEFAULT_DIALOG_CONFIRM));
+                (entity) ->
+                        createResultHandlerQuiz(
+                                entity,
+                                UITools.DEFAULT_DIALOG_CONFIRM,
+                                UITools.DEFAULT_DIALOG_ABORT));
     }
 
     /**
@@ -128,8 +132,8 @@ public class QuizUI {
                 .add(QuizDialogDesign.createQuizQuestion(quizQuestion, skin, outputMsg))
                 .grow()
                 .fill(); // changes size based on childrens;
+        textDialog.button(UITools.DEFAULT_DIALOG_ABORT, UITools.DEFAULT_DIALOG_ABORT);
         textDialog.button(buttonMsg, buttonMsg);
-
         textDialog.pack(); // resizes to size
         return textDialog;
     }
@@ -161,9 +165,13 @@ public class QuizUI {
      * Create a default callback-function that will delete the entity that stores the hud-component.
      */
     public static BiFunction<TextDialog, String, Boolean> createResultHandlerQuiz(
-            final Entity entity, final String closeButtonID) {
+            final Entity entity, final String confirmButtonID, String abortButtonID) {
         return (d, id) -> {
-            if (Objects.equals(id, closeButtonID)) {
+            if (Objects.equals(id, confirmButtonID)) {
+                Game.remove(entity);
+                return true;
+            }
+            if (Objects.equals(id, abortButtonID)) {
                 Game.remove(entity);
                 return true;
             }

--- a/dungeon/src/task/quizquestion/UIAnswerCallback.java
+++ b/dungeon/src/task/quizquestion/UIAnswerCallback.java
@@ -64,6 +64,9 @@ public final class UIAnswerCallback {
                 dslCallback.accept(quest, getAnswer(quest, answerSection(textDialog)));
                 Game.remove(hudEntity);
                 return true;
+            } else if (Objects.equals(id, UITools.DEFAULT_DIALOG_ABORT)) {
+                Game.remove(hudEntity);
+                return true;
             }
             return false;
         };

--- a/dungeon/test/manual/YesNoDialogTest.java
+++ b/dungeon/test/manual/YesNoDialogTest.java
@@ -1,0 +1,55 @@
+package manual;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Input;
+
+import contrib.hud.UITools;
+import contrib.systems.HudSystem;
+
+import core.Game;
+import core.utils.IVoidFunction;
+
+import task.YesNoDialog;
+import task.quizquestion.*;
+
+/**
+ * This is a manual test for the YesNODialog.
+ *
+ * <p>It sets up a basic game and will show a Yes-No if "F" is pressed.
+ *
+ * <p>Use this to check if the UI is displayed correctly.
+ *
+ * <p>Start this with ./gradlew runYesNoDialogTest
+ */
+public class YesNoDialogTest {
+
+    public static void main(String[] args) {
+        Game.initBaseLogger();
+        Game.add(new HudSystem());
+        Game.userOnFrame(
+                () -> {
+                    if (Gdx.input.isKeyJustPressed(Input.Keys.F)) {
+                        YesNoDialog.showYesNoDialog(
+                                "Test",
+                                "Test",
+                                new IVoidFunction() {
+                                    @Override
+                                    public void execute() {
+                                        UITools.generateNewTextDialog(
+                                                "Yes", "Ok", "Callback for yes.");
+                                    }
+                                },
+                                new IVoidFunction() {
+                                    @Override
+                                    public void execute() {
+                                        UITools.generateNewTextDialog(
+                                                "No", "Ok", "Callback for no.");
+                                    }
+                                });
+                    }
+                });
+
+        // build and start game
+        Game.run();
+    }
+}

--- a/game/src/contrib/hud/UITools.java
+++ b/game/src/contrib/hud/UITools.java
@@ -22,6 +22,7 @@ import java.util.function.Supplier;
 public class UITools {
     public static final Skin DEFAULT_SKIN = new Skin(Gdx.files.internal(Constants.SKIN_FOR_DIALOG));
     public static final String DEFAULT_DIALOG_CONFIRM = "confirm";
+    public static final String DEFAULT_DIALOG_ABORT = "abort";
     public static final String DEFAULT_DIALOG_TITLE = "Question";
 
     /**

--- a/game/src/contrib/hud/UITools.java
+++ b/game/src/contrib/hud/UITools.java
@@ -23,6 +23,8 @@ public class UITools {
     public static final Skin DEFAULT_SKIN = new Skin(Gdx.files.internal(Constants.SKIN_FOR_DIALOG));
     public static final String DEFAULT_DIALOG_CONFIRM = "confirm";
     public static final String DEFAULT_DIALOG_ABORT = "abort";
+    public static final String DEFAULT_DIALOG_YES = "yes";
+    public static final String DEFAULT_DIALOG_NO = "no";
     public static final String DEFAULT_DIALOG_TITLE = "Question";
 
     /**


### PR DESCRIPTION
fixes #1128 

*.   Fügt die Klasse `YesNoDialog` hinzu, welche es einfach macht, eine Ja-Nein Frage über das HUD zustellen und hinter jeder Antwort ein Callback zu hinterlegen. `YesNoDialog#showYesNoDialog(Task)` bastelt einen das UI incl Callback für das stellen einer Aufgabe zusammen. 
*   Fügt einen abort Button zu den Quiz-Fragen hinzu, damit man die Frage auch nicht beantworten kann.
Wenn "abort" gedrückt wird, wird der DSL-Callback **nicht** ausgeführt. 


@AHeinisch ich habe den PR bewusst gegen deinen Branch gestellt. Ich denke das passt da ganz gut rein. 