### PR TITLE
[DUNGEON] fix bug in petri net parsing, add some (debug) features to starter

### DIFF
--- a/dungeon/assets/scripts/task_test.dng
+++ b/dungeon/assets/scripts/task_test.dng
@@ -31,9 +31,7 @@ multiple_choice_task wuppie4 {
 }
 
 graph g_one{
-    aufgabe_1;
-    wuppie1;
-    wuppie2;
+    aufgabe_1->wuppie1->wuppie2[type=seq];
 }
 
 graph g_two{

--- a/dungeon/src/graphconverter/TaskGraphConverter.java
+++ b/dungeon/src/graphconverter/TaskGraphConverter.java
@@ -264,8 +264,8 @@ public class TaskGraphConverter {
                 .forEachRemaining(
                         taskEdge ->
                                 PetriNetFactory.connect(
-                                        noteToNet.get(taskEdge.startNode()),
                                         noteToNet.get(taskEdge.endNode()),
+                                        noteToNet.get(taskEdge.startNode()),
                                         taskEdge.edgeType()));
 
         // init token

--- a/dungeon/src/starter/Starter.java
+++ b/dungeon/src/starter/Starter.java
@@ -1,6 +1,7 @@
 package starter;
 
 import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Input;
 import com.badlogic.gdx.audio.Music;
 
 import contrib.configuration.KeyboardConfig;
@@ -52,7 +53,7 @@ public class Starter {
             entity -> {
                 StringBuilder questLogBuilder = new StringBuilder();
                 Task.allTasks()
-                        .filter(t -> t.state() == Task.TaskState.ACTIVE)
+                        .filter(t -> t.state() == Task.TaskState.PROCESSING_ACTIVE)
                         .forEach(
                                 task ->
                                         questLogBuilder
@@ -85,7 +86,7 @@ public class Starter {
     private static void onEntryPointSelection() {
         Game.userOnFrame(
                 () -> {
-
+                    debugKey();
                     // the player selected a Task/DSL-Entrypoint but it´s not loaded yet:
                     if (!realGameStarted && WizardTaskSelector.selectedDSLEntryPoint != null) {
                         realGameStarted = true;
@@ -96,6 +97,7 @@ public class Starter {
                         ILevel level =
                                 TaskGraphConverter.convert(
                                         config.dependencyGraph(), dslInterpreter);
+
                         Game.currentLevel(level);
                     }
                 });
@@ -184,5 +186,16 @@ public class Starter {
         backgroundMusic.setLooping(true);
         backgroundMusic.play();
         backgroundMusic.setVolume(.1f);
+    }
+
+    private static void debugKey() {
+        if (Gdx.input.isKeyJustPressed(Input.Keys.F)) {
+            Task.allTasks()
+                    .filter(t -> t.state() == Task.TaskState.PROCESSING_ACTIVE)
+                    .findFirst()
+                    .get()
+                    .state(Task.TaskState.FINISHED_CORRECT);
+            System.out.println(Task.allTasks());
+        }
     }
 }

--- a/dungeon/src/starter/Starter.java
+++ b/dungeon/src/starter/Starter.java
@@ -1,5 +1,8 @@
 package starter;
 
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.audio.Music;
+
 import contrib.configuration.KeyboardConfig;
 import contrib.crafting.Crafting;
 import contrib.entities.EntityFactory;
@@ -41,6 +44,7 @@ import java.util.function.Consumer;
  * paths.
  */
 public class Starter {
+    private static final String BACKGROUND_MUSIC = "sounds/background.wav";
     private static boolean realGameStarted = false;
     private static final DSLInterpreter dslInterpreter = new DSLInterpreter();
 
@@ -103,6 +107,7 @@ public class Starter {
                     createHero();
                     createSystems();
                     Game.currentLevel(WizardTaskSelector.wizardLevel());
+                    setupMusic();
                 });
 
         // load the wizard task selector level
@@ -153,7 +158,7 @@ public class Starter {
         Game.initBaseLogger();
         Game.windowTitle("DSL Dungeon");
         Game.frameRate(30);
-        Game.disableAudio(true);
+        Game.disableAudio(false);
         Game.loadConfig(
                 "dungeon_config.json",
                 contrib.configuration.KeyboardConfig.class,
@@ -171,5 +176,13 @@ public class Starter {
         Game.add(new HeroUISystem());
         Game.add(new HudSystem());
         Game.add(new SpikeSystem());
+        Game.add(new IdleSoundSystem());
+    }
+
+    private static void setupMusic() {
+        Music backgroundMusic = Gdx.audio.newMusic(Gdx.files.internal(BACKGROUND_MUSIC));
+        backgroundMusic.setLooping(true);
+        backgroundMusic.play();
+        backgroundMusic.setVolume(.1f);
     }
 }

--- a/dungeon/src/starter/WizardTaskSelector.java
+++ b/dungeon/src/starter/WizardTaskSelector.java
@@ -87,7 +87,7 @@ public class WizardTaskSelector {
     protected static SingleChoice selectTaskQuestion(Set<DSLEntryPoint> entryPoints) {
         SingleChoice question = new SingleChoice("Wähle deine Mission:");
         entryPoints.forEach(ep -> question.addAnswer(new PayloadTaskContent(ep)));
-        question.state(Task.TaskState.ACTIVE);
+        question.state(Task.TaskState.PROCESSING_ACTIVE);
         return question;
     }
 


### PR DESCRIPTION
Beim parsen des Abhängikeitsgraphen in ein Petri-Netz gab es einen dreher im Funktionsaufruf, den hab ich gefixt. 
Außerdem hab ich im Starter ein paar Features hinzugefügt
- QuestLog zeigt nun alle PROCESSING-ACTIVE Tasks an
- Musik und Sound auch im Starter aktiviert
- Zum debuggen: Mit der Taste "F" wird ein aktueller PROCESSING-ACTIVE Task auf FINISHED-CORRECT gesetzt. Damit kann die Schaltung des Petri-Net getestet werden. 
