### PR TITLE
[GAME] optimize closed `DoorTile` visuals

### DIFF
--- a/game/src/core/level/elements/tile/DoorTile.java
+++ b/game/src/core/level/elements/tile/DoorTile.java
@@ -50,7 +50,8 @@ public class DoorTile extends Tile {
 
     @Override
     public boolean isAccessible() {
-        return levelElement.value();
+        if (!open || (otherDoor != null && !otherDoor.isOpen())) return false;
+        else return levelElement.value();
     }
 
     /**
@@ -141,7 +142,7 @@ public class DoorTile extends Tile {
 
     @Override
     public String texturePath() {
-        if (open) return texturePath;
+        if (open && (otherDoor == null || otherDoor.isOpen())) return texturePath;
         else return closedTexturePath;
     }
 }


### PR DESCRIPTION
Verbessert die Door-Tiles im geschlossenen Zustand an zwei stellen.
1. geschlossene Türen sind nicht mehr accessible, dadurch kann man als Spieler nicht mehr in die geschlossene Tür laufen (da sah albern aus) 
2. Die Türen werden nur offen gezeigt, wenn BEIDE Türen geöffnet sind. Vorher war die Textur unabhänig von der Partner Tür.

Die Null-Checks sind während der Initialisierung der Level nötig. Zur Game-Laufzeit gibt es keine Türen ohne partner Tür (also nicht verwirren lassen)