### PR TITLE
[DUNGEON] add interfaces to allow native taskbuilder in java, add example taskbuilder for Quiz over GUI

### DIFF
--- a/dsl/src/interpreter/DSLInterpreter.java
+++ b/dsl/src/interpreter/DSLInterpreter.java
@@ -334,6 +334,7 @@ public class DSLInterpreter implements AstVisitor<Object>, ITaskBuilder {
      *     builder method was unsuccessful or no fitting scenario builder method for the given
      *     {@link Task} could be found, an empty {@link Optional} will be returned.
      */
+    @Override
     public Optional<Object> buildTask(Task task) {
         var taskClass = task.getClass();
 

--- a/dsl/src/interpreter/DSLInterpreter.java
+++ b/dsl/src/interpreter/DSLInterpreter.java
@@ -29,6 +29,8 @@ import semanticanalysis.types.*;
 import task.Quiz;
 import task.Task;
 
+import taskbuilder.ITaskBuilder;
+
 import java.util.*;
 
 // TODO: specify EXACT semantics of value copying and setting
@@ -37,7 +39,7 @@ import java.util.*;
 // abstraction coupling
 // will be high naturally
 @SuppressWarnings({"methodcount", "classdataabstractioncoupling"})
-public class DSLInterpreter implements AstVisitor<Object> {
+public class DSLInterpreter implements AstVisitor<Object>, ITaskBuilder {
     private RuntimeEnvironment environment;
     private final ArrayDeque<IMemorySpace> memoryStack;
     private final ArrayDeque<IMemorySpace> instanceMemoryStack;

--- a/dungeon/src/graphconverter/TaskGraphConverter.java
+++ b/dungeon/src/graphconverter/TaskGraphConverter.java
@@ -12,13 +12,13 @@ import core.level.elements.ILevel;
 import core.level.elements.tile.DoorTile;
 import core.level.utils.DesignLabel;
 
-import interpreter.DSLInterpreter;
-
 import petriNet.PetriNet;
 
 import task.Task;
 import task.components.DoorComponent;
 import task.components.TaskComponent;
+
+import taskbuilder.ITaskBuilder;
 
 import taskdependencygraph.TaskDependencyGraph;
 import taskdependencygraph.TaskNode;
@@ -28,29 +28,27 @@ import java.util.*;
 /**
  * Offers functions to generate a {@link LevelGraph} or Petri-Net for a TaskGraph .
  *
- * <p>Use {@link #callTaskBuilderFor(TaskDependencyGraph, DSLInterpreter)} to execute the
- * TaskBuilder for each {@link Task} in a {@link TaskDependencyGraph}.
+ * <p>Use {@link #callTaskBuilderFor(TaskDependencyGraph, ITaskBuilder)} to execute the TaskBuilder
+ * for each {@link Task} in a {@link TaskDependencyGraph}.
  *
  * <p>Use {@link #levelGraphFor(TaskDependencyGraph)} to generate a room-based level for the
  * TaskGraph.
  *
  * <p>Use {@link #petriNetFor(TaskDependencyGraph)} to generate a Petri net for the TaskGraph to.
  *
- * <p>Use {@link #convert(TaskDependencyGraph, DSLInterpreter)} to execute the complete chain.
+ * <p>Use {@link #convert(TaskDependencyGraph, ITaskBuilder)} to execute the complete chain.
  */
 public class TaskGraphConverter {
 
     /**
-     * Execute the complete chain of {@link #callTaskBuilderFor(TaskDependencyGraph,
-     * DSLInterpreter)}, {@link #levelGraphFor(TaskDependencyGraph)}, and {@link
-     * #petriNetFor(TaskDependencyGraph)}.
+     * Execute the complete chain of {@link #callTaskBuilderFor(TaskDependencyGraph, ITaskBuilder)},
+     * {@link #levelGraphFor(TaskDependencyGraph)}, and {@link #petriNetFor(TaskDependencyGraph)}.
      *
      * @param graph Graph to execute the full chain of conversion on.
      * @return the start room
      */
-    public static ILevel convert(
-            final TaskDependencyGraph graph, final DSLInterpreter dslInterpreter) {
-        callTaskBuilderFor(graph, dslInterpreter);
+    public static ILevel convert(final TaskDependencyGraph graph, final ITaskBuilder builder) {
+        callTaskBuilderFor(graph, builder);
         ILevel level = levelGraphFor(graph);
         petriNetFor(graph);
         return level;
@@ -62,12 +60,11 @@ public class TaskGraphConverter {
      * @param graph graph that contains the tasks.
      */
     public static void callTaskBuilderFor(
-            final TaskDependencyGraph graph, final DSLInterpreter interpreter) {
+            final TaskDependencyGraph graph, final ITaskBuilder builder) {
         graph.nodeIterator()
                 .forEachRemaining(
                         taskNode ->
-                                interpreter
-                                        .buildTask(taskNode.task())
+                                builder.buildTask(taskNode.task())
                                         .ifPresent(
                                                 buildTask ->
                                                         taskNode.task()

--- a/dungeon/src/starter/Starter.java
+++ b/dungeon/src/starter/Starter.java
@@ -26,6 +26,8 @@ import interpreter.DSLInterpreter;
 
 import task.Task;
 
+import taskbuilder.NativeTaskBuilder;
+
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
@@ -47,6 +49,7 @@ import java.util.function.Consumer;
 public class Starter {
     private static final String BACKGROUND_MUSIC = "sounds/background.wav";
     private static boolean realGameStarted = false;
+    private static final boolean USE_DSL_TASKBUILDER = true;
     private static final DSLInterpreter dslInterpreter = new DSLInterpreter();
 
     private static final Consumer<Entity> showQuestLog =
@@ -94,10 +97,15 @@ public class Starter {
                         DungeonConfig config =
                                 dslInterpreter.interpretEntryPoint(
                                         WizardTaskSelector.selectedDSLEntryPoint);
-                        ILevel level =
-                                TaskGraphConverter.convert(
-                                        config.dependencyGraph(), dslInterpreter);
-
+                        ILevel level;
+                        if (USE_DSL_TASKBUILDER)
+                            level =
+                                    TaskGraphConverter.convert(
+                                            config.dependencyGraph(), dslInterpreter);
+                        else
+                            level =
+                                    TaskGraphConverter.convert(
+                                            config.dependencyGraph(), new NativeTaskBuilder());
                         Game.currentLevel(level);
                     }
                 });

--- a/dungeon/src/starter/Starter.java
+++ b/dungeon/src/starter/Starter.java
@@ -49,7 +49,7 @@ import java.util.function.Consumer;
 public class Starter {
     private static final String BACKGROUND_MUSIC = "sounds/background.wav";
     private static boolean realGameStarted = false;
-    private static final boolean USE_DSL_TASKBUILDER = true;
+    private static final boolean USE_DSL_TASKBUILDER = false;
     private static final DSLInterpreter dslInterpreter = new DSLInterpreter();
 
     private static final Consumer<Entity> showQuestLog =

--- a/dungeon/src/taskbuilder/ITaskBuilder.java
+++ b/dungeon/src/taskbuilder/ITaskBuilder.java
@@ -6,5 +6,15 @@ import java.util.Optional;
 
 public interface ITaskBuilder {
 
+    /**
+     * Execute a scenario builder method for the given {@link Task}.
+     *
+     * @param task The {@link Task} to execute a scenario builder method for.
+     * @return An {@link Optional} containing the Java-Object which was instantiated from the return
+     *     value of the scenario builder. The content inside the {@link Optional} will be of type
+     *     HashSet<HashSet<core.Entity>>. If the execution of the scenario builder method was
+     *     unsuccessful or no fitting scenario builder method for the given {@link Task} could be
+     *     found, an empty {@link Optional} will be returned.
+     */
     Optional<Object> buildTask(Task task);
 }

--- a/dungeon/src/taskbuilder/ITaskBuilder.java
+++ b/dungeon/src/taskbuilder/ITaskBuilder.java
@@ -1,0 +1,10 @@
+package taskbuilder;
+
+import task.Task;
+
+import java.util.Optional;
+
+public interface ITaskBuilder {
+
+    Optional<Object> buildTask(Task task);
+}

--- a/dungeon/src/taskbuilder/NativeTaskBuilder.java
+++ b/dungeon/src/taskbuilder/NativeTaskBuilder.java
@@ -1,12 +1,38 @@
 package taskbuilder;
 
-import task.Task;
+import core.Entity;
 
+import task.AssignTask;
+import task.Task;
+import task.quizquestion.MultipleChoice;
+import task.quizquestion.SingleChoice;
+
+import java.util.HashSet;
 import java.util.Optional;
 
 public class NativeTaskBuilder implements ITaskBuilder {
     @Override
     public Optional<Object> buildTask(Task task) {
+
+        if (task instanceof SingleChoice)
+            return Optional.ofNullable(singleChoiceA((SingleChoice) task));
+        else if (task instanceof MultipleChoice)
+            return Optional.ofNullable(multipleChoiceA((MultipleChoice) task));
+        else if (task instanceof AssignTask)
+            return Optional.ofNullable(assignTaskA((AssignTask) task));
+        // HashSet<HashSet<core.Entity>>.
         return Optional.empty();
+    }
+
+    private HashSet<HashSet<Entity>> singleChoiceA(SingleChoice task) {
+        return null;
+    }
+
+    private HashSet<HashSet<Entity>> multipleChoiceA(MultipleChoice task) {
+        return null;
+    }
+
+    private HashSet<HashSet<Entity>> assignTaskA(AssignTask task) {
+        return null;
     }
 }

--- a/dungeon/src/taskbuilder/NativeTaskBuilder.java
+++ b/dungeon/src/taskbuilder/NativeTaskBuilder.java
@@ -44,8 +44,7 @@ public class NativeTaskBuilder implements ITaskBuilder {
             throw new RuntimeException(e);
         }
         questowner.addComponent(askOnInteraction(quiz));
-        TaskComponent tc = new TaskComponent(questowner);
-        quiz.managerEntity(questowner);
+        new TaskComponent(quiz, questowner);
 
         Set<Set<Entity>> outerSet = new HashSet<>();
         Set<Entity> innerSet = new HashSet<>();
@@ -68,7 +67,8 @@ public class NativeTaskBuilder implements ITaskBuilder {
 
     private BiConsumer<Task, Set<TaskContent>> showAnswersOnHud() {
         return (task, taskContents) -> {
-            float score = task.scoringFunction().apply(task, taskContents);
+            float score = task.gradeTask(taskContents);
+            task.managerEntity().get().removeComponent(InteractionComponent.class);
             UITools.generateNewTextDialog("Your score: " + score, "Ok", "Given answer");
         };
     }

--- a/dungeon/src/taskbuilder/NativeTaskBuilder.java
+++ b/dungeon/src/taskbuilder/NativeTaskBuilder.java
@@ -1,0 +1,12 @@
+package taskbuilder;
+
+import task.Task;
+
+import java.util.Optional;
+
+public class NativeTaskBuilder implements ITaskBuilder {
+    @Override
+    public Optional<Object> buildTask(Task task) {
+        return Optional.empty();
+    }
+}

--- a/dungeon/src/taskbuilder/NativeTaskBuilder.java
+++ b/dungeon/src/taskbuilder/NativeTaskBuilder.java
@@ -23,10 +23,13 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.BiConsumer;
 
+/**
+ * A {@link ITaskBuilder} written native in Java. Can be used as an alternativ to the {@link
+ * interpreter.DSLInterpreter}.
+ */
 public class NativeTaskBuilder implements ITaskBuilder {
     @Override
     public Optional<Object> buildTask(Task task) {
-
         if (task instanceof SingleChoice) return Optional.ofNullable(quizOnHud((Quiz) task));
         else if (task instanceof MultipleChoice) return Optional.ofNullable(quizOnHud((Quiz) task));
         else if (task instanceof AssignTask)

--- a/dungeon/src/taskbuilder/NativeTaskBuilder.java
+++ b/dungeon/src/taskbuilder/NativeTaskBuilder.java
@@ -1,38 +1,87 @@
 package taskbuilder;
 
+import contrib.components.InteractionComponent;
+import contrib.entities.EntityFactory;
+import contrib.hud.UITools;
+
 import core.Entity;
+import core.components.DrawComponent;
+import core.components.PositionComponent;
 
 import task.AssignTask;
+import task.Quiz;
 import task.Task;
+import task.TaskContent;
+import task.components.TaskComponent;
 import task.quizquestion.MultipleChoice;
 import task.quizquestion.SingleChoice;
+import task.quizquestion.UIAnswerCallback;
 
+import java.io.IOException;
 import java.util.HashSet;
 import java.util.Optional;
+import java.util.Set;
+import java.util.function.BiConsumer;
 
 public class NativeTaskBuilder implements ITaskBuilder {
     @Override
     public Optional<Object> buildTask(Task task) {
 
-        if (task instanceof SingleChoice)
-            return Optional.ofNullable(singleChoiceA((SingleChoice) task));
-        else if (task instanceof MultipleChoice)
-            return Optional.ofNullable(multipleChoiceA((MultipleChoice) task));
+        if (task instanceof SingleChoice) return Optional.ofNullable(quizOnHud((Quiz) task));
+        else if (task instanceof MultipleChoice) return Optional.ofNullable(quizOnHud((Quiz) task));
         else if (task instanceof AssignTask)
             return Optional.ofNullable(assignTaskA((AssignTask) task));
         // HashSet<HashSet<core.Entity>>.
         return Optional.empty();
     }
 
-    private HashSet<HashSet<Entity>> singleChoiceA(SingleChoice task) {
-        return null;
-    }
+    private Set<Set<Entity>> quizOnHud(Quiz quiz) {
+        Entity questowner = new Entity("Questowner");
+        questowner.addComponent(new PositionComponent());
+        try {
+            questowner.addComponent(new DrawComponent("character/knight"));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        questowner.addComponent(askOnInteraction(quiz));
+        TaskComponent tc = new TaskComponent(questowner);
+        quiz.managerEntity(questowner);
 
-    private HashSet<HashSet<Entity>> multipleChoiceA(MultipleChoice task) {
-        return null;
+        Set<Set<Entity>> outerSet = new HashSet<>();
+        Set<Entity> innerSet = new HashSet<>();
+        innerSet.add(questowner);
+        outerSet.add(innerSet);
+        outerSet.add(fillerSet());
+        outerSet.add(fillerSet());
+        outerSet.add(fillerSet());
+        return outerSet;
     }
 
     private HashSet<HashSet<Entity>> assignTaskA(AssignTask task) {
         return null;
+    }
+
+    private InteractionComponent askOnInteraction(Quiz quiz) {
+        return new InteractionComponent(
+                1, true, UIAnswerCallback.askOnInteraction(quiz, showAnswersOnHud()));
+    }
+
+    private BiConsumer<Task, Set<TaskContent>> showAnswersOnHud() {
+        return (task, taskContents) -> {
+            float score = task.scoringFunction().apply(task, taskContents);
+            UITools.generateNewTextDialog("Your score: " + score, "Ok", "Given answer");
+        };
+    }
+
+    private Set<Entity> fillerSet() {
+        try {
+            return Set.of(
+                    EntityFactory.newChest(),
+                    EntityFactory.randomMonster(),
+                    EntityFactory.randomMonster(),
+                    EntityFactory.randomMonster());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
     }
 }


### PR DESCRIPTION
Ich habe mal die Idee weitergedacht, neben den DSL-Taskbuilder auch native Taskbuilder in Java anzubieten.
Dafür hab ich das Interface `ITaskBuilder` hinzugefügt (der `DSLInterpreter` implementiert dies auch) und im `starter` einen code-toggle eingebaut, mit dem zwischen "DSL-TaskBuilder" und "NativeTaskBuilder" ausgewählt werden kann. 

Dann hab ich noch eine PoC TaskBuilder-Funktion für Quiz-Fragen angelegt. Hier wird die Frage dann per UI gestellt. 
