### PR TITLE
[DSL] Grading-Funktionen in DSL integrieren

### DIFF
--- a/dsl/src/interpreter/DSLInterpreter.java
+++ b/dsl/src/interpreter/DSLInterpreter.java
@@ -1182,6 +1182,9 @@ public class DSLInterpreter implements AstVisitor<Object> {
             setSetValue(assigneeSetValue, valueToAssign);
         } else if (assignee instanceof FunctionValue assigneeFunctionValue) {
             setFunctionValue(assigneeFunctionValue, valueToAssign);
+        } else if (assignee instanceof PropertyValue propertyValue) {
+            var instantiatedValue = this.environment.getTypeInstantiator().instantiate(valueToAssign);
+            assignee.setInternalValue(instantiatedValue);
         } else {
             assignee.setInternalValue(valueToAssign.getInternalValue());
         }

--- a/dsl/src/interpreter/DSLInterpreter.java
+++ b/dsl/src/interpreter/DSLInterpreter.java
@@ -1590,6 +1590,15 @@ public class DSLInterpreter implements AstVisitor<Object> {
     // endregion
 
     // region helpers for native functions/methods
+
+    /**
+     * Evaluates a List of {@link Node}s in the current {@link IMemorySpace} of this {@link
+     * DSLInterpreter}.
+     *
+     * @param nodes The {@link Node}s to evaluate.
+     * @return a List of {@link Value}s, which holds the evaluated Nodes. In the same order as
+     *     passed Nodes.
+     */
     public List<Value> evaluateNodes(List<Node> nodes) {
         ArrayList<Value> values = new ArrayList<>(nodes.size());
         for (Node node : nodes) {
@@ -1599,6 +1608,13 @@ public class DSLInterpreter implements AstVisitor<Object> {
         return values;
     }
 
+    /**
+     * Convert a List of {@link Value}s to Objects by using the internal {@link TypeInstantiator}.
+     *
+     * @param values The List of {@link Value}s to convert.
+     * @return a List of Objects, which holds the converted values. In the same order as passed
+     *     Values.
+     */
     public List<Object> translateValuesToObjects(List<Value> values) {
         ArrayList<Object> objects = new ArrayList<>(values.size());
         var instantiator = this.getRuntimeEnvironment().getTypeInstantiator();

--- a/dsl/src/interpreter/DSLInterpreter.java
+++ b/dsl/src/interpreter/DSLInterpreter.java
@@ -1183,7 +1183,8 @@ public class DSLInterpreter implements AstVisitor<Object> {
         } else if (assignee instanceof FunctionValue assigneeFunctionValue) {
             setFunctionValue(assigneeFunctionValue, valueToAssign);
         } else if (assignee instanceof PropertyValue propertyValue) {
-            var instantiatedValue = this.environment.getTypeInstantiator().instantiate(valueToAssign);
+            var instantiatedValue =
+                    this.environment.getTypeInstantiator().instantiate(valueToAssign);
             assignee.setInternalValue(instantiatedValue);
         } else {
             assignee.setInternalValue(valueToAssign.getInternalValue());
@@ -1587,7 +1588,6 @@ public class DSLInterpreter implements AstVisitor<Object> {
         return null;
     }
     // endregion
-
 
     // region helpers for native functions/methods
     public List<Value> evaluateNodes(List<Node> nodes) {

--- a/dsl/src/interpreter/DSLInterpreter.java
+++ b/dsl/src/interpreter/DSLInterpreter.java
@@ -1584,4 +1584,26 @@ public class DSLInterpreter implements AstVisitor<Object> {
         return null;
     }
     // endregion
+
+
+    // region helpers for native functions/methods
+    public List<Value> evaluateNodes(List<Node> nodes) {
+        ArrayList<Value> values = new ArrayList<>(nodes.size());
+        for (Node node : nodes) {
+            Value value = (Value) node.accept(this);
+            values.add(value);
+        }
+        return values;
+    }
+
+    public List<Object> translateValuesToObjects(List<Value> values) {
+        ArrayList<Object> objects = new ArrayList<>(values.size());
+        var instantiator = this.getRuntimeEnvironment().getTypeInstantiator();
+        for (Value value : values) {
+            Object object = instantiator.instantiate(value);
+            objects.add(object);
+        }
+        return objects;
+    }
+    // endregion
 }

--- a/dsl/src/runtime/FunctionValue.java
+++ b/dsl/src/runtime/FunctionValue.java
@@ -1,18 +1,19 @@
 package runtime;
 
 import semanticanalysis.ICallable;
+import semanticanalysis.types.BuiltInType;
 import semanticanalysis.types.IType;
 
 /** This Value represents the instance of an {@link ICallable}. */
 public class FunctionValue extends Value {
-    ICallable callable;
+    public static FunctionValue NONE = new FunctionValue(BuiltInType.noType, null);
 
     /**
      * @return index of the symbol representing the function definition, which is called by this
      *     Value
      */
     public ICallable getCallable() {
-        return callable;
+        return (ICallable) this.getInternalValue();
     }
 
     /**
@@ -23,11 +24,10 @@ public class FunctionValue extends Value {
      */
     public FunctionValue(IType functionReturnValue, ICallable callable) {
         super(functionReturnValue, callable);
-        this.callable = callable;
     }
 
     @Override
     public Object clone() {
-        return new FunctionValue(this.dataType, this.callable);
+        return new FunctionValue(this.dataType, this.getCallable());
     }
 }

--- a/dsl/src/runtime/GameEnvironment.java
+++ b/dsl/src/runtime/GameEnvironment.java
@@ -279,7 +279,7 @@ public class GameEnvironment implements IEvironment {
             nativeFunctions.add(nativeGradeSingleChoice);
 
             NativeFunction nativeGradeMultipleChoice =
-                new MultipleChoiceGrading(this.globalScope, taskType, taskContentSetType);
+                    new MultipleChoiceGrading(this.globalScope, taskType, taskContentSetType);
             nativeFunctions.add(nativeGradeMultipleChoice);
         }
 
@@ -441,9 +441,9 @@ public class GameEnvironment implements IEvironment {
          */
         public MultipleChoiceGrading(IScope parentScope, IType taskType, IType taskContentSetType) {
             super(
-                "grade_multiple_choice_task",
-                parentScope,
-                new FunctionType(BuiltInType.floatType, taskType, taskContentSetType));
+                    "grade_multiple_choice_task",
+                    parentScope,
+                    new FunctionType(BuiltInType.floatType, taskType, taskContentSetType));
             this.func = GradingFunctions.multipeChoiceGrading();
         }
 

--- a/dsl/src/runtime/GameEnvironment.java
+++ b/dsl/src/runtime/GameEnvironment.java
@@ -102,6 +102,7 @@ public class GameEnvironment implements IEvironment {
 
         methods.add(SingleChoiceTask.GetContentMethod.instance);
         methods.add(MultipleChoiceTask.GetContentMethod.instance);
+        methods.add(SingleChoiceTask.SingleChoiceSetGradingFunction.instance);
 
         return methods;
     }

--- a/dsl/src/runtime/GameEnvironment.java
+++ b/dsl/src/runtime/GameEnvironment.java
@@ -103,6 +103,7 @@ public class GameEnvironment implements IEvironment {
         methods.add(SingleChoiceTask.GetContentMethod.instance);
         methods.add(MultipleChoiceTask.GetContentMethod.instance);
         methods.add(SingleChoiceTask.SingleChoiceSetGradingFunction.instance);
+        methods.add(MultipleChoiceTask.MultipleChoiceSetGradingFunction.instance);
 
         return methods;
     }

--- a/dsl/src/runtime/GameEnvironment.java
+++ b/dsl/src/runtime/GameEnvironment.java
@@ -25,6 +25,8 @@ import interpreter.DSLInterpreter;
 
 import parser.ast.Node;
 
+import reporting.GradingFunctions;
+
 import runtime.nativefunctions.NativeFunction;
 import runtime.nativefunctions.NativePrint;
 
@@ -41,10 +43,8 @@ import task.taskdsltypes.SingleChoiceDescriptionProperty;
 import task.taskdsltypes.SingleChoiceTask;
 
 import java.lang.reflect.Type;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
+import java.util.*;
+import java.util.function.BiFunction;
 
 public class GameEnvironment implements IEvironment {
     // TODO: the TypeBuilder should be completely encapsulated, so that types can only
@@ -268,6 +268,20 @@ public class GameEnvironment implements IEvironment {
                 new NativeBuildQuestItem(Scope.NULL, questItemType, taskContentType);
         nativeFunctions.add(nativeBuildQuestItem);
 
+        // grading functions
+        var taskSymbol = this.globalScope.resolve("task");
+        if (!taskSymbol.equals(Symbol.NULL)) {
+            IType taskType = (IType) taskSymbol;
+            IType taskContentSetType = new SetType(taskContentType, this.globalScope);
+            NativeFunction nativeGradeSingleChoice =
+                    new SingleChoiceGrading(this.globalScope, taskType, taskContentSetType);
+            nativeFunctions.add(nativeGradeSingleChoice);
+
+            NativeFunction nativeGradeMultipleChoice =
+                new MultipleChoiceGrading(this.globalScope, taskType, taskContentSetType);
+            nativeFunctions.add(nativeGradeMultipleChoice);
+        }
+
         return nativeFunctions;
     }
 
@@ -369,6 +383,80 @@ public class GameEnvironment implements IEvironment {
 
                 return questItemObject;
             }
+        }
+
+        @Override
+        public ICallable.Type getCallableType() {
+            return ICallable.Type.Native;
+        }
+    }
+
+    // endregion
+
+    // region native grading functions
+
+    private static class SingleChoiceGrading extends NativeFunction {
+        private BiFunction<Task, Set<TaskContent>, Float> func;
+
+        /**
+         * Constructor
+         *
+         * @param parentScope parent scope of this function
+         */
+        public SingleChoiceGrading(IScope parentScope, IType taskType, IType taskContentSetType) {
+            super(
+                    "grade_single_choice_task",
+                    parentScope,
+                    new FunctionType(BuiltInType.floatType, taskType, taskContentSetType));
+            this.func = GradingFunctions.singleChoiceGrading();
+        }
+
+        @Override
+        public Object call(DSLInterpreter interpreter, List<Node> parameters) {
+            assert parameters != null && parameters.size() > 0;
+
+            var parameterValues = this.evaluateParameters(interpreter, parameters);
+            var parameterObjects = this.translateValuesToObjects(interpreter, parameterValues);
+            Task task = (Task) parameterObjects.get(0);
+            Set<TaskContent> taskContentSet = (Set<TaskContent>) parameterObjects.get(1);
+
+            // call func
+            return func.apply(task, taskContentSet);
+        }
+
+        @Override
+        public ICallable.Type getCallableType() {
+            return ICallable.Type.Native;
+        }
+    }
+
+    private static class MultipleChoiceGrading extends NativeFunction {
+        private BiFunction<Task, Set<TaskContent>, Float> func;
+
+        /**
+         * Constructor
+         *
+         * @param parentScope parent scope of this function
+         */
+        public MultipleChoiceGrading(IScope parentScope, IType taskType, IType taskContentSetType) {
+            super(
+                "grade_multiple_choice_task",
+                parentScope,
+                new FunctionType(BuiltInType.floatType, taskType, taskContentSetType));
+            this.func = GradingFunctions.multipeChoiceGrading();
+        }
+
+        @Override
+        public Object call(DSLInterpreter interpreter, List<Node> parameters) {
+            assert parameters != null && parameters.size() > 0;
+
+            var parameterValues = this.evaluateParameters(interpreter, parameters);
+            var parameterObjects = this.translateValuesToObjects(interpreter, parameterValues);
+            Task task = (Task) parameterObjects.get(0);
+            Set<TaskContent> taskContentSet = (Set<TaskContent>) parameterObjects.get(1);
+
+            // call func
+            return func.apply(task, taskContentSet);
         }
 
         @Override

--- a/dsl/src/runtime/GameEnvironment.java
+++ b/dsl/src/runtime/GameEnvironment.java
@@ -415,8 +415,8 @@ public class GameEnvironment implements IEvironment {
         public Object call(DSLInterpreter interpreter, List<Node> parameters) {
             assert parameters != null && parameters.size() > 0;
 
-            var parameterValues = this.evaluateParameters(interpreter, parameters);
-            var parameterObjects = this.translateValuesToObjects(interpreter, parameterValues);
+            var parameterValues = interpreter.evaluateNodes(parameters);
+            var parameterObjects = interpreter.translateValuesToObjects(parameterValues);
             Task task = (Task) parameterObjects.get(0);
             Set<TaskContent> taskContentSet = (Set<TaskContent>) parameterObjects.get(1);
 
@@ -450,8 +450,8 @@ public class GameEnvironment implements IEvironment {
         public Object call(DSLInterpreter interpreter, List<Node> parameters) {
             assert parameters != null && parameters.size() > 0;
 
-            var parameterValues = this.evaluateParameters(interpreter, parameters);
-            var parameterObjects = this.translateValuesToObjects(interpreter, parameterValues);
+            var parameterValues = interpreter.evaluateNodes(parameters);
+            var parameterObjects = interpreter.translateValuesToObjects(parameterValues);
             Task task = (Task) parameterObjects.get(0);
             Set<TaskContent> taskContentSet = (Set<TaskContent>) parameterObjects.get(1);
 

--- a/dsl/src/runtime/nativefunctions/ExtensionMethod.java
+++ b/dsl/src/runtime/nativefunctions/ExtensionMethod.java
@@ -48,11 +48,8 @@ public class ExtensionMethod extends Symbol implements ICallable {
         Object instanceObject = instance.getInternalValue();
 
         // interpret parameters and extract internal values
-        List<Object> parameterObjects =
-                parameters.stream()
-                        .map(p -> p.accept(interperter))
-                        .map(o -> ((Value) o).getInternalValue())
-                        .toList();
+        var parameterValues = interperter.evaluateNodes(parameters);
+        List<Object> parameterObjects = interperter.translateValuesToObjects(parameterValues);
 
         return this.extensionMethod.call(instanceObject, parameterObjects);
     }

--- a/dsl/src/runtime/nativefunctions/NativeFunction.java
+++ b/dsl/src/runtime/nativefunctions/NativeFunction.java
@@ -1,11 +1,18 @@
 package runtime.nativefunctions;
 
+import interpreter.DSLInterpreter;
+import parser.ast.Node;
+import runtime.SetValue;
+import runtime.Value;
 import semanticanalysis.ICallable;
 import semanticanalysis.IScope;
 import semanticanalysis.ScopedSymbol;
 import semanticanalysis.Symbol;
 import semanticanalysis.types.FunctionType;
 import semanticanalysis.types.IType;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public abstract class NativeFunction extends ScopedSymbol implements ICallable {
     protected NativeFunction(String name, IScope parentScope, FunctionType type) {
@@ -22,6 +29,25 @@ public abstract class NativeFunction extends ScopedSymbol implements ICallable {
 
     public void overwriteFunctionType(FunctionType type) {
         this.dataType = type;
+    }
+
+    protected List<Value> evaluateParameters(DSLInterpreter interpreter, List<Node> parameterNodes) {
+        ArrayList<Value> parameterValues = new ArrayList<>(parameterNodes.size());
+        for (Node node : parameterNodes) {
+            Value taskValue = (Value) node.accept(interpreter);
+            parameterValues.add(taskValue);
+        }
+        return parameterValues;
+    }
+
+    protected List<Object> translateValuesToObjects(DSLInterpreter interpreter, List<Value> values) {
+        ArrayList<Object> objects = new ArrayList<>(values.size());
+        var instantiator = interpreter.getRuntimeEnvironment().getTypeInstantiator();
+        for (Value value : values) {
+            Object object = instantiator.instantiate(value);
+            objects.add(object);
+        }
+        return objects;
     }
 
     @Override

--- a/dsl/src/runtime/nativefunctions/NativeFunction.java
+++ b/dsl/src/runtime/nativefunctions/NativeFunction.java
@@ -31,27 +31,10 @@ public abstract class NativeFunction extends ScopedSymbol implements ICallable {
         this.dataType = type;
     }
 
-    protected List<Value> evaluateParameters(DSLInterpreter interpreter, List<Node> parameterNodes) {
-        ArrayList<Value> parameterValues = new ArrayList<>(parameterNodes.size());
-        for (Node node : parameterNodes) {
-            Value taskValue = (Value) node.accept(interpreter);
-            parameterValues.add(taskValue);
-        }
-        return parameterValues;
-    }
-
-    protected List<Object> translateValuesToObjects(DSLInterpreter interpreter, List<Value> values) {
-        ArrayList<Object> objects = new ArrayList<>(values.size());
-        var instantiator = interpreter.getRuntimeEnvironment().getTypeInstantiator();
-        for (Value value : values) {
-            Object object = instantiator.instantiate(value);
-            objects.add(object);
-        }
-        return objects;
-    }
 
     @Override
     public FunctionType getFunctionType() {
         return (FunctionType) this.getDataType();
     }
 }
+

--- a/dsl/src/runtime/nativefunctions/NativeFunction.java
+++ b/dsl/src/runtime/nativefunctions/NativeFunction.java
@@ -1,18 +1,11 @@
 package runtime.nativefunctions;
 
-import interpreter.DSLInterpreter;
-import parser.ast.Node;
-import runtime.SetValue;
-import runtime.Value;
 import semanticanalysis.ICallable;
 import semanticanalysis.IScope;
 import semanticanalysis.ScopedSymbol;
 import semanticanalysis.Symbol;
 import semanticanalysis.types.FunctionType;
 import semanticanalysis.types.IType;
-
-import java.util.ArrayList;
-import java.util.List;
 
 public abstract class NativeFunction extends ScopedSymbol implements ICallable {
     protected NativeFunction(String name, IScope parentScope, FunctionType type) {
@@ -31,10 +24,8 @@ public abstract class NativeFunction extends ScopedSymbol implements ICallable {
         this.dataType = type;
     }
 
-
     @Override
     public FunctionType getFunctionType() {
         return (FunctionType) this.getDataType();
     }
 }
-

--- a/dsl/src/runtime/nativefunctions/NativeFunction.java
+++ b/dsl/src/runtime/nativefunctions/NativeFunction.java
@@ -3,11 +3,21 @@ package runtime.nativefunctions;
 import semanticanalysis.ICallable;
 import semanticanalysis.IScope;
 import semanticanalysis.ScopedSymbol;
+import semanticanalysis.Symbol;
 import semanticanalysis.types.FunctionType;
+import semanticanalysis.types.IType;
 
 public abstract class NativeFunction extends ScopedSymbol implements ICallable {
     protected NativeFunction(String name, IScope parentScope, FunctionType type) {
         super(name, parentScope, type);
+
+        // create generically named parameter symbols
+        for (int i = 0; i < type.getParameterTypes().size(); i++) {
+            IType parameterType = type.getParameterTypes().get(i);
+            String parameterName = "param" + i;
+            Symbol parameterSymbol = new Symbol(parameterName, this, parameterType);
+            this.bind(parameterSymbol);
+        }
     }
 
     public void overwriteFunctionType(FunctionType type) {

--- a/dsl/src/semanticanalysis/types/IDSLExtensionMethod.java
+++ b/dsl/src/semanticanalysis/types/IDSLExtensionMethod.java
@@ -2,6 +2,7 @@ package semanticanalysis.types;
 
 import interpreter.DSLInterpreter;
 
+import java.lang.reflect.Type;
 import java.util.List;
 
 /**
@@ -26,5 +27,5 @@ public interface IDSLExtensionMethod<T, R> {
     R call(T instance, List<Object> params);
 
     /** Should return an in-order list of the classes, which will be used for the parameters. */
-    List<Class<?>> getParameterTypes();
+    List<Type> getParameterTypes();
 }

--- a/dsl/src/semanticanalysis/types/TypeBuilder.java
+++ b/dsl/src/semanticanalysis/types/TypeBuilder.java
@@ -253,12 +253,17 @@ public class TypeBuilder {
                 if (parametersClass.isAnnotationPresent(FunctionalInterface.class)) {
                     // If the parameters class is annotated with @FunctionalInterface, we need to
                     // create a FunctionType for the parameter. For this we
-                    // need the *Parameterized* Type of the parameter (which stores the information about the
-                    // types used in the declaration of the generic type, i.e. `Integer` in `List<Integer>`).
-                    // This CANNOT be integrated in `createDSLTypeForJavaTypeInScope` (see below), because
-                    // the *Parameterized* Type is ONLY accessible via the Parameter of the method, which is
+                    // need the *Parameterized* Type of the parameter (which stores the information
+                    // about the
+                    // types used in the declaration of the generic type, i.e. `Integer` in
+                    // `List<Integer>`).
+                    // This CANNOT be integrated in `createDSLTypeForJavaTypeInScope` (see below),
+                    // because
+                    // the *Parameterized* Type is ONLY accessible via the Parameter of the method,
+                    // which is
                     // not available in the `createDSLTypeForJavaTypeInScope`-method!
-                    var parameterizedParameterType = (ParameterizedType) parameter.getParameterizedType();
+                    var parameterizedParameterType =
+                            (ParameterizedType) parameter.getParameterizedType();
                     paramDSLType = createFunctionType(parameterizedParameterType, parentScope);
                 } else if (List.class.isAssignableFrom((Class<?>) parametersType)) {
                     // TODO: refactor this to be included in createDSLTypeForJavaTypeInScope, see:
@@ -316,8 +321,7 @@ public class TypeBuilder {
             Field field, AggregateType parentType, IScope globalScope) {
         String callbackName = getDSLFieldName(field);
         IType callbackType =
-                createFunctionType(
-                        (ParameterizedType) field.getGenericType(), globalScope);
+                createFunctionType((ParameterizedType) field.getGenericType(), globalScope);
 
         return new Symbol(callbackName, parentType, callbackType);
     }
@@ -330,7 +334,8 @@ public class TypeBuilder {
         IType functionType = BuiltInType.noType;
         if (functionTypeBuilder != null) {
             functionType =
-                    functionTypeBuilder.buildFunctionType(parameterizedFunctionalInterfaceType, this, globalScope);
+                    functionTypeBuilder.buildFunctionType(
+                            parameterizedFunctionalInterfaceType, this, globalScope);
             functionType = bindOrResolveTypeInScope(functionType, globalScope);
         }
 
@@ -558,16 +563,17 @@ public class TypeBuilder {
                     try {
                         Class<?> rawType = (Class<?>) parameterizedParameterType.getRawType();
                         if (rawType.isAnnotationPresent(FunctionalInterface.class)) {
-                            valueDSLType = this.createFunctionType(parameterizedParameterType, globalScope);
+                            valueDSLType =
+                                    this.createFunctionType(
+                                            parameterizedParameterType, globalScope);
                         }
-                    } catch (ClassCastException ex){
+                    } catch (ClassCastException ex) {
                         //
                     }
                 }
                 if (valueDSLType == null) {
                     valueDSLType = createDSLTypeForJavaTypeInScope(globalScope, valueType);
                 }
-
 
                 // create and bind property symbol
                 PropertySymbol propertySymbol =
@@ -609,7 +615,9 @@ public class TypeBuilder {
                         try {
                             Class<?> rawType = (Class<?>) parameterizedParameterType.getRawType();
                             if (rawType.isAnnotationPresent(FunctionalInterface.class)) {
-                                dslType = this.createFunctionType(parameterizedParameterType, globalScope);
+                                dslType =
+                                        this.createFunctionType(
+                                                parameterizedParameterType, globalScope);
                             }
                         } catch (ClassCastException ex) {
                             //

--- a/dsl/src/semanticanalysis/types/TypeBuilder.java
+++ b/dsl/src/semanticanalysis/types/TypeBuilder.java
@@ -96,6 +96,8 @@ public class TypeBuilder {
             return BuiltInType.boolType;
         } else if (String.class.equals(clazz) || String.class.isAssignableFrom(clazz)) {
             return BuiltInType.stringType;
+        } else if (Void.class.isAssignableFrom(clazz)) {
+            return BuiltInType.noType;
         } else if (TaskDependencyGraph.class.equals(clazz)
                 || TaskDependencyGraph.class.isAssignableFrom(clazz)) {
             return BuiltInType.graphType;

--- a/dsl/src/semanticanalysis/types/TypeBuilder.java
+++ b/dsl/src/semanticanalysis/types/TypeBuilder.java
@@ -553,7 +553,21 @@ public class TypeBuilder {
 
                 // get properties datatype
                 var valueType = parameterizedType.getActualTypeArguments()[1];
-                IType valueDSLType = createDSLTypeForJavaTypeInScope(globalScope, valueType);
+                IType valueDSLType = null;
+                if (valueType instanceof ParameterizedType parameterizedParameterType) {
+                    try {
+                        Class<?> rawType = (Class<?>) parameterizedParameterType.getRawType();
+                        if (rawType.isAnnotationPresent(FunctionalInterface.class)) {
+                            valueDSLType = this.createFunctionType(parameterizedParameterType, globalScope);
+                        }
+                    } catch (ClassCastException ex){
+                        //
+                    }
+                }
+                if (valueDSLType == null) {
+                    valueDSLType = createDSLTypeForJavaTypeInScope(globalScope, valueType);
+                }
+
 
                 // create and bind property symbol
                 PropertySymbol propertySymbol =

--- a/dsl/src/semanticanalysis/types/TypeBuilder.java
+++ b/dsl/src/semanticanalysis/types/TypeBuilder.java
@@ -304,17 +304,23 @@ public class TypeBuilder {
     protected Symbol createCallbackMemberSymbol(
             Field field, AggregateType parentType, IScope globalScope) {
         String callbackName = getDSLFieldName(field);
+        IType callbackType = getCallbackType((ParameterizedType) field.getGenericType(), parentType, globalScope);
+
+        return new Symbol(callbackName, parentType, callbackType);
+    }
+
+    protected IType getCallbackType(
+        ParameterizedType parameterizedType, AggregateType parentType, IScope globalScope) {
+        var rawType = parameterizedType.getRawType();
+        var functionTypeBuilder = functionTypeBuilders.get(rawType);
 
         IType callbackType = BuiltInType.noType;
-        var fieldsClass = field.getType();
-        var functionTypeBuilder = functionTypeBuilders.get(fieldsClass);
-
         if (functionTypeBuilder != null) {
-            callbackType = functionTypeBuilder.buildFunctionType(field.getGenericType(), this, globalScope);
+            callbackType = functionTypeBuilder.buildFunctionType(parameterizedType, this, globalScope);
             callbackType = bindOrResolveTypeInScope(callbackType, globalScope);
         }
 
-        return new Symbol(callbackName, parentType, callbackType);
+        return callbackType;
     }
 
     /**

--- a/dsl/src/semanticanalysis/types/TypeBuilder.java
+++ b/dsl/src/semanticanalysis/types/TypeBuilder.java
@@ -310,7 +310,7 @@ public class TypeBuilder {
         var functionTypeBuilder = functionTypeBuilders.get(fieldsClass);
 
         if (functionTypeBuilder != null) {
-            callbackType = functionTypeBuilder.buildFunctionType(field, this, globalScope);
+            callbackType = functionTypeBuilder.buildFunctionType(field.getGenericType(), this, globalScope);
             callbackType = bindOrResolveTypeInScope(callbackType, globalScope);
         }
 

--- a/dsl/src/semanticanalysis/types/TypeInstantiator.java
+++ b/dsl/src/semanticanalysis/types/TypeInstantiator.java
@@ -5,6 +5,7 @@ import interpreter.DSLInterpreter;
 import runtime.*;
 
 import semanticanalysis.FunctionSymbol;
+import semanticanalysis.ICallable;
 import semanticanalysis.PropertySymbol;
 import semanticanalysis.types.callbackadapter.CallbackAdapter;
 import semanticanalysis.types.callbackadapter.CallbackAdapterBuilder;
@@ -115,6 +116,11 @@ public class TypeInstantiator {
         return enumInstance;
     }
 
+    private Object instantiateFunctionValue(FunctionValue value) {
+        ICallable callable = value.getCallable();
+        return this.callbackAdapterBuilder.buildAdapter(callable);
+    }
+
     /**
      * Instantiate a {@link List} instance from a {@link ListValue}. Convert every entry of the
      * {@link ListValue} into an Object.
@@ -214,6 +220,8 @@ public class TypeInstantiator {
                 convertedObject = instantiateSet((SetValue) value);
             } else if (valuesType.getTypeKind().equals(IType.Kind.EnumType)) {
                 convertedObject = instantiateEnum((EnumValue) value);
+            } else if (valuesType.getTypeKind().equals(IType.Kind.FunctionType)) {
+                convertedObject = instantiateFunctionValue((FunctionValue) value);
             } else if (valuesType.getTypeKind().equals(IType.Kind.Aggregate)) {
                 if (convertedObject == null) {
                     // if the value is a prototype, instantiation is handled by
@@ -355,7 +363,7 @@ public class TypeInstantiator {
                     }
                 }
                 if (field.isAnnotationPresent(DSLCallback.class)) {
-                    if (fieldValue != Value.NONE) {
+                    if (fieldValue != Value.NONE && fieldValue != FunctionValue.NONE) {
                         assert fieldValue.getDataType().getTypeKind() == IType.Kind.FunctionType;
                         FunctionValue functionValue = (FunctionValue) fieldValue;
                         if (!(functionValue.getCallable()

--- a/dsl/src/semanticanalysis/types/TypeInstantiator.java
+++ b/dsl/src/semanticanalysis/types/TypeInstantiator.java
@@ -22,7 +22,8 @@ public class TypeInstantiator {
                             IType.Kind.SetType,
                             IType.Kind.ListType,
                             IType.Kind.Basic,
-                            IType.Kind.EnumType));
+                            IType.Kind.EnumType,
+                            IType.Kind.FunctionType));
     private final HashMap<String, Object> context = new HashMap<>();
     private final CallbackAdapterBuilder callbackAdapterBuilder;
 

--- a/dsl/src/semanticanalysis/types/callbackadapter/BiFunctionCallbackAdapter.java
+++ b/dsl/src/semanticanalysis/types/callbackadapter/BiFunctionCallbackAdapter.java
@@ -4,15 +4,15 @@ import interpreter.DSLInterpreter;
 
 import runtime.RuntimeEnvironment;
 
-import semanticanalysis.FunctionSymbol;
+import semanticanalysis.ICallable;
 
 import java.util.function.BiFunction;
 
 public class BiFunctionCallbackAdapter extends CallbackAdapter implements BiFunction {
 
     BiFunctionCallbackAdapter(
-            RuntimeEnvironment rtEnv, FunctionSymbol functionSymbol, DSLInterpreter interpreter) {
-        super(rtEnv, functionSymbol, interpreter);
+            RuntimeEnvironment rtEnv, ICallable callable, DSLInterpreter interpreter) {
+        super(rtEnv, callable, interpreter);
     }
 
     @Override

--- a/dsl/src/semanticanalysis/types/callbackadapter/BiFunctionFunctionTypeBuilder.java
+++ b/dsl/src/semanticanalysis/types/callbackadapter/BiFunctionFunctionTypeBuilder.java
@@ -17,8 +17,7 @@ public class BiFunctionFunctionTypeBuilder implements IFunctionTypeBuilder {
 
     @Override
     public FunctionType buildFunctionType(
-            Field field, TypeBuilder typeBuilder, IScope globalScope) {
-        var genericType = field.getGenericType();
+            Type genericType, TypeBuilder typeBuilder, IScope globalScope) {
 
         var parameterizedType = (ParameterizedType) genericType;
         Type[] typeArray = parameterizedType.getActualTypeArguments();

--- a/dsl/src/semanticanalysis/types/callbackadapter/BiFunctionFunctionTypeBuilder.java
+++ b/dsl/src/semanticanalysis/types/callbackadapter/BiFunctionFunctionTypeBuilder.java
@@ -5,7 +5,6 @@ import semanticanalysis.types.FunctionType;
 import semanticanalysis.types.IType;
 import semanticanalysis.types.TypeBuilder;
 
-import java.lang.reflect.Field;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 

--- a/dsl/src/semanticanalysis/types/callbackadapter/BiFunctionFunctionTypeBuilder.java
+++ b/dsl/src/semanticanalysis/types/callbackadapter/BiFunctionFunctionTypeBuilder.java
@@ -16,10 +16,11 @@ public class BiFunctionFunctionTypeBuilder implements IFunctionTypeBuilder {
 
     @Override
     public FunctionType buildFunctionType(
-            Type genericType, TypeBuilder typeBuilder, IScope globalScope) {
+            ParameterizedType parameterizedFunctionType,
+            TypeBuilder typeBuilder,
+            IScope globalScope) {
 
-        var parameterizedType = (ParameterizedType) genericType;
-        Type[] typeArray = parameterizedType.getActualTypeArguments();
+        Type[] typeArray = parameterizedFunctionType.getActualTypeArguments();
 
         // the first type parameter of the BiFunction<T,U,R> interface will correspond to
         // the type of the first parameter of the function

--- a/dsl/src/semanticanalysis/types/callbackadapter/CallbackAdapter.java
+++ b/dsl/src/semanticanalysis/types/callbackadapter/CallbackAdapter.java
@@ -4,11 +4,9 @@ import core.utils.TriConsumer;
 
 import interpreter.DSLInterpreter;
 
-import parser.ast.FuncDefNode;
-
 import runtime.*;
 
-import semanticanalysis.FunctionSymbol;
+import semanticanalysis.ICallable;
 import semanticanalysis.types.FunctionType;
 
 import java.util.Arrays;
@@ -23,24 +21,21 @@ public class CallbackAdapter implements Consumer, TriConsumer {
 
     private final RuntimeEnvironment rtEnv;
     private final FunctionType functionType;
-    private final FuncDefNode funcDefNode;
+    private final ICallable callable;
     private final DSLInterpreter interpreter;
 
-    CallbackAdapter(
-            RuntimeEnvironment rtEnv, FunctionSymbol functionSymbol, DSLInterpreter interpreter) {
+    CallbackAdapter(RuntimeEnvironment rtEnv, ICallable callable, DSLInterpreter interpreter) {
         this.rtEnv = rtEnv;
-        this.functionType = (FunctionType) functionSymbol.getDataType();
-        this.funcDefNode = functionSymbol.getAstRootNode();
+        this.functionType = callable.getFunctionType();
+        this.callable = callable;
         this.interpreter = interpreter;
     }
 
     public Object call(Object... params) {
-        var functionSymbol = rtEnv.getSymbolTable().getSymbolsForAstNode(funcDefNode).get(0);
-
-        var returnValue =
+        Value returnValue =
                 (Value)
-                        interpreter.executeUserDefinedFunctionRawParameters(
-                                (FunctionSymbol) functionSymbol, Arrays.stream(params).toList());
+                        interpreter.callCallableRawParameters(
+                                this.callable, Arrays.stream(params).toList());
 
         return convertValueToObject(returnValue);
     }

--- a/dsl/src/semanticanalysis/types/callbackadapter/CallbackAdapterBuilder.java
+++ b/dsl/src/semanticanalysis/types/callbackadapter/CallbackAdapterBuilder.java
@@ -2,7 +2,7 @@ package semanticanalysis.types.callbackadapter;
 
 import interpreter.DSLInterpreter;
 
-import semanticanalysis.FunctionSymbol;
+import semanticanalysis.ICallable;
 import semanticanalysis.types.BuiltInType;
 import semanticanalysis.types.FunctionType;
 
@@ -21,22 +21,21 @@ public class CallbackAdapterBuilder {
      * Build a {@link CallbackAdapter} for a concrete DSL function for assigning to a callback-Field
      * in a Component of the Dungeons ECS.
      *
-     * @param functionSymbol The Symbol representing the function definition
+     * @param callable The {@link ICallable} representing the function
      * @return The created {@link CallbackAdapter}
      */
-    public CallbackAdapter buildAdapter(FunctionSymbol functionSymbol) {
-        FunctionType functionType = (FunctionType) functionSymbol.getDataType();
+    public CallbackAdapter buildAdapter(ICallable callable) {
+        FunctionType functionType = callable.getFunctionType();
         if (functionType.getReturnType() != BuiltInType.noType
                 && functionType.getParameterTypes().size() == 1) {
             return new FunctionCallbackAdapter(
-                    interpreter.getRuntimeEnvironment(), functionSymbol, interpreter);
+                    interpreter.getRuntimeEnvironment(), callable, interpreter);
         } else if (functionType.getReturnType() != BuiltInType.noType
                 && functionType.getParameterTypes().size() == 2) {
             return new BiFunctionCallbackAdapter(
-                    interpreter.getRuntimeEnvironment(), functionSymbol, interpreter);
+                    interpreter.getRuntimeEnvironment(), callable, interpreter);
         } else {
-            return new CallbackAdapter(
-                    interpreter.getRuntimeEnvironment(), functionSymbol, interpreter);
+            return new CallbackAdapter(interpreter.getRuntimeEnvironment(), callable, interpreter);
         }
     }
 }

--- a/dsl/src/semanticanalysis/types/callbackadapter/ConsumerFunctionTypeBuilder.java
+++ b/dsl/src/semanticanalysis/types/callbackadapter/ConsumerFunctionTypeBuilder.java
@@ -7,7 +7,6 @@ import semanticanalysis.types.IType;
 import semanticanalysis.types.TypeBuilder;
 
 import java.lang.reflect.ParameterizedType;
-import java.lang.reflect.Type;
 import java.util.ArrayList;
 
 /**
@@ -22,13 +21,14 @@ public class ConsumerFunctionTypeBuilder implements IFunctionTypeBuilder {
 
     @Override
     public FunctionType buildFunctionType(
-            Type genericType, TypeBuilder typeBuilder, IScope globalScope) {
+            ParameterizedType parameterizedFunctionType,
+            TypeBuilder typeBuilder,
+            IScope globalScope) {
 
-        var parameterizedType = (ParameterizedType) genericType;
         // the parameters will be the arguments for the function
         ArrayList<IType> parameterTypes =
-                new ArrayList<>(parameterizedType.getActualTypeArguments().length);
-        for (var parameterType : parameterizedType.getActualTypeArguments()) {
+                new ArrayList<>(parameterizedFunctionType.getActualTypeArguments().length);
+        for (var parameterType : parameterizedFunctionType.getActualTypeArguments()) {
             IType dslType = typeBuilder.createDSLTypeForJavaTypeInScope(globalScope, parameterType);
             if (null == dslType) {
                 throw new RuntimeException("Type of parameter of Consumer could not be translated");

--- a/dsl/src/semanticanalysis/types/callbackadapter/ConsumerFunctionTypeBuilder.java
+++ b/dsl/src/semanticanalysis/types/callbackadapter/ConsumerFunctionTypeBuilder.java
@@ -6,7 +6,6 @@ import semanticanalysis.types.FunctionType;
 import semanticanalysis.types.IType;
 import semanticanalysis.types.TypeBuilder;
 
-import java.lang.reflect.Field;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
@@ -23,7 +22,7 @@ public class ConsumerFunctionTypeBuilder implements IFunctionTypeBuilder {
 
     @Override
     public FunctionType buildFunctionType(
-        Type genericType, TypeBuilder typeBuilder, IScope globalScope) {
+            Type genericType, TypeBuilder typeBuilder, IScope globalScope) {
 
         var parameterizedType = (ParameterizedType) genericType;
         // the parameters will be the arguments for the function

--- a/dsl/src/semanticanalysis/types/callbackadapter/ConsumerFunctionTypeBuilder.java
+++ b/dsl/src/semanticanalysis/types/callbackadapter/ConsumerFunctionTypeBuilder.java
@@ -8,6 +8,7 @@ import semanticanalysis.types.TypeBuilder;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
 import java.util.ArrayList;
 
 /**
@@ -22,8 +23,7 @@ public class ConsumerFunctionTypeBuilder implements IFunctionTypeBuilder {
 
     @Override
     public FunctionType buildFunctionType(
-            Field field, TypeBuilder typeBuilder, IScope globalScope) {
-        var genericType = field.getGenericType();
+        Type genericType, TypeBuilder typeBuilder, IScope globalScope) {
 
         var parameterizedType = (ParameterizedType) genericType;
         // the parameters will be the arguments for the function

--- a/dsl/src/semanticanalysis/types/callbackadapter/FunctionCallbackAdapter.java
+++ b/dsl/src/semanticanalysis/types/callbackadapter/FunctionCallbackAdapter.java
@@ -4,15 +4,15 @@ import interpreter.DSLInterpreter;
 
 import runtime.RuntimeEnvironment;
 
-import semanticanalysis.FunctionSymbol;
+import semanticanalysis.ICallable;
 
 import java.util.function.Function;
 
 public class FunctionCallbackAdapter extends CallbackAdapter implements Function {
 
     FunctionCallbackAdapter(
-            RuntimeEnvironment rtEnv, FunctionSymbol functionSymbol, DSLInterpreter interpreter) {
-        super(rtEnv, functionSymbol, interpreter);
+            RuntimeEnvironment rtEnv, ICallable callable, DSLInterpreter interpreter) {
+        super(rtEnv, callable, interpreter);
     }
 
     @Override

--- a/dsl/src/semanticanalysis/types/callbackadapter/FunctionFunctionTypeBuilder.java
+++ b/dsl/src/semanticanalysis/types/callbackadapter/FunctionFunctionTypeBuilder.java
@@ -20,10 +20,11 @@ public class FunctionFunctionTypeBuilder implements IFunctionTypeBuilder {
 
     @Override
     public FunctionType buildFunctionType(
-            Type genericType, TypeBuilder typeBuilder, IScope globalScope) {
+            ParameterizedType parameterizedFunctionType,
+            TypeBuilder typeBuilder,
+            IScope globalScope) {
 
-        var parameterizedType = (ParameterizedType) genericType;
-        Type[] typeArray = parameterizedType.getActualTypeArguments();
+        Type[] typeArray = parameterizedFunctionType.getActualTypeArguments();
 
         // the first type parameter of the Function<T,R> interface will correspond to
         // the type of the single parameter of the function

--- a/dsl/src/semanticanalysis/types/callbackadapter/FunctionFunctionTypeBuilder.java
+++ b/dsl/src/semanticanalysis/types/callbackadapter/FunctionFunctionTypeBuilder.java
@@ -21,8 +21,7 @@ public class FunctionFunctionTypeBuilder implements IFunctionTypeBuilder {
 
     @Override
     public FunctionType buildFunctionType(
-            Field field, TypeBuilder typeBuilder, IScope globalScope) {
-        var genericType = field.getGenericType();
+            Type genericType, TypeBuilder typeBuilder, IScope globalScope) {
 
         var parameterizedType = (ParameterizedType) genericType;
         Type[] typeArray = parameterizedType.getActualTypeArguments();

--- a/dsl/src/semanticanalysis/types/callbackadapter/FunctionFunctionTypeBuilder.java
+++ b/dsl/src/semanticanalysis/types/callbackadapter/FunctionFunctionTypeBuilder.java
@@ -5,7 +5,6 @@ import semanticanalysis.types.FunctionType;
 import semanticanalysis.types.IType;
 import semanticanalysis.types.TypeBuilder;
 
-import java.lang.reflect.Field;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 

--- a/dsl/src/semanticanalysis/types/callbackadapter/IFunctionTypeBuilder.java
+++ b/dsl/src/semanticanalysis/types/callbackadapter/IFunctionTypeBuilder.java
@@ -4,17 +4,22 @@ import semanticanalysis.IScope;
 import semanticanalysis.types.FunctionType;
 import semanticanalysis.types.TypeBuilder;
 
-import java.lang.reflect.Type;
+import java.lang.reflect.ParameterizedType;
 
 /** Builder interface for a {@link FunctionType} for a callback method */
 public interface IFunctionTypeBuilder {
     /**
      * Build a {@link FunctionType} representing the signature of a callback
      *
-     * @param genericType the generic type of the function type to build
+     * @param parameterizedFunctionType the parameterized type (with generic type information) of
+     *     the function type to build
      * @param typeBuilder {@link TypeBuilder} instance to lookup parameter types
+     * @param globalScope the global {@link IScope} of the {@link runtime.IEvironment} in which to
+     *     build the function type.
      * @return {@link FunctionType} corresponding to the callback signature
      */
-    // FunctionType buildFunctionType(Field field, TypeBuilder typeBuilder, IScope globalScope);
-    FunctionType buildFunctionType(Type genericType, TypeBuilder typeBuilder, IScope globalScope);
+    FunctionType buildFunctionType(
+            ParameterizedType parameterizedFunctionType,
+            TypeBuilder typeBuilder,
+            IScope globalScope);
 }

--- a/dsl/src/semanticanalysis/types/callbackadapter/IFunctionTypeBuilder.java
+++ b/dsl/src/semanticanalysis/types/callbackadapter/IFunctionTypeBuilder.java
@@ -4,7 +4,6 @@ import semanticanalysis.IScope;
 import semanticanalysis.types.FunctionType;
 import semanticanalysis.types.TypeBuilder;
 
-import java.lang.reflect.Field;
 import java.lang.reflect.Type;
 
 /** Builder interface for a {@link FunctionType} for a callback method */
@@ -16,6 +15,6 @@ public interface IFunctionTypeBuilder {
      * @param typeBuilder {@link TypeBuilder} instance to lookup parameter types
      * @return {@link FunctionType} corresponding to the callback signature
      */
-    //FunctionType buildFunctionType(Field field, TypeBuilder typeBuilder, IScope globalScope);
+    // FunctionType buildFunctionType(Field field, TypeBuilder typeBuilder, IScope globalScope);
     FunctionType buildFunctionType(Type genericType, TypeBuilder typeBuilder, IScope globalScope);
 }

--- a/dsl/src/semanticanalysis/types/callbackadapter/IFunctionTypeBuilder.java
+++ b/dsl/src/semanticanalysis/types/callbackadapter/IFunctionTypeBuilder.java
@@ -5,15 +5,17 @@ import semanticanalysis.types.FunctionType;
 import semanticanalysis.types.TypeBuilder;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.Type;
 
 /** Builder interface for a {@link FunctionType} for a callback method */
 public interface IFunctionTypeBuilder {
     /**
      * Build a {@link FunctionType} representing the signature of a callback
      *
-     * @param field The field defining the callback
+     * @param genericType the generic type of the function type to build
      * @param typeBuilder {@link TypeBuilder} instance to lookup parameter types
      * @return {@link FunctionType} corresponding to the callback signature
      */
-    FunctionType buildFunctionType(Field field, TypeBuilder typeBuilder, IScope globalScope);
+    //FunctionType buildFunctionType(Field field, TypeBuilder typeBuilder, IScope globalScope);
+    FunctionType buildFunctionType(Type genericType, TypeBuilder typeBuilder, IScope globalScope);
 }

--- a/dsl/test/interpreter/TestDSLInterpreter.java
+++ b/dsl/test/interpreter/TestDSLInterpreter.java
@@ -31,6 +31,7 @@ import semanticanalysis.types.*;
 
 import task.QuestItem;
 import task.Quiz;
+import task.TaskContent;
 
 import taskdependencygraph.TaskDependencyGraph;
 import taskdependencygraph.TaskEdge;
@@ -3588,5 +3589,59 @@ public class TestDSLInterpreter {
         // Assert.assertEquals("MyName", item.displayName());
         Quiz.Content content = (Quiz.Content) item.taskContentComponent().content();
         Assert.assertEquals("2", content.content());
+    }
+
+    @Test
+    public void testSetGradingFuncSingleChoice() {
+        String program =
+                """
+            single_choice_task t1 {
+                description: "Task1",
+                    answers: ["1", "2", "3"],
+                correct_answer_index: 2,
+                grading_function: grade_single_choice_task
+            }
+
+            graph g {
+                t1
+            }
+
+            dungeon_config c {
+                dependency_graph: g
+            }
+
+            item_type item_type1 {
+                display_name: "MyName",
+                description: "Hello, this is a description",
+                texture_path: "items/book/wisdom_scroll.png"
+            }
+
+            fn build_scenario1(single_choice_task t) -> entity<><> {
+                var ret_set : entity<><>;
+
+                var first_room_set : entity<>;
+
+                var item : quest_item;
+                var content : task_content[];
+                content = t.get_content();
+
+                item = build_quest_item(item_type1, content.get(1));
+                place_quest_item(item, first_room_set);
+
+                ret_set.add(first_room_set);
+                return ret_set;
+            }
+        """;
+
+        DSLInterpreter interpreter = new DSLInterpreter();
+        DungeonConfig config = (DungeonConfig) interpreter.getQuestConfig(program);
+        var task = config.dependencyGraph().nodeIterator().next().task();
+        var builtTask = (HashSet<HashSet<core.Entity>>) interpreter.buildTask(task).get();
+
+        TaskContent content = task.contentByIndex(2);
+        HashSet<TaskContent> tcSet = new HashSet<>();
+        tcSet.add(content);
+        var score = (Float) task.scoringFunction().apply(task, tcSet);
+        Assert.assertEquals((Float) 1.0f, score);
     }
 }

--- a/dsl/test/interpreter/TestDSLInterpreter.java
+++ b/dsl/test/interpreter/TestDSLInterpreter.java
@@ -3626,7 +3626,7 @@ public class TestDSLInterpreter {
     @Test
     public void testSetGradingFuncMultipleChoice() {
         String program =
-            """
+                """
         multiple_choice_task t1 {
             description: "Task1",
             answers: ["1", "2", "3"],
@@ -3655,7 +3655,7 @@ public class TestDSLInterpreter {
     @Test
     public void testSetGradingFunctionInScenarioBuilderSingleChoice() {
         String program =
-            """
+                """
         single_choice_task t1 {
             description: "Task1",
             answers: ["1", "2", "3"],

--- a/dsl/test/interpreter/mockecs/TestComponent2.java
+++ b/dsl/test/interpreter/mockecs/TestComponent2.java
@@ -2,6 +2,7 @@ package interpreter.mockecs;
 
 import semanticanalysis.types.*;
 
+import java.lang.reflect.Type;
 import java.util.Arrays;
 import java.util.List;
 
@@ -61,8 +62,8 @@ public class TestComponent2 extends Component {
         }
 
         @Override
-        public List<Class<?>> getParameterTypes() {
-            var arr = new Class<?>[] {Integer.class, Integer.class};
+        public List<Type> getParameterTypes() {
+            var arr = new Type[] {Integer.class, Integer.class};
             return Arrays.stream(arr).toList();
         }
     }

--- a/dungeon/src/task/taskdsltypes/MultipleChoiceTask.java
+++ b/dungeon/src/task/taskdsltypes/MultipleChoiceTask.java
@@ -12,6 +12,7 @@ import task.Task;
 import task.TaskContent;
 import task.quizquestion.MultipleChoice;
 
+import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.*;
 import java.util.function.BiFunction;
@@ -89,6 +90,74 @@ public class MultipleChoiceTask {
         public List<Type> getParameterTypes() {
             var arr = new Type[] {};
             return Arrays.stream(arr).toList();
+        }
+    }
+
+    /**
+     * {@link IDSLExtensionMethod} to set the grading function of a {@link MultipleChoice} instance.
+     */
+    @DSLExtensionMethod(name = "set_grading_function", extendedType = MultipleChoice.class)
+    public static class MultipleChoiceSetGradingFunction
+            implements IDSLExtensionMethod<MultipleChoice, Void> {
+        public static MultipleChoiceTask.MultipleChoiceSetGradingFunction instance =
+                new MultipleChoiceTask.MultipleChoiceSetGradingFunction();
+
+        @Override
+        public Void call(MultipleChoice instance, List<Object> params) {
+            var func = (BiFunction<Task, Set<TaskContent>, Float>) params.get(0);
+            instance.scoringFunction(func);
+            return null;
+        }
+
+        // region parameterized parameter type declaration
+
+        // The TypeBuilder needs an implementation of ParameterizedType (with the actual type
+        // information)
+        // to create a FunctionType for the method parameter. As this method will accept a
+        // BiFunction<Task, Set<TaskContent>, Float> as a parameter, we need to build this
+        // ParameterizedType here by ourselves.
+        private static final ParameterizedType biFuncType =
+                new ParameterizedType() {
+                    @Override
+                    public Type[] getActualTypeArguments() {
+                        return new Type[] {Task.class, setType, Float.class};
+                    }
+
+                    @Override
+                    public Type getRawType() {
+                        return BiFunction.class;
+                    }
+
+                    @Override
+                    public Type getOwnerType() {
+                        return null;
+                    }
+                };
+
+        private static final ParameterizedType setType =
+                new ParameterizedType() {
+                    @Override
+                    public Type[] getActualTypeArguments() {
+                        return new Type[] {TaskContent.class};
+                    }
+
+                    @Override
+                    public Type getRawType() {
+                        return Set.class;
+                    }
+
+                    @Override
+                    public Type getOwnerType() {
+                        return null;
+                    }
+                };
+
+        // endregion
+
+        @Override
+        public List<Type> getParameterTypes() {
+            var typeArr = new Type[] {biFuncType};
+            return Arrays.stream(typeArr).toList();
         }
     }
 }

--- a/dungeon/src/task/taskdsltypes/MultipleChoiceTask.java
+++ b/dungeon/src/task/taskdsltypes/MultipleChoiceTask.java
@@ -14,6 +14,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
+import java.util.function.BiFunction;
 
 /** Typeadapter for creation of {@link MultipleChoice} instances via dsl. */
 public class MultipleChoiceTask {
@@ -21,9 +22,8 @@ public class MultipleChoiceTask {
     public static MultipleChoice buildQuizFromMultipleChoiceTask(
             @DSLTypeMember(name = "description") String description,
             @DSLTypeMember(name = "answers") List<Quiz.Content> answers,
-            @DSLTypeMember(name = "correct_answer_index") List<Integer> correctAnswerIndices // ,
-            // TODO: siehe https://github.com/Programmiermethoden/Dungeon/issues/916
-            //  @DSLTypeMember(name="score_function") BiFunction<Task, Set<Quiz.Content>, Float>
+            @DSLTypeMember(name = "correct_answer_index") List<Integer> correctAnswerIndices,
+            @DSLTypeMember(name="grading_function") BiFunction<Task, Set<TaskContent>, Float> gradingFunction
             //  scoreFunction
             ) {
         MultipleChoice mc = new MultipleChoice(description);
@@ -35,7 +35,7 @@ public class MultipleChoiceTask {
         for (var index : correctAnswerIndices) {
             mc.addCorrectAnswerIndex(index);
         }
-        mc.scoringFunction(MultipleChoiceTask::score);
+        mc.scoringFunction(gradingFunction);
 
         return mc;
     }

--- a/dungeon/src/task/taskdsltypes/MultipleChoiceTask.java
+++ b/dungeon/src/task/taskdsltypes/MultipleChoiceTask.java
@@ -1,5 +1,6 @@
 package task.taskdsltypes;
 
+import reporting.GradingFunctions;
 import semanticanalysis.types.DSLExtensionMethod;
 import semanticanalysis.types.DSLTypeAdapter;
 import semanticanalysis.types.DSLTypeMember;
@@ -10,10 +11,8 @@ import task.Task;
 import task.TaskContent;
 import task.quizquestion.MultipleChoice;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Set;
+import java.lang.reflect.Type;
+import java.util.*;
 import java.util.function.BiFunction;
 
 /** Typeadapter for creation of {@link MultipleChoice} instances via dsl. */
@@ -35,7 +34,9 @@ public class MultipleChoiceTask {
         for (var index : correctAnswerIndices) {
             mc.addCorrectAnswerIndex(index);
         }
-        mc.scoringFunction(gradingFunction);
+
+        // default value
+        mc.scoringFunction(Objects.requireNonNullElseGet(gradingFunction, GradingFunctions::multipeChoiceGrading));
 
         return mc;
     }
@@ -81,8 +82,8 @@ public class MultipleChoiceTask {
         }
 
         @Override
-        public List<Class<?>> getParameterTypes() {
-            var arr = new Class<?>[] {};
+        public List<Type> getParameterTypes() {
+            var arr = new Type[] {};
             return Arrays.stream(arr).toList();
         }
     }

--- a/dungeon/src/task/taskdsltypes/MultipleChoiceTask.java
+++ b/dungeon/src/task/taskdsltypes/MultipleChoiceTask.java
@@ -1,6 +1,7 @@
 package task.taskdsltypes;
 
 import reporting.GradingFunctions;
+
 import semanticanalysis.types.DSLExtensionMethod;
 import semanticanalysis.types.DSLTypeAdapter;
 import semanticanalysis.types.DSLTypeMember;
@@ -22,7 +23,8 @@ public class MultipleChoiceTask {
             @DSLTypeMember(name = "description") String description,
             @DSLTypeMember(name = "answers") List<Quiz.Content> answers,
             @DSLTypeMember(name = "correct_answer_index") List<Integer> correctAnswerIndices,
-            @DSLTypeMember(name="grading_function") BiFunction<Task, Set<TaskContent>, Float> gradingFunction
+            @DSLTypeMember(name = "grading_function")
+                    BiFunction<Task, Set<TaskContent>, Float> gradingFunction
             //  scoreFunction
             ) {
         MultipleChoice mc = new MultipleChoice(description);
@@ -36,7 +38,9 @@ public class MultipleChoiceTask {
         }
 
         // default value
-        mc.scoringFunction(Objects.requireNonNullElseGet(gradingFunction, GradingFunctions::multipeChoiceGrading));
+        mc.scoringFunction(
+                Objects.requireNonNullElseGet(
+                        gradingFunction, GradingFunctions::multipeChoiceGrading));
 
         return mc;
     }

--- a/dungeon/src/task/taskdsltypes/SingleChoiceTask.java
+++ b/dungeon/src/task/taskdsltypes/SingleChoiceTask.java
@@ -85,6 +85,9 @@ public class SingleChoiceTask {
         }
     }
 
+    /**
+     * {@link IDSLExtensionMethod} to set the grading function of a {@link SingleChoice} instance.
+     */
     @DSLExtensionMethod(name = "set_grading_function", extendedType = SingleChoice.class)
     public static class SingleChoiceSetGradingFunction
             implements IDSLExtensionMethod<SingleChoice, Void> {

--- a/dungeon/src/task/taskdsltypes/SingleChoiceTask.java
+++ b/dungeon/src/task/taskdsltypes/SingleChoiceTask.java
@@ -1,19 +1,18 @@
 package task.taskdsltypes;
 
-import semanticanalysis.types.DSLExtensionMethod;
-import semanticanalysis.types.DSLTypeAdapter;
-import semanticanalysis.types.DSLTypeMember;
-import semanticanalysis.types.IDSLExtensionMethod;
+import reporting.GradingFunctions;
+import semanticanalysis.types.*;
 
+import task.QuestItem;
 import task.Quiz;
 import task.Task;
 import task.TaskContent;
+import task.components.TaskContentComponent;
 import task.quizquestion.SingleChoice;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Set;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.*;
 import java.util.function.BiFunction;
 
 /** Typeadapter for the creation of {@link SingleChoice} instances via dsl. */
@@ -33,8 +32,8 @@ public class SingleChoiceTask {
         }
 
         sc.addCorrectAnswerIndex(correctAnswerIndex);
-        // sc.scoringFunction(SingleChoiceTask::score);
-        sc.scoringFunction(gradingFunction);
+        // default value
+        sc.scoringFunction(Objects.requireNonNullElseGet(gradingFunction, GradingFunctions::singleChoiceGrading));
 
         return sc;
     }
@@ -79,8 +78,8 @@ public class SingleChoiceTask {
         }
 
         @Override
-        public List<Class<?>> getParameterTypes() {
-            var arr = new Class<?>[] {};
+        public List<Type> getParameterTypes() {
+            var arr = new Type[] {};
             return Arrays.stream(arr).toList();
         }
     }

--- a/dungeon/src/task/taskdsltypes/SingleChoiceTask.java
+++ b/dungeon/src/task/taskdsltypes/SingleChoiceTask.java
@@ -14,6 +14,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
+import java.util.function.BiFunction;
 
 /** Typeadapter for the creation of {@link SingleChoice} instances via dsl. */
 public class SingleChoiceTask {
@@ -22,11 +23,9 @@ public class SingleChoiceTask {
     public static SingleChoice buildQuizFromSingleChoiceTask(
             @DSLTypeMember(name = "description") String description,
             @DSLTypeMember(name = "answers") List<Quiz.Content> answers,
-            @DSLTypeMember(name = "correct_answer_index") int correctAnswerIndex // ,
-            // TODO: siehe https://github.com/Programmiermethoden/Dungeon/issues/916
-            //  @DSLTypeMember(name="score_function") BiFunction<Task, Set<Quiz.Content>, Float>
-            //  scoreFunction
-            ) {
+            @DSLTypeMember(name = "correct_answer_index") int correctAnswerIndex,
+            @DSLTypeMember(name = "grading_function")
+                    BiFunction<Task, Set<TaskContent>, Float> gradingFunction) {
         SingleChoice sc = new SingleChoice(description);
 
         for (Quiz.Content answer : answers) {
@@ -34,7 +33,8 @@ public class SingleChoiceTask {
         }
 
         sc.addCorrectAnswerIndex(correctAnswerIndex);
-        sc.scoringFunction(SingleChoiceTask::score);
+        // sc.scoringFunction(SingleChoiceTask::score);
+        sc.scoringFunction(gradingFunction);
 
         return sc;
     }

--- a/dungeon/src/task/taskdsltypes/SingleChoiceTask.java
+++ b/dungeon/src/task/taskdsltypes/SingleChoiceTask.java
@@ -1,13 +1,12 @@
 package task.taskdsltypes;
 
 import reporting.GradingFunctions;
+
 import semanticanalysis.types.*;
 
-import task.QuestItem;
 import task.Quiz;
 import task.Task;
 import task.TaskContent;
-import task.components.TaskContentComponent;
 import task.quizquestion.SingleChoice;
 
 import java.lang.reflect.ParameterizedType;
@@ -33,7 +32,9 @@ public class SingleChoiceTask {
 
         sc.addCorrectAnswerIndex(correctAnswerIndex);
         // default value
-        sc.scoringFunction(Objects.requireNonNullElseGet(gradingFunction, GradingFunctions::singleChoiceGrading));
+        sc.scoringFunction(
+                Objects.requireNonNullElseGet(
+                        gradingFunction, GradingFunctions::singleChoiceGrading));
 
         return sc;
     }
@@ -85,62 +86,66 @@ public class SingleChoiceTask {
     }
 
     @DSLExtensionMethod(name = "set_grading_function", extendedType = SingleChoice.class)
-    public static class SingleChoiceSetGradingFunction implements IDSLExtensionMethod<SingleChoice, Void> {
-        public static SingleChoiceTask.SingleChoiceSetGradingFunction instance = new SingleChoiceTask.SingleChoiceSetGradingFunction();
-
+    public static class SingleChoiceSetGradingFunction
+            implements IDSLExtensionMethod<SingleChoice, Void> {
+        public static SingleChoiceTask.SingleChoiceSetGradingFunction instance =
+                new SingleChoiceTask.SingleChoiceSetGradingFunction();
 
         @Override
         public Void call(SingleChoice instance, List<Object> params) {
-            var func = (BiFunction<Task, Set<TaskContent>, Float> )params.get(0);
+            var func = (BiFunction<Task, Set<TaskContent>, Float>) params.get(0);
             instance.scoringFunction(func);
             return null;
         }
 
         // region parameterized parameter type declaration
 
-        // The TypeBuilder needs an implementation of ParameterizedType (with the actual type information)
+        // The TypeBuilder needs an implementation of ParameterizedType (with the actual type
+        // information)
         // to create a FunctionType for the method parameter. As this method will accept a
         // BiFunction<Task, Set<TaskContent>, Float> as a parameter, we need to build this
         // ParameterizedType here by ourselves.
-        private final static ParameterizedType biFuncType = new ParameterizedType() {
-            @Override
-            public Type[] getActualTypeArguments() {
-                return new Type[]{Task.class, setType, Float.class};
-            }
+        private static final ParameterizedType biFuncType =
+                new ParameterizedType() {
+                    @Override
+                    public Type[] getActualTypeArguments() {
+                        return new Type[] {Task.class, setType, Float.class};
+                    }
 
-            @Override
-            public Type getRawType() {
-                return BiFunction.class;
-            }
+                    @Override
+                    public Type getRawType() {
+                        return BiFunction.class;
+                    }
 
-            @Override
-            public Type getOwnerType() {
-                return null;
-            }
-        };
+                    @Override
+                    public Type getOwnerType() {
+                        return null;
+                    }
+                };
 
-        private final static ParameterizedType setType = new ParameterizedType() {
-            @Override
-            public Type[] getActualTypeArguments() {
-                return new Type[]{TaskContent.class};
-            }
+        private static final ParameterizedType setType =
+                new ParameterizedType() {
+                    @Override
+                    public Type[] getActualTypeArguments() {
+                        return new Type[] {TaskContent.class};
+                    }
 
-            @Override
-            public Type getRawType() {
-                return Set.class;
-            }
+                    @Override
+                    public Type getRawType() {
+                        return Set.class;
+                    }
 
-            @Override
-            public Type getOwnerType() {
-                return null;
-            }
-        };
+                    @Override
+                    public Type getOwnerType() {
+                        return null;
+                    }
+                };
 
         // endregion
 
         @Override
         public List<Type> getParameterTypes() {
-            var typeArr = new Type[]{biFuncType};
+            var typeArr = new Type[] {biFuncType};
             return Arrays.stream(typeArr).toList();
         }
     }

--- a/dungeon/src/task/taskdsltypes/SingleChoiceTask.java
+++ b/dungeon/src/task/taskdsltypes/SingleChoiceTask.java
@@ -83,4 +83,65 @@ public class SingleChoiceTask {
             return Arrays.stream(arr).toList();
         }
     }
+
+    @DSLExtensionMethod(name = "set_grading_function", extendedType = SingleChoice.class)
+    public static class SingleChoiceSetGradingFunction implements IDSLExtensionMethod<SingleChoice, Void> {
+        public static SingleChoiceTask.SingleChoiceSetGradingFunction instance = new SingleChoiceTask.SingleChoiceSetGradingFunction();
+
+
+        @Override
+        public Void call(SingleChoice instance, List<Object> params) {
+            var func = (BiFunction<Task, Set<TaskContent>, Float> )params.get(0);
+            instance.scoringFunction(func);
+            return null;
+        }
+
+        // region parameterized parameter type declaration
+
+        // The TypeBuilder needs an implementation of ParameterizedType (with the actual type information)
+        // to create a FunctionType for the method parameter. As this method will accept a
+        // BiFunction<Task, Set<TaskContent>, Float> as a parameter, we need to build this
+        // ParameterizedType here by ourselves.
+        private final static ParameterizedType biFuncType = new ParameterizedType() {
+            @Override
+            public Type[] getActualTypeArguments() {
+                return new Type[]{Task.class, setType, Float.class};
+            }
+
+            @Override
+            public Type getRawType() {
+                return BiFunction.class;
+            }
+
+            @Override
+            public Type getOwnerType() {
+                return null;
+            }
+        };
+
+        private final static ParameterizedType setType = new ParameterizedType() {
+            @Override
+            public Type[] getActualTypeArguments() {
+                return new Type[]{TaskContent.class};
+            }
+
+            @Override
+            public Type getRawType() {
+                return Set.class;
+            }
+
+            @Override
+            public Type getOwnerType() {
+                return null;
+            }
+        };
+
+        // endregion
+
+        @Override
+        public List<Type> getParameterTypes() {
+            var typeArr = new Type[]{biFuncType};
+            return Arrays.stream(typeArr).toList();
+        }
+    }
 }


### PR DESCRIPTION
Fixes #916 

Fügt die Möglichkeit hinzu, auch Native Funktionen (also Funktionen, die nicht in der DSL selbst definiert werden) als `CallbackAdapter` zu verpacken und damit als Callback zu verwenden.

Integriert die `singleChoiceGrading` und `multipleChoiceGrading` Funktionen aus `GradingFunctions` als native Funktionen in die DSL. Fügt Extension Methoden zu Single und Multiplechoice tasks hinzu, um auch nachträglich grading funktion setzen zu können.

Kleine Bugfixes (siehe commit messages).

~TODO:~
- [x] Javadoc
- [x] Aufräumen