### PR TITLE
[GAME] fix bug where an absolut path was used to link the font for the gui

### DIFF
--- a/game/src/contrib/hud/crafting/CraftingGUI.java
+++ b/game/src/contrib/hud/crafting/CraftingGUI.java
@@ -1,6 +1,6 @@
 package contrib.hud.crafting;
 
-import com.badlogic.gdx.files.FileHandle;
+import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.Batch;
@@ -48,6 +48,9 @@ import java.util.Arrays;
  * percentage of the height of the crafting GUI.
  */
 public class CraftingGUI extends CombinableGUI {
+
+    private static final String FONT_FNT = "skin/myFont.fnt";
+    private static final String FONT_PNG = "skin/myFont.png";
 
     // Position settings
     private static final int NUMBER_PADDING = 5;
@@ -110,10 +113,7 @@ public class CraftingGUI extends CombinableGUI {
 
         // Init Font
         bitmapFont =
-                new BitmapFont(
-                        new FileHandle("./game/assets/skin/myFont.fnt"),
-                        new FileHandle("./game/assets/skin/myFont.png"),
-                        false);
+                new BitmapFont(Gdx.files.internal(FONT_FNT), Gdx.files.internal(FONT_PNG), false);
     }
 
     private final ArrayList<Item> items = new ArrayList<>();

--- a/game/src/contrib/hud/inventory/InventoryGUI.java
+++ b/game/src/contrib/hud/inventory/InventoryGUI.java
@@ -2,7 +2,6 @@ package contrib.hud.inventory;
 
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input;
-import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.graphics.Texture;
@@ -27,6 +26,8 @@ import core.components.PositionComponent;
 
 public class InventoryGUI extends CombinableGUI {
 
+    private static final String FONT_FNT = "skin/myFont.fnt";
+    private static final String FONT_PNG = "skin/myFont.png";
     private static final int MAX_ITEMS_PER_ROW = 8;
     private static final int BORDER_COLOR = 0x9dc1ebff;
     private static final int BACKGROUND_COLOR = 0x3e3e63e1;
@@ -54,10 +55,7 @@ public class InventoryGUI extends CombinableGUI {
         background = new TextureRegion(texture, 0, 0, 1, 1);
         hoverBackground = new TextureRegion(texture, 1, 0, 1, 1);
         bitmapFont =
-                new BitmapFont(
-                        new FileHandle("./game/assets/skin/myFont.fnt"),
-                        new FileHandle("./game/assets/skin/myFont.png"),
-                        false);
+                new BitmapFont(Gdx.files.internal(FONT_FNT), Gdx.files.internal(FONT_PNG), false);
     }
 
     private final InventoryComponent inventoryComponent;


### PR DESCRIPTION
fix #1138 

anstelle des `FileHandler` mit absoluten Pfad wird nun der Pfad via `Gdx.files.internal` bestimmt.
Damit läuft das Inventar auch in der jar
