### PR TITLE
[GAME] add god-mode (option to make the player invincible) 

### DIFF
--- a/game/src/contrib/components/HealthComponent.java
+++ b/game/src/contrib/components/HealthComponent.java
@@ -44,6 +44,8 @@ public final class HealthComponent implements Component {
     private int currentHealthpoints;
     private @Null Entity lastCause = null;
 
+    private boolean godMode = false;
+
     /**
      * Create a new HealthComponent.
      *
@@ -128,6 +130,7 @@ public final class HealthComponent implements Component {
      */
     public void currentHealthpoints(int amount) {
         this.currentHealthpoints = Math.min(maximalHealthpoints, amount);
+        if (godMode) this.currentHealthpoints = Math.max(currentHealthpoints, 1);
     }
 
     /**
@@ -177,5 +180,16 @@ public final class HealthComponent implements Component {
      */
     public boolean isDead() {
         return currentHealthpoints <= 0;
+    }
+
+    /**
+     * Activate or deactivate the god mode-
+     *
+     * <p>in god mode the entity can not die.
+     *
+     * @param status true to actiavte, false to deactivate.
+     */
+    public void godMode(boolean status) {
+        this.godMode = status;
     }
 }

--- a/game/test/contrib/systems/HealthSystemTest.java
+++ b/game/test/contrib/systems/HealthSystemTest.java
@@ -49,6 +49,28 @@ public class HealthSystemTest {
     }
 
     @Test
+    public void updateEntityDiesGodMode() throws IOException {
+        Game.removeAllEntities();
+        Entity entity = new Entity();
+        Consumer<Entity> onDeath = Mockito.mock(Consumer.class);
+        DrawComponent ac = new DrawComponent(ANIMATION_PATH);
+        HealthComponent component = new HealthComponent(1, onDeath);
+        component.godMode(true);
+        entity.addComponent(ac);
+        entity.addComponent(component);
+        Game.add(entity);
+        HealthSystem system = new HealthSystem();
+        Game.add(system);
+        component.currentHealthpoints(0);
+        system.execute();
+        assertFalse(
+                "Entity can not die, so dont show die animation",
+                ac.isCurrentAnimation(AdditionalAnimations.DIE));
+        assertTrue(
+                "Entity should still be in game.", Game.entityStream().anyMatch(e -> e == entity));
+    }
+
+    @Test
     public void updateEntityGetDamage() throws IOException {
         Game.removeAllEntities();
         Entity entity = new Entity();


### PR DESCRIPTION
Fügt die `HealthComponent ` eine Option hinzu in den "god mode" zu gehen.
Im god-mode kann die HP nicht unter 1 fallen, daher kann die Entität nicht sterben.

Das könnte für die Evaluierung nützlich werden, da wir noch kein Save and Load System haben und die Studis bestimmt kein spaß daran haben, immer wieder von vorne anzufangen. 