### PR TITLE
[GAME] fix bug where Chest in EntityFactory could be placed out of level

### DIFF
--- a/game/src/contrib/entities/EntityFactory.java
+++ b/game/src/contrib/entities/EntityFactory.java
@@ -275,7 +275,7 @@ public class EntityFactory {
                 IntStream.range(0, RANDOM.nextInt(1, 3))
                         .mapToObj(i -> itemDataGenerator.generateItemData())
                         .collect(Collectors.toSet());
-        return newChest(items, null);
+        return newChest(items, PositionComponent.ILLEGAL_POSITION);
     }
 
     /**

--- a/game/test/contrib/entities/ChestTest.java
+++ b/game/test/contrib/entities/ChestTest.java
@@ -127,5 +127,24 @@ public class ChestTest {
         assertTrue(
                 "Chest should have at least 1 Item",
                 1 <= inventoryComponent.map(InventoryComponent.class::cast).get().items().length);
+
+        assertEquals(
+                "x Position has to be ILLEGAL",
+                PositionComponent.ILLEGAL_POSITION.x,
+                newChest.fetch(PositionComponent.class)
+                        .map(PositionComponent.class::cast)
+                        .get()
+                        .position()
+                        .x,
+                0.00001f);
+        assertEquals(
+                "y Position has to be ILLEGAL",
+                PositionComponent.ILLEGAL_POSITION.y,
+                newChest.fetch(PositionComponent.class)
+                        .map(PositionComponent.class::cast)
+                        .get()
+                        .position()
+                        .y,
+                0.00001f);
     }
 }


### PR DESCRIPTION
Mit der `EntityFactory` konnten Kisten generiert werden ohne eine Position zu übergeben.
In diesen Fall wurde ein zufälliges (betretbares) Tile im aktuellen Level ausgewählt und die Kiste dort platziert.
Wenn ich die Kiste aber generiere, um sie in einen anderen Raum als den grade aktiven zu platzieren, ist diese Position ggf. ungültig.


Da wir das Problem schon an andere stelle hatten, haben wir dafür da `PositionSystem` und die `ILLEGAL_POSITION` eingeführt.

tldr: Kisten werden jetzt initial mit der ILLEGAL POSITION initalisiert und dann vom System zufällig verteilt. 




Anmerkung: Das ist  #1135 nochmal "neu", nachdem ich den rebase braindead verhauen habe.