### PR TITLE
[DSL] Fügt Assignment Tasks (Zuordnungsaufgaben) zur DSL hinzu.

### DIFF
--- a/dsl/src/antlr/DungeonDSL.g4
+++ b/dsl/src/antlr/DungeonDSL.g4
@@ -70,8 +70,8 @@ stmt
     ;
 
 loop_stmt
-    : 'for' type_id=ID var_id=ID 'in' iteratable_id=expression stmt                         #for_loop
-    | 'for' type_id=ID var_id=ID 'in' iteratable_id=expression 'count' counter_id=ID stmt   #for_loop_counting
+    : 'for' type_id=type_decl var_id=ID 'in' iteratable_id=expression stmt                         #for_loop
+    | 'for' type_id=type_decl var_id=ID 'in' iteratable_id=expression 'count' counter_id=ID stmt   #for_loop_counting
     | 'while' expression stmt                                                               #while_loop
     ;
 

--- a/dsl/src/antlr/DungeonDSL.g4
+++ b/dsl/src/antlr/DungeonDSL.g4
@@ -169,9 +169,10 @@ param_def
     ;
 
 type_decl
-    : type_decl '<>'   #set_param_type
-    | type_decl '[]'   #list_param_type
-    | ID                #id_param_type
+    : type_decl '<>'                        #set_param_type
+    | type_decl '[]'                        #list_param_type
+    | '[' type_decl ARROW  type_decl ']'    #map_param_type
+    | ID                                    #id_param_type
     ;
 
 param_def_list

--- a/dsl/src/interpreter/DSLEntryPointFinder.java
+++ b/dsl/src/interpreter/DSLEntryPointFinder.java
@@ -113,6 +113,11 @@ public class DSLEntryPointFinder implements AstVisitor<Object> {
     }
 
     @Override
+    public Object visit(MapTypeIdentifierNode node) {
+        return node.getName();
+    }
+
+    @Override
     public Object visit(DotDefNode node) {
         return null;
     }

--- a/dsl/src/interpreter/DSLInterpreter.java
+++ b/dsl/src/interpreter/DSLInterpreter.java
@@ -1162,9 +1162,9 @@ public class DSLInterpreter implements AstVisitor<Object> {
     private boolean setMapValue(MapValue assignee, Value valueToAssign) {
         if (!(valueToAssign instanceof MapValue mapValueToAssign)) {
             throw new RuntimeException(
-                "Can't assign value "
-                    + valueToAssign
-                    + " to MapValue, it is not a MapValue itself!");
+                    "Can't assign value "
+                            + valueToAssign
+                            + " to MapValue, it is not a MapValue itself!");
         }
 
         assignee.clearMap();

--- a/dsl/src/interpreter/DSLInterpreter.java
+++ b/dsl/src/interpreter/DSLInterpreter.java
@@ -1113,7 +1113,6 @@ public class DSLInterpreter implements AstVisitor<Object> {
                 aggregateAssignee.setMemorySpace(encapsulatedObject);
                 aggregateAssignee.setInternalValue(content);
             } else if (assigneesType.getName().equals("element")) {
-                // TODO: how to handle "empty" element: _ ?
                 String stringValue = valueToAssign.getInternalValue().toString();
                 Element<String> content = new Element<>(stringValue);
                 EncapsulatedObject encapsulatedObject =

--- a/dsl/src/interpreter/DSLInterpreter.java
+++ b/dsl/src/interpreter/DSLInterpreter.java
@@ -29,6 +29,7 @@ import semanticanalysis.types.*;
 import task.Element;
 import task.Quiz;
 import task.Task;
+import task.taskdsltypes.AssignTaskDSLType;
 
 import java.util.*;
 
@@ -667,6 +668,13 @@ public class DSLInterpreter implements AstVisitor<Object> {
         if (!(ms instanceof EncapsulatedObject)) {
             memoryStack.push(ms);
 
+            if (objectsValue.getDataType().getName().equals("assign_task")) {
+                // create "_" Value
+                ms.bindValue(
+                        "_",
+                        new Value(BuiltInType.stringType, AssignTaskDSLType.EMPTY_ELEMENT_NAME));
+            }
+
             // accept every propertyDefinition
             for (var propDefNode : node.getPropertyDefinitions()) {
                 propDefNode.accept(this);
@@ -1097,8 +1105,8 @@ public class DSLInterpreter implements AstVisitor<Object> {
                 String stringValue = valueToAssign.getInternalValue().toString();
                 Quiz.Content content = new Quiz.Content(stringValue);
                 EncapsulatedObject encapsulatedObject =
-                    new EncapsulatedObject(
-                        content, (AggregateType) assigneesType, this.environment);
+                        new EncapsulatedObject(
+                                content, (AggregateType) assigneesType, this.environment);
 
                 aggregateAssignee.setMemorySpace(encapsulatedObject);
                 aggregateAssignee.setInternalValue(content);
@@ -1107,8 +1115,8 @@ public class DSLInterpreter implements AstVisitor<Object> {
                 String stringValue = valueToAssign.getInternalValue().toString();
                 Element<String> content = new Element<>(stringValue);
                 EncapsulatedObject encapsulatedObject =
-                    new EncapsulatedObject(
-                        content, (AggregateType) assigneesType, this.environment);
+                        new EncapsulatedObject(
+                                content, (AggregateType) assigneesType, this.environment);
 
                 aggregateAssignee.setMemorySpace(encapsulatedObject);
                 aggregateAssignee.setInternalValue(content);

--- a/dsl/src/interpreter/DSLInterpreter.java
+++ b/dsl/src/interpreter/DSLInterpreter.java
@@ -26,6 +26,7 @@ import semanticanalysis.*;
 // CHECKSTYLE:ON: AvoidStarImport
 import semanticanalysis.types.*;
 
+import task.Element;
 import task.Quiz;
 import task.Task;
 
@@ -1096,8 +1097,18 @@ public class DSLInterpreter implements AstVisitor<Object> {
                 String stringValue = valueToAssign.getInternalValue().toString();
                 Quiz.Content content = new Quiz.Content(stringValue);
                 EncapsulatedObject encapsulatedObject =
-                        new EncapsulatedObject(
-                                content, (AggregateType) assigneesType, this.environment);
+                    new EncapsulatedObject(
+                        content, (AggregateType) assigneesType, this.environment);
+
+                aggregateAssignee.setMemorySpace(encapsulatedObject);
+                aggregateAssignee.setInternalValue(content);
+            } else if (assigneesType.getName().equals("element")) {
+                // TODO: how to handle "empty" element: _ ?
+                String stringValue = valueToAssign.getInternalValue().toString();
+                Element<String> content = new Element<>(stringValue);
+                EncapsulatedObject encapsulatedObject =
+                    new EncapsulatedObject(
+                        content, (AggregateType) assigneesType, this.environment);
 
                 aggregateAssignee.setMemorySpace(encapsulatedObject);
                 aggregateAssignee.setInternalValue(content);

--- a/dsl/src/parser/DungeonASTConverter.java
+++ b/dsl/src/parser/DungeonASTConverter.java
@@ -548,14 +548,14 @@ public class DungeonASTConverter implements antlr.main.DungeonDSLListener {
     }
 
     @Override
-    public void enterMap_param_type(DungeonDSLParser.Map_param_typeContext ctx) { }
+    public void enterMap_param_type(DungeonDSLParser.Map_param_typeContext ctx) {}
 
     @Override
     public void exitMap_param_type(DungeonDSLParser.Map_param_typeContext ctx) {
         Node rhsTypeNode = astStack.pop();
         Node lhsTypeNode = astStack.pop();
         MapTypeIdentifierNode mapTypeIdentifierNode =
-            new MapTypeIdentifierNode((IdNode) lhsTypeNode, (IdNode) rhsTypeNode);
+                new MapTypeIdentifierNode((IdNode) lhsTypeNode, (IdNode) rhsTypeNode);
         astStack.push(mapTypeIdentifierNode);
     }
 

--- a/dsl/src/parser/DungeonASTConverter.java
+++ b/dsl/src/parser/DungeonASTConverter.java
@@ -553,6 +553,8 @@ public class DungeonASTConverter implements antlr.main.DungeonDSLListener {
     @Override
     public void exitMap_param_type(DungeonDSLParser.Map_param_typeContext ctx) {
         Node rhsTypeNode = astStack.pop();
+        // pop the arrow
+        astStack.pop();
         Node lhsTypeNode = astStack.pop();
         MapTypeIdentifierNode mapTypeIdentifierNode =
                 new MapTypeIdentifierNode((IdNode) lhsTypeNode, (IdNode) rhsTypeNode);

--- a/dsl/src/parser/DungeonASTConverter.java
+++ b/dsl/src/parser/DungeonASTConverter.java
@@ -145,7 +145,6 @@ public class DungeonASTConverter implements antlr.main.DungeonDSLListener {
         assert varIdNode.type.equals(Node.Type.Identifier);
 
         Node varTypeIdNode = astStack.pop();
-        assert varTypeIdNode.type.equals(Node.Type.Identifier);
 
         ForLoopStmtNode loopStmtNode =
                 new ForLoopStmtNode(varTypeIdNode, varIdNode, iterableNode, stmtNode);
@@ -168,7 +167,6 @@ public class DungeonASTConverter implements antlr.main.DungeonDSLListener {
         assert varIdNode.type.equals(Node.Type.Identifier);
 
         Node varTypeIdNode = astStack.pop();
-        assert varTypeIdNode.type.equals(Node.Type.Identifier);
 
         CountingLoopStmtNode loopStmtNode =
                 new CountingLoopStmtNode(

--- a/dsl/src/parser/DungeonASTConverter.java
+++ b/dsl/src/parser/DungeonASTConverter.java
@@ -548,6 +548,18 @@ public class DungeonASTConverter implements antlr.main.DungeonDSLListener {
     }
 
     @Override
+    public void enterMap_param_type(DungeonDSLParser.Map_param_typeContext ctx) { }
+
+    @Override
+    public void exitMap_param_type(DungeonDSLParser.Map_param_typeContext ctx) {
+        Node rhsTypeNode = astStack.pop();
+        Node lhsTypeNode = astStack.pop();
+        MapTypeIdentifierNode mapTypeIdentifierNode =
+            new MapTypeIdentifierNode((IdNode) lhsTypeNode, (IdNode) rhsTypeNode);
+        astStack.push(mapTypeIdentifierNode);
+    }
+
+    @Override
     public void enterId_param_type(DungeonDSLParser.Id_param_typeContext ctx) {}
 
     @Override

--- a/dsl/src/parser/ast/AstVisitor.java
+++ b/dsl/src/parser/ast/AstVisitor.java
@@ -416,6 +416,16 @@ public interface AstVisitor<T> {
     }
 
     /**
+     * Visitor method for MapTypeDefinitionNodes
+     *
+     * @param node Node to visit
+     * @return T
+     */
+    default T visit(MapTypeIdentifierNode node) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
      * Visitor method for LoopStmtNodes
      *
      * @param node Node to visit

--- a/dsl/src/parser/ast/MapTypeIdentifierNode.java
+++ b/dsl/src/parser/ast/MapTypeIdentifierNode.java
@@ -5,8 +5,8 @@ public class MapTypeIdentifierNode extends IdNode {
     /** Constructor */
     public MapTypeIdentifierNode(IdNode keyTypeNode, IdNode elementTypeNode) {
         super(
-                Type.ListTypeIdentifierNode,
-                "[" + keyTypeNode.getName() + "->" + elementTypeNode + "]",
+                Type.MapTypeIdentifierNode,
+                "[" + keyTypeNode.getName() + "->" + elementTypeNode.getName() + "]",
                 keyTypeNode.getSourceFileReference());
         this.addChild(keyTypeNode);
         this.addChild(elementTypeNode);

--- a/dsl/src/parser/ast/MapTypeIdentifierNode.java
+++ b/dsl/src/parser/ast/MapTypeIdentifierNode.java
@@ -1,0 +1,29 @@
+package parser.ast;
+
+public class MapTypeIdentifierNode extends IdNode {
+
+    /**
+     * Constructor
+     */
+    public MapTypeIdentifierNode(IdNode keyTypeNode, IdNode elementTypeNode) {
+        super(
+            Type.ListTypeIdentifierNode,
+            "[" + keyTypeNode.getName() + "->" +
+                elementTypeNode + "]", keyTypeNode.getSourceFileReference());
+        this.addChild(keyTypeNode);
+        this.addChild(elementTypeNode);
+    }
+
+    public IdNode getKeyTypeNode() {
+        return (IdNode) this.getChild(0);
+    }
+
+    public IdNode getElementTypeNode() {
+        return (IdNode) this.getChild(1);
+    }
+
+    @Override
+    public <T> T accept(AstVisitor<T> visitor) {
+        return visitor.visit(this);
+    }
+}

--- a/dsl/src/parser/ast/MapTypeIdentifierNode.java
+++ b/dsl/src/parser/ast/MapTypeIdentifierNode.java
@@ -2,14 +2,12 @@ package parser.ast;
 
 public class MapTypeIdentifierNode extends IdNode {
 
-    /**
-     * Constructor
-     */
+    /** Constructor */
     public MapTypeIdentifierNode(IdNode keyTypeNode, IdNode elementTypeNode) {
         super(
-            Type.ListTypeIdentifierNode,
-            "[" + keyTypeNode.getName() + "->" +
-                elementTypeNode + "]", keyTypeNode.getSourceFileReference());
+                Type.ListTypeIdentifierNode,
+                "[" + keyTypeNode.getName() + "->" + elementTypeNode + "]",
+                keyTypeNode.getSourceFileReference());
         this.addChild(keyTypeNode);
         this.addChild(elementTypeNode);
     }

--- a/dsl/src/parser/ast/Node.java
+++ b/dsl/src/parser/ast/Node.java
@@ -69,6 +69,7 @@ public class Node {
         SetDefinitionNode,
         ListTypeIdentifierNode,
         SetTypeIdentifierNode,
+        MapTypeIdentifierNode,
         LoopStmtNode,
         LoopBottomMark,
         ItemPrototypeDefinition,

--- a/dsl/src/runtime/GameEnvironment.java
+++ b/dsl/src/runtime/GameEnvironment.java
@@ -102,6 +102,7 @@ public class GameEnvironment implements IEvironment {
         methods.add(MultipleChoiceTask.GetContentMethod.instance);
         methods.add(SingleChoiceTask.SingleChoiceSetGradingFunction.instance);
         methods.add(MultipleChoiceTask.MultipleChoiceSetGradingFunction.instance);
+        methods.add(AssignTaskDSLType.GetSolutionMethod.instance);
 
         return methods;
     }

--- a/dsl/src/runtime/GameEnvironment.java
+++ b/dsl/src/runtime/GameEnvironment.java
@@ -281,6 +281,12 @@ public class GameEnvironment implements IEvironment {
             NativeFunction nativeGradeMultipleChoice =
                     new MultipleChoiceGrading(this.globalScope, taskType, taskContentSetType);
             nativeFunctions.add(nativeGradeMultipleChoice);
+
+            NativeFunction nativeGradeAssignEasy = new AssignmentGradingEasy(this.globalScope, taskType, taskContentSetType);
+            nativeFunctions.add(nativeGradeAssignEasy);
+
+            NativeFunction nativeGradeAssignHard = new AssignmentGradingHard(this.globalScope, taskType, taskContentSetType);
+            nativeFunctions.add(nativeGradeAssignHard);
         }
 
         return nativeFunctions;
@@ -466,5 +472,74 @@ public class GameEnvironment implements IEvironment {
         }
     }
 
+    private static class AssignmentGradingEasy extends NativeFunction {
+        private BiFunction<Task, Set<TaskContent>, Float> func;
+
+        /**
+         * Constructor
+         *
+         * @param parentScope parent scope of this function
+         */
+        public AssignmentGradingEasy(IScope parentScope, IType taskType, IType taskContentSetType) {
+            super(
+                "grade_assign_task_easy",
+                parentScope,
+                new FunctionType(BuiltInType.floatType, taskType, taskContentSetType));
+            this.func = GradingFunctions.assignGradingEasy();
+        }
+
+        @Override
+        public Object call(DSLInterpreter interpreter, List<Node> parameters) {
+            assert parameters != null && parameters.size() > 0;
+
+            var parameterValues = interpreter.evaluateNodes(parameters);
+            var parameterObjects = interpreter.translateValuesToObjects(parameterValues);
+            Task task = (Task) parameterObjects.get(0);
+            Set<TaskContent> taskContentSet = (Set<TaskContent>) parameterObjects.get(1);
+
+            // call func
+            return func.apply(task, taskContentSet);
+        }
+
+        @Override
+        public ICallable.Type getCallableType() {
+            return ICallable.Type.Native;
+        }
+    }
+
+    private static class AssignmentGradingHard extends NativeFunction {
+        private BiFunction<Task, Set<TaskContent>, Float> func;
+
+        /**
+         * Constructor
+         *
+         * @param parentScope parent scope of this function
+         */
+        public AssignmentGradingHard(IScope parentScope, IType taskType, IType taskContentSetType) {
+            super(
+                "grade_assign_task_hard",
+                parentScope,
+                new FunctionType(BuiltInType.floatType, taskType, taskContentSetType));
+            this.func = GradingFunctions.assignGradingHard();
+        }
+
+        @Override
+        public Object call(DSLInterpreter interpreter, List<Node> parameters) {
+            assert parameters != null && parameters.size() > 0;
+
+            var parameterValues = interpreter.evaluateNodes(parameters);
+            var parameterObjects = interpreter.translateValuesToObjects(parameterValues);
+            Task task = (Task) parameterObjects.get(0);
+            Set<TaskContent> taskContentSet = (Set<TaskContent>) parameterObjects.get(1);
+
+            // call func
+            return func.apply(task, taskContentSet);
+        }
+
+        @Override
+        public ICallable.Type getCallableType() {
+            return ICallable.Type.Native;
+        }
+    }
     // endregion
 }

--- a/dsl/src/runtime/GameEnvironment.java
+++ b/dsl/src/runtime/GameEnvironment.java
@@ -33,11 +33,9 @@ import runtime.nativefunctions.NativePrint;
 import semanticanalysis.*;
 import semanticanalysis.types.*;
 
-import task.QuestItem;
-import task.Quiz;
-import task.Task;
-import task.TaskContent;
+import task.*;
 import task.components.TaskComponent;
+import task.taskdsltypes.AssignTaskDSLType;
 import task.taskdsltypes.MultipleChoiceTask;
 import task.taskdsltypes.SingleChoiceDescriptionProperty;
 import task.taskdsltypes.SingleChoiceTask;
@@ -77,8 +75,8 @@ public class GameEnvironment implements IEvironment {
                     TaskComponent.class,
                     Task.class,
                     TaskContent.class,
-                    // SingleChoiceTask.class,
                     Quiz.Content.class,
+                    Element.class,
                     Tile.Direction.class
                 };
     }
@@ -141,6 +139,7 @@ public class GameEnvironment implements IEvironment {
 
         typeBuilder.registerTypeAdapter(SingleChoiceTask.class, this.globalScope);
         typeBuilder.registerTypeAdapter(MultipleChoiceTask.class, this.globalScope);
+        typeBuilder.registerTypeAdapter(AssignTaskDSLType.class, this.globalScope);
         typeBuilder.registerTypeAdapter(QuestItemAdapter.class, this.globalScope);
     }
 

--- a/dsl/src/runtime/GameEnvironment.java
+++ b/dsl/src/runtime/GameEnvironment.java
@@ -2,6 +2,8 @@ package runtime;
 
 import contrib.components.AIComponent;
 import contrib.components.CollideComponent;
+import contrib.components.InteractionComponent;
+import contrib.components.InventoryComponent;
 import contrib.entities.WorldItemBuilder;
 import contrib.item.Item;
 
@@ -35,6 +37,8 @@ import semanticanalysis.types.*;
 
 import task.*;
 import task.components.TaskComponent;
+import task.components.TaskContentComponent;
+import task.quizquestion.SingleChoice;
 import task.taskdsltypes.AssignTaskDSLType;
 import task.taskdsltypes.MultipleChoiceTask;
 import task.taskdsltypes.SingleChoiceDescriptionProperty;
@@ -73,6 +77,9 @@ public class GameEnvironment implements IEvironment {
                     CollideComponent.class,
                     DrawComponent.class,
                     TaskComponent.class,
+                    TaskContentComponent.class,
+                    InventoryComponent.class,
+                    InteractionComponent.class,
                     Task.class,
                     TaskContent.class,
                     Quiz.Content.class,
@@ -89,8 +96,10 @@ public class GameEnvironment implements IEvironment {
         properties.add(EntityExtension.PositionComponentProperty.instance);
         properties.add(EntityExtension.DrawComponentProperty.instance);
         properties.add(EntityExtension.TaskComponentProperty.instance);
+        properties.add(EntityExtension.TaskContentComponentProperty.instance);
         properties.add(TaskComponent.TaskProperty.instance);
         properties.add(QuestItemExtension.TaskContentComponentProperty.instance);
+        properties.add(TaskContentComponent.ContentProperty.instance);
 
         return properties;
     }
@@ -103,6 +112,7 @@ public class GameEnvironment implements IEvironment {
         methods.add(SingleChoiceTask.SingleChoiceSetGradingFunction.instance);
         methods.add(MultipleChoiceTask.MultipleChoiceSetGradingFunction.instance);
         methods.add(AssignTaskDSLType.GetSolutionMethod.instance);
+        methods.add(IsElementEmptyMethod.instance);
 
         return methods;
     }
@@ -400,6 +410,28 @@ public class GameEnvironment implements IEvironment {
             return ICallable.Type.Native;
         }
     }
+
+    @DSLExtensionMethod(name = "is_empty", extendedType = Element.class)
+    public static class IsElementEmptyMethod
+        implements IDSLExtensionMethod<Element, Boolean> {
+        public static IsElementEmptyMethod instance = new IsElementEmptyMethod();
+
+        @Override
+        public Boolean call(Element instance, List<Object> params) {
+            if (instance.equals(AssignTask.EMPTY_ELEMENT) || instance.content() == null || instance.content().equals("")) {
+                return true;
+            }
+            return false;
+        }
+
+        @Override
+        public List<Type> getParameterTypes() {
+            var arr = new Type[] {};
+            return Arrays.stream(arr).toList();
+        }
+    }
+
+
 
     // endregion
 

--- a/dsl/src/runtime/GameEnvironment.java
+++ b/dsl/src/runtime/GameEnvironment.java
@@ -282,10 +282,12 @@ public class GameEnvironment implements IEvironment {
                     new MultipleChoiceGrading(this.globalScope, taskType, taskContentSetType);
             nativeFunctions.add(nativeGradeMultipleChoice);
 
-            NativeFunction nativeGradeAssignEasy = new AssignmentGradingEasy(this.globalScope, taskType, taskContentSetType);
+            NativeFunction nativeGradeAssignEasy =
+                    new AssignmentGradingEasy(this.globalScope, taskType, taskContentSetType);
             nativeFunctions.add(nativeGradeAssignEasy);
 
-            NativeFunction nativeGradeAssignHard = new AssignmentGradingHard(this.globalScope, taskType, taskContentSetType);
+            NativeFunction nativeGradeAssignHard =
+                    new AssignmentGradingHard(this.globalScope, taskType, taskContentSetType);
             nativeFunctions.add(nativeGradeAssignHard);
         }
 
@@ -482,9 +484,9 @@ public class GameEnvironment implements IEvironment {
          */
         public AssignmentGradingEasy(IScope parentScope, IType taskType, IType taskContentSetType) {
             super(
-                "grade_assign_task_easy",
-                parentScope,
-                new FunctionType(BuiltInType.floatType, taskType, taskContentSetType));
+                    "grade_assign_task_easy",
+                    parentScope,
+                    new FunctionType(BuiltInType.floatType, taskType, taskContentSetType));
             this.func = GradingFunctions.assignGradingEasy();
         }
 
@@ -517,9 +519,9 @@ public class GameEnvironment implements IEvironment {
          */
         public AssignmentGradingHard(IScope parentScope, IType taskType, IType taskContentSetType) {
             super(
-                "grade_assign_task_hard",
-                parentScope,
-                new FunctionType(BuiltInType.floatType, taskType, taskContentSetType));
+                    "grade_assign_task_hard",
+                    parentScope,
+                    new FunctionType(BuiltInType.floatType, taskType, taskContentSetType));
             this.func = GradingFunctions.assignGradingHard();
         }
 

--- a/dsl/src/runtime/GameEnvironment.java
+++ b/dsl/src/runtime/GameEnvironment.java
@@ -38,7 +38,6 @@ import semanticanalysis.types.*;
 import task.*;
 import task.components.TaskComponent;
 import task.components.TaskContentComponent;
-import task.quizquestion.SingleChoice;
 import task.taskdsltypes.AssignTaskDSLType;
 import task.taskdsltypes.MultipleChoiceTask;
 import task.taskdsltypes.SingleChoiceDescriptionProperty;
@@ -412,13 +411,14 @@ public class GameEnvironment implements IEvironment {
     }
 
     @DSLExtensionMethod(name = "is_empty", extendedType = Element.class)
-    public static class IsElementEmptyMethod
-        implements IDSLExtensionMethod<Element, Boolean> {
+    public static class IsElementEmptyMethod implements IDSLExtensionMethod<Element, Boolean> {
         public static IsElementEmptyMethod instance = new IsElementEmptyMethod();
 
         @Override
         public Boolean call(Element instance, List<Object> params) {
-            if (instance.equals(AssignTask.EMPTY_ELEMENT) || instance.content() == null || instance.content().equals("")) {
+            if (instance.equals(AssignTask.EMPTY_ELEMENT)
+                    || instance.content() == null
+                    || instance.content().equals("")) {
                 return true;
             }
             return false;
@@ -430,8 +430,6 @@ public class GameEnvironment implements IEvironment {
             return Arrays.stream(arr).toList();
         }
     }
-
-
 
     // endregion
 

--- a/dsl/src/runtime/MapValue.java
+++ b/dsl/src/runtime/MapValue.java
@@ -1,7 +1,9 @@
 package runtime;
 
 import interpreter.DSLInterpreter;
+
 import parser.ast.Node;
+
 import semanticanalysis.IInstanceCallable;
 import semanticanalysis.types.MapType;
 
@@ -50,7 +52,7 @@ public class MapValue extends Value {
         }
 
         internalObjectMap.put(internalKeyValue, internalEntryValue);
-        internalMap().put(key,entry);
+        internalMap().put(key, entry);
 
         return true;
     }

--- a/dsl/src/runtime/MapValue.java
+++ b/dsl/src/runtime/MapValue.java
@@ -56,7 +56,6 @@ public class MapValue extends Value {
         internalMap().clear();
     }
 
-
     // region native_methods
     /**
      * Native method, which implements adding a Value to the internal {@link Map} of a {@link

--- a/dsl/src/runtime/MapValue.java
+++ b/dsl/src/runtime/MapValue.java
@@ -1,41 +1,37 @@
 package runtime;
 
-import interpreter.DSLInterpreter;
-
-import parser.ast.Node;
-
-import semanticanalysis.IInstanceCallable;
 import semanticanalysis.types.MapType;
 import semanticanalysis.types.SetType;
 
-import java.util.*;
+import java.util.HashMap;
+import java.util.Map;
 
-/** Implements a set value */
-public class SetValue extends Value {
+public class MapValue extends Value {
 
     // stores the internal values of the Value-instances in order to ensure,
     // that only Value-instances with distinct internal values are stored
-    private HashSet<Object> internalValueSet = new HashSet<>();
+    private HashMap<Object, Object> internalValueSet = new HashMap<>();
 
     /**
      * Constructor
      *
      * @param dataType type of the set
      */
-    public SetValue(SetType dataType) {
-        super(dataType, new HashSet<Value>());
+    public MapValue(SetType dataType) {
+        super(dataType, new HashMap<Value, Value>());
     }
 
-    public SetType getDataType() {
-        return (SetType) this.dataType;
+    public MapType getDataType() {
+        return (MapType) this.dataType;
     }
 
     /**
-     * @return the internal HashSet of this {@link SetValue}.
+     * @return the internal HashMap of this {@link SetValue}.
      */
-    public HashSet<Value> internalSet() {
-        return ((HashSet<Value>) this.object);
+    public HashMap<Value, Value> internalMap() {
+        return ((HashMap<Value, Value>) this.object);
     }
+
     /**
      * Add a Value to the set. The Value will only be added to the set, if no other Value with the
      * same internal value of the passed Value is already stored in this set.
@@ -43,88 +39,92 @@ public class SetValue extends Value {
      * @param value the Value to store in the set
      * @return true, if the Value was added, false otherwise
      */
-    public boolean addValue(Value value) {
-        var internalValue = value.getInternalValue();
-        if (internalValueSet.contains(internalValue)) {
-            return false;
-        }
-        internalValueSet.add(internalValue);
-        internalSet().add(value);
-        return true;
+    public boolean addValue(Value key, Value value) {
+        // TODO
+        throw new UnsupportedOperationException();
     }
 
     /**
      * @return all stored values
      */
-    public Set<Value> getValues() {
-        return internalSet();
+    public Map<Value, Value> getValues() {
+        // TODO
+        throw new UnsupportedOperationException();
     }
 
-    public void clearSet() {
-        internalSet().clear();
+    public void clearMap() {
+        internalMap().clear();
     }
+
 
     // region native_methods
     /**
-     * Native method, which implements adding a Value to the internal {@link Set} of a {@link
-     * SetValue}.
+     * Native method, which implements adding a Value to the internal {@link Map} of a {@link
+     * MapValue}.
      */
+    // TODO:
+    /*
     public static class AddMethod implements IInstanceCallable {
 
-        public static SetValue.AddMethod instance = new SetValue.AddMethod();
+        public static MapValue.AddMethod instance = new MapValue.AddMethod();
 
         private AddMethod() {}
 
         @Override
         public Object call(DSLInterpreter interpreter, Object instance, List<Node> parameters) {
-            SetValue setValue = (SetValue) instance;
+            MapValue setValue = (SetValue) instance;
             Node paramNode = parameters.get(0);
             Value paramValue = (Value) paramNode.accept(interpreter);
 
             return setValue.addValue(paramValue);
         }
-    }
+    }*/
 
     /**
      * Native method, which implements calculating the size (i.e. the number of stored elements of a
-     * {@link SetValue}.
+     * {@link MapValue}.
      */
+    /*
     public static class SizeMethod implements IInstanceCallable {
 
-        public static SetValue.SizeMethod instance = new SetValue.SizeMethod();
+        public static MapValue.SizeMethod instance = new SetValue.SizeMethod();
 
         private SizeMethod() {}
 
         @Override
         public Object call(DSLInterpreter interpreter, Object instance, List<Node> parameters) {
-            SetValue setValue = (SetValue) instance;
+            MapValue setValue = (SetValue) instance;
 
-            return setValue.internalSet().size();
+            return setValue.internalMap().size();
         }
     }
 
+     */
+
     /**
      * Native method, which checks whether a given Value is present in the internal value set of a
-     * {@link SetValue}. Because different instances of {@link Value} can refer to the same internal
+     * {@link MapValue}. Because different instances of {@link Value} can refer to the same internal
      * value, the internal values are used for the lookup.
      */
+    /*
     public static class ContainsMethod implements IInstanceCallable {
 
-        public static SetValue.ContainsMethod instance = new SetValue.ContainsMethod();
+        public static MapValue.ContainsMethod instance = new SetValue.ContainsMethod();
 
         private ContainsMethod() {}
 
         @Override
         public Object call(DSLInterpreter interpreter, Object instance, List<Node> parameters) {
-            SetValue setValue = (SetValue) instance;
+            MapValue setValue = (SetValue) instance;
 
             Node valueToCheckNode = parameters.get(0);
             Value valueToCheck = (Value) valueToCheckNode.accept(interpreter);
 
-            return setValue.internalValueSet.contains(valueToCheck.getInternalValue());
+            return setValue.internalValueMap.contains(valueToCheck.getInternalValue());
         }
     }
+
+     */
     // endregion
 
 }
-

--- a/dsl/src/runtime/MapValue.java
+++ b/dsl/src/runtime/MapValue.java
@@ -1,7 +1,6 @@
 package runtime;
 
 import semanticanalysis.types.MapType;
-import semanticanalysis.types.SetType;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -10,14 +9,14 @@ public class MapValue extends Value {
 
     // stores the internal values of the Value-instances in order to ensure,
     // that only Value-instances with distinct internal values are stored
-    private HashMap<Object, Object> internalValueSet = new HashMap<>();
+    private HashMap<Object, Object> internalObjectMap = new HashMap<>();
 
     /**
      * Constructor
      *
      * @param dataType type of the set
      */
-    public MapValue(SetType dataType) {
+    public MapValue(MapType dataType) {
         super(dataType, new HashMap<Value, Value>());
     }
 
@@ -36,23 +35,54 @@ public class MapValue extends Value {
      * Add a Value to the set. The Value will only be added to the set, if no other Value with the
      * same internal value of the passed Value is already stored in this set.
      *
-     * @param value the Value to store in the set
+     * @param entry the Value to store in the set
      * @return true, if the Value was added, false otherwise
      */
-    public boolean addValue(Value key, Value value) {
-        // TODO
-        throw new UnsupportedOperationException();
+    public boolean addValue(Value key, Value entry) {
+        var internalKeyValue = key.getInternalValue();
+        var internalEntryValue = entry.getInternalValue();
+
+        if (internalObjectMap.containsKey(internalKeyValue)) {
+            // don't add value
+            return false;
+        }
+
+        internalObjectMap.put(internalKeyValue, internalEntryValue);
+        internalMap().put(key,entry);
+
+        return true;
+    }
+
+    public boolean removeKeyValue(Value key) {
+        var internalKeyValue = key.getInternalValue();
+
+        if (!internalObjectMap.containsKey(internalKeyValue)) {
+            return false;
+        }
+
+        internalObjectMap.remove(internalKeyValue);
+        internalMap().remove(key);
+        return true;
+    }
+
+    public Value getValue(Value key) {
+        var value = internalMap().get(key);
+        if (value == null) {
+            return Value.NONE;
+        } else {
+            return value;
+        }
     }
 
     /**
      * @return all stored values
      */
     public Map<Value, Value> getValues() {
-        // TODO
-        throw new UnsupportedOperationException();
+        return new HashMap<>(this.internalMap());
     }
 
     public void clearMap() {
+        internalObjectMap.clear();
         internalMap().clear();
     }
 

--- a/dsl/src/runtime/MapValue.java
+++ b/dsl/src/runtime/MapValue.java
@@ -1,9 +1,11 @@
 package runtime;
 
+import interpreter.DSLInterpreter;
+import parser.ast.Node;
+import semanticanalysis.IInstanceCallable;
 import semanticanalysis.types.MapType;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 public class MapValue extends Value {
 
@@ -91,8 +93,6 @@ public class MapValue extends Value {
      * Native method, which implements adding a Value to the internal {@link Map} of a {@link
      * MapValue}.
      */
-    // TODO:
-    /*
     public static class AddMethod implements IInstanceCallable {
 
         public static MapValue.AddMethod instance = new MapValue.AddMethod();
@@ -101,59 +101,45 @@ public class MapValue extends Value {
 
         @Override
         public Object call(DSLInterpreter interpreter, Object instance, List<Node> parameters) {
-            MapValue setValue = (SetValue) instance;
-            Node paramNode = parameters.get(0);
-            Value paramValue = (Value) paramNode.accept(interpreter);
+            MapValue mapValue = (MapValue) instance;
+            Node keyNode = parameters.get(0);
+            Node elementNode = parameters.get(1);
+            Value keyValue = (Value) keyNode.accept(interpreter);
+            Value elementValue = (Value) elementNode.accept(interpreter);
 
-            return setValue.addValue(paramValue);
-        }
-    }*/
-
-    /**
-     * Native method, which implements calculating the size (i.e. the number of stored elements of a
-     * {@link MapValue}.
-     */
-    /*
-    public static class SizeMethod implements IInstanceCallable {
-
-        public static MapValue.SizeMethod instance = new SetValue.SizeMethod();
-
-        private SizeMethod() {}
-
-        @Override
-        public Object call(DSLInterpreter interpreter, Object instance, List<Node> parameters) {
-            MapValue setValue = (SetValue) instance;
-
-            return setValue.internalMap().size();
+            return mapValue.addValue(keyValue, elementValue);
         }
     }
 
-     */
+    public static class GetKeysMethod implements IInstanceCallable {
 
-    /**
-     * Native method, which checks whether a given Value is present in the internal value set of a
-     * {@link MapValue}. Because different instances of {@link Value} can refer to the same internal
-     * value, the internal values are used for the lookup.
-     */
-    /*
-    public static class ContainsMethod implements IInstanceCallable {
+        public static MapValue.GetKeysMethod instance = new MapValue.GetKeysMethod();
 
-        public static MapValue.ContainsMethod instance = new SetValue.ContainsMethod();
-
-        private ContainsMethod() {}
+        private GetKeysMethod() {}
 
         @Override
         public Object call(DSLInterpreter interpreter, Object instance, List<Node> parameters) {
-            MapValue setValue = (SetValue) instance;
-
-            Node valueToCheckNode = parameters.get(0);
-            Value valueToCheck = (Value) valueToCheckNode.accept(interpreter);
-
-            return setValue.internalValueMap.contains(valueToCheck.getInternalValue());
+            MapValue mapValue = (MapValue) instance;
+            ArrayList<Value> keys = new ArrayList<>();
+            keys.addAll(mapValue.internalMap().keySet());
+            return keys;
         }
     }
 
-     */
+    public static class GetElementsMethod implements IInstanceCallable {
+
+        public static MapValue.GetElementsMethod instance = new MapValue.GetElementsMethod();
+
+        private GetElementsMethod() {}
+
+        @Override
+        public Object call(DSLInterpreter interpreter, Object instance, List<Node> parameters) {
+            MapValue mapValue = (MapValue) instance;
+            ArrayList<Value> values = new ArrayList<>();
+            values.addAll(mapValue.internalMap().values());
+            return values;
+        }
+    }
     // endregion
 
 }

--- a/dsl/src/runtime/RuntimeObjectTranslator.java
+++ b/dsl/src/runtime/RuntimeObjectTranslator.java
@@ -72,6 +72,13 @@ public class RuntimeObjectTranslator {
                 case Aggregate:
                     var aggregateType = (AggregateType) dslType;
 
+                    // might already be an aggregateValue
+                    if (object instanceof AggregateValue aggregateValue) {
+                        if (aggregateValue.getDataType().equals(aggregateType)) {
+                            return aggregateValue;
+                        }
+                    }
+
                     returnValue = new AggregateValue(aggregateType, parentMemorySpace, object);
                     var encapsulatedObject =
                             new EncapsulatedObject(object, aggregateType, environment);

--- a/dsl/src/runtime/RuntimeObjectTranslator.java
+++ b/dsl/src/runtime/RuntimeObjectTranslator.java
@@ -85,6 +85,10 @@ public class RuntimeObjectTranslator {
                     // create new list value
                     ListValue listValue = new ListValue((ListType) dslType);
 
+                    if (object instanceof ListValue) {
+                        return (ListValue)object;
+                    }
+
                     // translate each element to target type
                     List<?> passedList = (List<?>) object;
                     for (Object element : passedList) {
@@ -103,6 +107,10 @@ public class RuntimeObjectTranslator {
                     // create new list value
                     SetValue setValue = new SetValue((SetType) dslType);
 
+                    if (object instanceof SetValue) {
+                        return (SetValue)object;
+                    }
+
                     // translate each element to target type
                     Set<?> passedSet = (Set<?>) object;
                     for (Object element : passedSet) {
@@ -120,6 +128,10 @@ public class RuntimeObjectTranslator {
                     MapType mapType = (MapType) dslType;
                     // create new map value
                     MapValue mapValue = new MapValue(mapType);
+
+                    if (object instanceof MapValue) {
+                        return (MapValue)object;
+                    }
 
                     // translate each element to target type
                     Map<?,?> passedMap = (Map<?,?>) object;

--- a/dsl/src/runtime/RuntimeObjectTranslator.java
+++ b/dsl/src/runtime/RuntimeObjectTranslator.java
@@ -93,7 +93,7 @@ public class RuntimeObjectTranslator {
                     ListValue listValue = new ListValue((ListType) dslType);
 
                     if (object instanceof ListValue) {
-                        return (ListValue)object;
+                        return (ListValue) object;
                     }
 
                     // translate each element to target type
@@ -115,18 +115,18 @@ public class RuntimeObjectTranslator {
                     SetValue setValue = new SetValue((SetType) dslType);
 
                     if (object instanceof SetValue) {
-                        return (SetValue)object;
+                        return (SetValue) object;
                     }
 
                     // translate each element to target type
                     Set<?> passedSet = (Set<?>) object;
                     for (Object element : passedSet) {
                         Value elementValue =
-                            translateRuntimeObject(
-                                element,
-                                parentMemorySpace,
-                                environment,
-                                setType.getElementType());
+                                translateRuntimeObject(
+                                        element,
+                                        parentMemorySpace,
+                                        environment,
+                                        setType.getElementType());
                         setValue.addValue(elementValue);
                     }
                     returnValue = setValue;
@@ -137,27 +137,24 @@ public class RuntimeObjectTranslator {
                     MapValue mapValue = new MapValue(mapType);
 
                     if (object instanceof MapValue) {
-                        return (MapValue)object;
+                        return (MapValue) object;
                     }
 
                     // translate each element to target type
-                    Map<?,?> passedMap = (Map<?,?>) object;
+                    Map<?, ?> passedMap = (Map<?, ?>) object;
                     for (var entry : passedMap.entrySet()) {
                         var key = entry.getKey();
                         var element = entry.getValue();
 
                         Value keyValue =
                                 translateRuntimeObject(
-                                        key,
+                                        key, parentMemorySpace, environment, mapType.getKeyType());
+                        Value elementValue =
+                                translateRuntimeObject(
+                                        element,
                                         parentMemorySpace,
                                         environment,
-                                        mapType.getKeyType());
-                        Value elementValue =
-                            translateRuntimeObject(
-                                element,
-                                parentMemorySpace,
-                                environment,
-                                mapType.getElementType());
+                                        mapType.getElementType());
                         mapValue.addValue(keyValue, elementValue);
                     }
                     returnValue = mapValue;

--- a/dsl/src/runtime/RuntimeObjectTranslator.java
+++ b/dsl/src/runtime/RuntimeObjectTranslator.java
@@ -5,6 +5,7 @@ import semanticanalysis.types.*;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -106,14 +107,41 @@ public class RuntimeObjectTranslator {
                     Set<?> passedSet = (Set<?>) object;
                     for (Object element : passedSet) {
                         Value elementValue =
-                                translateRuntimeObject(
-                                        element,
-                                        parentMemorySpace,
-                                        environment,
-                                        setType.getElementType());
+                            translateRuntimeObject(
+                                element,
+                                parentMemorySpace,
+                                environment,
+                                setType.getElementType());
                         setValue.addValue(elementValue);
                     }
                     returnValue = setValue;
+                    break;
+                case MapType:
+                    MapType mapType = (MapType) dslType;
+                    // create new map value
+                    MapValue mapValue = new MapValue(mapType);
+
+                    // translate each element to target type
+                    Map<?,?> passedMap = (Map<?,?>) object;
+                    for (var entry : passedMap.entrySet()) {
+                        var key = entry.getKey();
+                        var element = entry.getValue();
+
+                        Value keyValue =
+                                translateRuntimeObject(
+                                        key,
+                                        parentMemorySpace,
+                                        environment,
+                                        mapType.getKeyType());
+                        Value elementValue =
+                            translateRuntimeObject(
+                                element,
+                                parentMemorySpace,
+                                environment,
+                                mapType.getElementType());
+                        mapValue.addValue(keyValue, elementValue);
+                    }
+                    returnValue = mapValue;
                     break;
                 case EnumType:
                     // find symbol corresponding to the passed variant

--- a/dsl/src/runtime/SetValue.java
+++ b/dsl/src/runtime/SetValue.java
@@ -60,6 +60,7 @@ public class SetValue extends Value {
     }
 
     public void clearSet() {
+        internalValueSet.clear();
         internalSet().clear();
     }
 

--- a/dsl/src/runtime/SetValue.java
+++ b/dsl/src/runtime/SetValue.java
@@ -5,7 +5,6 @@ import interpreter.DSLInterpreter;
 import parser.ast.Node;
 
 import semanticanalysis.IInstanceCallable;
-import semanticanalysis.types.MapType;
 import semanticanalysis.types.SetType;
 
 import java.util.*;
@@ -127,4 +126,3 @@ public class SetValue extends Value {
     // endregion
 
 }
-

--- a/dsl/src/semanticanalysis/FunctionDefinitionBinder.java
+++ b/dsl/src/semanticanalysis/FunctionDefinitionBinder.java
@@ -207,4 +207,32 @@ public class FunctionDefinitionBinder implements AstVisitor<Void> {
         }
         return null;
     }
+
+    @Override
+    public Void visit(MapTypeIdentifierNode node) {
+        IScope globalScope = this.symbolTable.globalScope;
+        String typeName = node.getName();
+        Symbol resolvedType = globalScope.resolve(typeName);
+
+        // construct a new MapType for the node, if it was not previously created
+        if (resolvedType == Symbol.NULL) {
+            // create key type
+            IdNode keyTypeNode = node.getKeyTypeNode();
+            if (keyTypeNode.type != Node.Type.Identifier) {
+                keyTypeNode.accept(this);
+            }
+
+            // create element type
+            IdNode elementTypeNode = node.getElementTypeNode();
+            if (elementTypeNode.type != Node.Type.Identifier) {
+                elementTypeNode.accept(this);
+            }
+
+            var keyType = globalScope.resolveType(keyTypeNode.getName());
+            var elementType = globalScope.resolveType(elementTypeNode.getName());
+            MapType setType = new MapType(keyType, elementType, globalScope);
+            globalScope.bind(setType);
+        }
+        return null;
+    }
 }

--- a/dsl/src/semanticanalysis/SemanticAnalyzer.java
+++ b/dsl/src/semanticanalysis/SemanticAnalyzer.java
@@ -649,6 +649,34 @@ public class SemanticAnalyzer implements AstVisitor<Void> {
     }
 
     @Override
+    public Void visit(MapTypeIdentifierNode node) {
+        IScope globalScope = this.symbolTable.globalScope;
+        String typeName = node.getName();
+        Symbol resolvedType = globalScope.resolve(typeName);
+
+        // construct a new MapType for the node, if it was not previously created
+        if (resolvedType == Symbol.NULL) {
+            // create key type
+            IdNode keyTypeNode = node.getKeyTypeNode();
+            if (keyTypeNode.type != Node.Type.Identifier) {
+                keyTypeNode.accept(this);
+            }
+
+            // create element type
+            IdNode elementTypeNode = node.getElementTypeNode();
+            if (elementTypeNode.type != Node.Type.Identifier) {
+                elementTypeNode.accept(this);
+            }
+
+            var keyType = globalScope.resolveType(keyTypeNode.getName());
+            var elementType = globalScope.resolveType(elementTypeNode.getName());
+            MapType setType = new MapType(keyType, elementType, globalScope);
+            globalScope.bind(setType);
+        }
+        return null;
+    }
+
+    @Override
     public Void visit(ListDefinitionNode node) {
         visitChildren(node);
         return null;

--- a/dsl/src/semanticanalysis/types/DSLType.java
+++ b/dsl/src/semanticanalysis/types/DSLType.java
@@ -4,9 +4,6 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import java.lang.reflect.Type;
-import java.util.ArrayList;
-import java.util.List;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)

--- a/dsl/src/semanticanalysis/types/DSLType.java
+++ b/dsl/src/semanticanalysis/types/DSLType.java
@@ -4,6 +4,9 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.List;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
@@ -15,4 +18,6 @@ public @interface DSLType {
      * @return
      */
     public String name() default "";
+
+    public Class<?>[] templateArguments() default {};
 }

--- a/dsl/src/semanticanalysis/types/IType.java
+++ b/dsl/src/semanticanalysis/types/IType.java
@@ -8,6 +8,7 @@ public interface IType {
         FunctionType,
         SetType,
         ListType,
+        MapType,
         EnumType
     }
 

--- a/dsl/src/semanticanalysis/types/MapType.java
+++ b/dsl/src/semanticanalysis/types/MapType.java
@@ -1,8 +1,8 @@
 package semanticanalysis.types;
 
-import runtime.ListValue;
 import runtime.MapValue;
 import runtime.nativefunctions.NativeMethod;
+
 import semanticanalysis.IScope;
 import semanticanalysis.ScopedSymbol;
 
@@ -28,29 +28,29 @@ public class MapType extends ScopedSymbol implements IType {
         this.elementType = elementType;
 
         NativeMethod addMethod =
-            new NativeMethod(
-                "add",
-                this,
-                new FunctionType(BuiltInType.noType, keyType, elementType),
-                MapValue.AddMethod.instance);
+                new NativeMethod(
+                        "add",
+                        this,
+                        new FunctionType(BuiltInType.noType, keyType, elementType),
+                        MapValue.AddMethod.instance);
         this.bind(addMethod);
 
         var keyListType = new ListType(keyType, parentScope);
         NativeMethod getKeysMethod =
-            new NativeMethod(
-                "get_keys",
-                this,
-                new FunctionType(keyListType),
-                MapValue.GetKeysMethod.instance);
+                new NativeMethod(
+                        "get_keys",
+                        this,
+                        new FunctionType(keyListType),
+                        MapValue.GetKeysMethod.instance);
         this.bind(getKeysMethod);
 
         var elementListType = new ListType(elementType, parentScope);
         NativeMethod getElementsMethod =
-            new NativeMethod(
-                "get_elements",
-                this,
-                new FunctionType(elementListType),
-                MapValue.GetElementsMethod.instance);
+                new NativeMethod(
+                        "get_elements",
+                        this,
+                        new FunctionType(elementListType),
+                        MapValue.GetElementsMethod.instance);
         this.bind(getElementsMethod);
     }
 

--- a/dsl/src/semanticanalysis/types/MapType.java
+++ b/dsl/src/semanticanalysis/types/MapType.java
@@ -16,7 +16,7 @@ public class MapType extends ScopedSymbol implements IType {
     }
 
     public static String getMapTypeName(IType keyType, IType elementType) {
-        return elementType.getName() + "<>";
+        return "[" + keyType.getName() + "->" + elementType.getName() + "]";
     }
 
     public MapType(IType keyType, IType elementType, IScope parentScope) {

--- a/dsl/src/semanticanalysis/types/MapType.java
+++ b/dsl/src/semanticanalysis/types/MapType.java
@@ -1,0 +1,58 @@
+package semanticanalysis.types;
+
+import semanticanalysis.IScope;
+import semanticanalysis.ScopedSymbol;
+
+public class MapType extends ScopedSymbol implements IType {
+    private final IType keyType;
+    private final IType elementType;
+
+    public IType getKeyType() {
+        return this.keyType;
+    }
+
+    public IType getElementType() {
+        return this.elementType;
+    }
+
+    public static String getMapTypeName(IType keyType, IType elementType) {
+        return elementType.getName() + "<>";
+    }
+
+    public MapType(IType keyType, IType elementType, IScope parentScope) {
+        super(getMapTypeName(keyType, elementType), parentScope, elementType);
+        this.keyType = keyType;
+        this.elementType = elementType;
+
+        /*
+        NativeMethod addMethod =
+            new NativeMethod(
+                "add",
+                this,
+                new FunctionType(BuiltInType.boolType, elementType),
+                SetValue.AddMethod.instance);
+        this.bind(addMethod);
+
+        NativeMethod sizeMethod =
+            new NativeMethod(
+                "size",
+                this,
+                new FunctionType(BuiltInType.intType, BuiltInType.noType),
+                SetValue.SizeMethod.instance);
+        this.bind(sizeMethod);
+
+        NativeMethod getMethod =
+            new NativeMethod(
+                "contains",
+                this,
+                new FunctionType(BuiltInType.boolType, elementType),
+                SetValue.ContainsMethod.instance);
+        this.bind(getMethod);
+         */
+    }
+
+    @Override
+    public Kind getTypeKind() {
+        return Kind.MapType;
+    }
+}

--- a/dsl/src/semanticanalysis/types/MapType.java
+++ b/dsl/src/semanticanalysis/types/MapType.java
@@ -1,5 +1,8 @@
 package semanticanalysis.types;
 
+import runtime.ListValue;
+import runtime.MapValue;
+import runtime.nativefunctions.NativeMethod;
 import semanticanalysis.IScope;
 import semanticanalysis.ScopedSymbol;
 
@@ -24,31 +27,31 @@ public class MapType extends ScopedSymbol implements IType {
         this.keyType = keyType;
         this.elementType = elementType;
 
-        /*
         NativeMethod addMethod =
             new NativeMethod(
                 "add",
                 this,
-                new FunctionType(BuiltInType.boolType, elementType),
-                SetValue.AddMethod.instance);
+                new FunctionType(BuiltInType.noType, keyType, elementType),
+                MapValue.AddMethod.instance);
         this.bind(addMethod);
 
-        NativeMethod sizeMethod =
+        var keyListType = new ListType(keyType, parentScope);
+        NativeMethod getKeysMethod =
             new NativeMethod(
-                "size",
+                "get_keys",
                 this,
-                new FunctionType(BuiltInType.intType, BuiltInType.noType),
-                SetValue.SizeMethod.instance);
-        this.bind(sizeMethod);
+                new FunctionType(keyListType),
+                MapValue.GetKeysMethod.instance);
+        this.bind(getKeysMethod);
 
-        NativeMethod getMethod =
+        var elementListType = new ListType(elementType, parentScope);
+        NativeMethod getElementsMethod =
             new NativeMethod(
-                "contains",
+                "get_elements",
                 this,
-                new FunctionType(BuiltInType.boolType, elementType),
-                SetValue.ContainsMethod.instance);
-        this.bind(getMethod);
-         */
+                new FunctionType(elementListType),
+                MapValue.GetElementsMethod.instance);
+        this.bind(getElementsMethod);
     }
 
     @Override

--- a/dsl/src/semanticanalysis/types/SetType.java
+++ b/dsl/src/semanticanalysis/types/SetType.java
@@ -7,7 +7,6 @@ import semanticanalysis.IScope;
 import semanticanalysis.ScopedSymbol;
 
 public class SetType extends ScopedSymbol implements IType {
-    // private final IType elementType;
     public IType getElementType() {
         return this.dataType;
     }
@@ -49,3 +48,4 @@ public class SetType extends ScopedSymbol implements IType {
         return Kind.SetType;
     }
 }
+

--- a/dsl/src/semanticanalysis/types/SetType.java
+++ b/dsl/src/semanticanalysis/types/SetType.java
@@ -48,4 +48,3 @@ public class SetType extends ScopedSymbol implements IType {
         return Kind.SetType;
     }
 }
-

--- a/dsl/src/semanticanalysis/types/TypeBuilder.java
+++ b/dsl/src/semanticanalysis/types/TypeBuilder.java
@@ -279,9 +279,9 @@ public class TypeBuilder {
                                     parentScope);
                 } else if (Map.class.isAssignableFrom((Class<?>) parametersType)) {
                     paramDSLType =
-                        createMapType(
-                            (ParameterizedType) parametersAnnotatedType.getType(),
-                            parentScope);
+                            createMapType(
+                                    (ParameterizedType) parametersAnnotatedType.getType(),
+                                    parentScope);
                 }
             }
 
@@ -443,7 +443,7 @@ public class TypeBuilder {
                         createSetType((ParameterizedType) field.getGenericType(), globalScope);
             } else if (Map.class.isAssignableFrom(fieldsType)) {
                 memberDSLType =
-                    createMapType((ParameterizedType) field.getGenericType(), globalScope);
+                        createMapType((ParameterizedType) field.getGenericType(), globalScope);
             }
         }
         if (memberDSLType == null) {

--- a/dsl/src/semanticanalysis/types/TypeBuilder.java
+++ b/dsl/src/semanticanalysis/types/TypeBuilder.java
@@ -10,7 +10,6 @@ import semanticanalysis.types.callbackadapter.ConsumerFunctionTypeBuilder;
 import semanticanalysis.types.callbackadapter.FunctionFunctionTypeBuilder;
 import semanticanalysis.types.callbackadapter.IFunctionTypeBuilder;
 
-import task.Element;
 import taskdependencygraph.TaskDependencyGraph;
 
 import java.lang.reflect.*;
@@ -386,7 +385,11 @@ public class TypeBuilder {
     }
 
     protected Symbol createDataMemberSymbolWithTemplateType(
-        Field field, Class<?> parentClass, AggregateType parentType, IScope globalScope, Type[] templateTypes) {
+            Field field,
+            Class<?> parentClass,
+            AggregateType parentType,
+            IScope globalScope,
+            Type[] templateTypes) {
 
         var genericType = field.getGenericType();
         var typeParameters = parentClass.getTypeParameters();
@@ -412,10 +415,10 @@ public class TypeBuilder {
             // is list or set?
             if (List.class.isAssignableFrom(fieldsType)) {
                 memberDSLType =
-                    createListType((ParameterizedType) field.getGenericType(), globalScope);
+                        createListType((ParameterizedType) field.getGenericType(), globalScope);
             } else if (Set.class.isAssignableFrom(fieldsType)) {
                 memberDSLType =
-                    createSetType((ParameterizedType) field.getGenericType(), globalScope);
+                        createSetType((ParameterizedType) field.getGenericType(), globalScope);
             }
         }
         if (memberDSLType == null) {
@@ -577,13 +580,19 @@ public class TypeBuilder {
                 if (field.isAnnotationPresent(DSLTypeMember.class)
                         || field.isAnnotationPresent(DSLTypeNameMember.class)) {
                     var genericType = field.getGenericType();
-                    if (genericType instanceof TypeVariable<?> && dslTypeAnnotation.templateArguments().length > 0) {
+                    if (genericType instanceof TypeVariable<?>
+                            && dslTypeAnnotation.templateArguments().length > 0) {
                         var fieldSymbol =
-                            createDataMemberSymbolWithTemplateType(field, clazz, aggregateType, globalScope, dslTypeAnnotation.templateArguments());
+                                createDataMemberSymbolWithTemplateType(
+                                        field,
+                                        clazz,
+                                        aggregateType,
+                                        globalScope,
+                                        dslTypeAnnotation.templateArguments());
                         aggregateType.bind(fieldSymbol);
                     } else {
                         var fieldSymbol =
-                            createDataMemberSymbol(field, clazz, aggregateType, globalScope);
+                                createDataMemberSymbol(field, clazz, aggregateType, globalScope);
                         aggregateType.bind(fieldSymbol);
                     }
                 }

--- a/dsl/src/semanticanalysis/types/TypeBuilder.java
+++ b/dsl/src/semanticanalysis/types/TypeBuilder.java
@@ -411,13 +411,13 @@ public class TypeBuilder {
             // is list or set?
             if (List.class.isAssignableFrom(fieldsType)) {
                 fieldsDSLType =
-                    createListType((ParameterizedType) field.getGenericType(), globalScope);
+                        createListType((ParameterizedType) field.getGenericType(), globalScope);
             } else if (Set.class.isAssignableFrom(fieldsType)) {
                 fieldsDSLType =
-                    createSetType((ParameterizedType) field.getGenericType(), globalScope);
+                        createSetType((ParameterizedType) field.getGenericType(), globalScope);
             } else if (Map.class.isAssignableFrom(fieldsType)) {
                 fieldsDSLType =
-                    createMapType((ParameterizedType) field.getGenericType(), globalScope);
+                        createMapType((ParameterizedType) field.getGenericType(), globalScope);
             }
         }
         if (fieldsDSLType == null) {
@@ -598,12 +598,13 @@ public class TypeBuilder {
                     Symbol fieldSymbol;
                     if (genericType instanceof TypeVariable<?>
                             && dslTypeAnnotation.templateArguments().length > 0) {
-                        fieldSymbol = createDataMemberSymbolWithTemplateType(
-                            field,
-                            clazz,
-                            aggregateType,
-                            globalScope,
-                            dslTypeAnnotation.templateArguments());
+                        fieldSymbol =
+                                createDataMemberSymbolWithTemplateType(
+                                        field,
+                                        clazz,
+                                        aggregateType,
+                                        globalScope,
+                                        dslTypeAnnotation.templateArguments());
                     } else {
                         fieldSymbol = createDataMemberSymbol(field, aggregateType, globalScope);
                     }

--- a/dsl/src/semanticanalysis/types/TypeInstantiator.java
+++ b/dsl/src/semanticanalysis/types/TypeInstantiator.java
@@ -154,6 +154,21 @@ public class TypeInstantiator {
         return hashSetInstance;
     }
 
+    public Map<?,?> instantiateMap(MapValue mapValue) {
+        HashMap<Object, Object> hashMapInstance = new HashMap<>();
+        HashMap<Value, Value> internalValue = mapValue.internalMap();
+
+        // TODO: rename!!!
+        for (var mapEntry : internalValue.entrySet()) {
+            Value keyValue = mapEntry.getKey();
+            var convertedKeyValue = convertValueToObject(keyValue);
+            Value valueValue = mapEntry.getValue();
+            var convertedValueValue = convertValueToObject(valueValue);
+            hashMapInstance.put(convertedKeyValue, convertedValueValue);
+        }
+        return hashMapInstance;
+    }
+
     /**
      * Push an object as part of the context (so it can be looked up, if it is referenced by {@link
      * DSLContextMember} by a constructor parameter)
@@ -224,6 +239,8 @@ public class TypeInstantiator {
                 convertedObject = instantiateList((ListValue) value);
             } else if (valuesType.getTypeKind().equals(IType.Kind.SetType)) {
                 convertedObject = instantiateSet((SetValue) value);
+            } else if (valuesType.getTypeKind().equals(IType.Kind.MapType)) {
+                convertedObject = instantiateMap((MapValue) value);
             } else if (valuesType.getTypeKind().equals(IType.Kind.EnumType)) {
                 convertedObject = instantiateEnum((EnumValue) value);
             } else if (valuesType.getTypeKind().equals(IType.Kind.FunctionType)) {

--- a/dsl/src/semanticanalysis/types/TypeInstantiator.java
+++ b/dsl/src/semanticanalysis/types/TypeInstantiator.java
@@ -156,15 +156,14 @@ public class TypeInstantiator {
 
     public Map<?, ?> instantiateMap(MapValue mapValue) {
         HashMap<Object, Object> hashMapInstance = new HashMap<>();
-        HashMap<Value, Value> internalValue = mapValue.internalMap();
+        HashMap<Value, Value> internalMap = mapValue.internalMap();
 
-        // TODO: rename!!!
-        for (var mapEntry : internalValue.entrySet()) {
+        for (var mapEntry : internalMap.entrySet()) {
             Value keyValue = mapEntry.getKey();
             var convertedKeyValue = convertValueToObject(keyValue);
-            Value valueValue = mapEntry.getValue();
-            var convertedValueValue = convertValueToObject(valueValue);
-            hashMapInstance.put(convertedKeyValue, convertedValueValue);
+            Value entryValue = mapEntry.getValue();
+            var convertedEntryValue = convertValueToObject(entryValue);
+            hashMapInstance.put(convertedKeyValue, convertedEntryValue);
         }
         return hashMapInstance;
     }

--- a/dsl/src/semanticanalysis/types/TypeInstantiator.java
+++ b/dsl/src/semanticanalysis/types/TypeInstantiator.java
@@ -154,7 +154,7 @@ public class TypeInstantiator {
         return hashSetInstance;
     }
 
-    public Map<?,?> instantiateMap(MapValue mapValue) {
+    public Map<?, ?> instantiateMap(MapValue mapValue) {
         HashMap<Object, Object> hashMapInstance = new HashMap<>();
         HashMap<Value, Value> internalValue = mapValue.internalMap();
 

--- a/dsl/test/interpreter/TestDSLInterpreter.java
+++ b/dsl/test/interpreter/TestDSLInterpreter.java
@@ -3732,10 +3732,10 @@ public class TestDSLInterpreter {
     @Test
     public void testDeclareAssignmentTask() {
         String program =
-            """
+                """
                 assign_task t1 {
                     description: "Task1",
-                    solution: <["a", "b"], ["c", "d"], ["y", "x"], ["c", "hallo"]>
+                    solution: <["a", "b"], ["c", "d"], ["y", "x"], ["c", "hallo"], [_, "world"], ["derp", _]>
                 }
 
                 graph g {
@@ -3750,6 +3750,8 @@ public class TestDSLInterpreter {
         DSLInterpreter interpreter = new DSLInterpreter();
         DungeonConfig config = (DungeonConfig) interpreter.getQuestConfig(program);
         var task = config.dependencyGraph().nodeIterator().next().task();
+
+        // TODO: asserts
         boolean b = true;
     }
 }

--- a/dsl/test/interpreter/TestDSLInterpreter.java
+++ b/dsl/test/interpreter/TestDSLInterpreter.java
@@ -3810,4 +3810,49 @@ public class TestDSLInterpreter {
         var derpElementSetEntry = derpElementSet.stream().toList().get(0);
         Assert.assertEquals(AssignTask.EMPTY_ELEMENT, derpElementSetEntry);
     }
+
+    @Test
+    public void testAssignmentTaskScenarioBuilder() {
+        String program =
+            """
+            assign_task t1 {
+                description: "Task1",
+                solution: <["a", "b"], ["c", "d"], ["y", "x"], ["c", "hallo"], [_, "world"], ["derp", _]>
+            }
+
+            graph g {
+                t1
+            }
+
+            dungeon_config c {
+                dependency_graph: g
+            }
+
+            fn build_task(assign_task t) -> entity<><> {
+                var return_set : entity<><>;
+                var room_set : entity<>;
+
+                var solution_map : [element -> element<>];
+                solution_map = t.get_solution();
+
+                print(solution_map);
+
+                return_set.add(room_set);
+                return return_set;
+            }
+        """;
+
+        // print currently just prints to system.out, so we need to
+        // check the contents for the printed string
+        var outputStream = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(outputStream));
+
+        DSLInterpreter interpreter = new DSLInterpreter();
+        DungeonConfig config = (DungeonConfig) interpreter.getQuestConfig(program);
+        var task = (AssignTask) config.dependencyGraph().nodeIterator().next().task();
+
+        var builtTask = (HashSet<HashSet<core.Entity>>) interpreter.buildTask(task).get();
+
+        String output = outputStream.toString();
+    }
 }

--- a/dsl/test/interpreter/TestDSLInterpreter.java
+++ b/dsl/test/interpreter/TestDSLInterpreter.java
@@ -31,8 +31,8 @@ import semanticanalysis.SemanticAnalyzer;
 import semanticanalysis.types.*;
 
 import task.*;
-
 import task.components.TaskContentComponent;
+
 import taskdependencygraph.TaskDependencyGraph;
 import taskdependencygraph.TaskEdge;
 import taskdependencygraph.TaskNode;
@@ -3813,7 +3813,7 @@ public class TestDSLInterpreter {
     @Test
     public void testAssignmentTaskScenarioBuilder() {
         String program =
-            """
+                """
             assign_task t1 {
                 description: "Task1",
                 solution: <["a", "b"], ["c", "d"], ["y", "x"], ["c", "hallo"], [_, "world"], ["!", _]>
@@ -3904,7 +3904,7 @@ public class TestDSLInterpreter {
                 if (optionalItemComp.isPresent()) {
                     ItemComponent itemComp = optionalItemComp.get();
                     QuestItem questItem = (QuestItem) itemComp.item();
-                    var element = (Element<String>)questItem.taskContentComponent().content();
+                    var element = (Element<String>) questItem.taskContentComponent().content();
                     elementContents.add(element.content());
                 }
             }
@@ -3924,7 +3924,7 @@ public class TestDSLInterpreter {
                 var optionalInventoryComponent = entity.fetch(InventoryComponent.class);
                 if (optionalInventoryComponent.isPresent()) {
                     TaskContentComponent tcc = entity.fetch(TaskContentComponent.class).get();
-                    Element<String> element = (Element<String>)tcc.content();
+                    Element<String> element = (Element<String>) tcc.content();
                     keyContents.add(element.content());
                 }
             }

--- a/dsl/test/interpreter/TestDSLInterpreter.java
+++ b/dsl/test/interpreter/TestDSLInterpreter.java
@@ -3701,21 +3701,21 @@ public class TestDSLInterpreter {
     @Test
     public void testNameSymbol() {
         String program =
-                """
-            single_choice_task t1 {
-                description: "Task1",
-                answers: ["1", "2", "3"],
-                correct_answer_index: 2
-            }
+            """
+                single_choice_task t1 {
+                    description: "Task1",
+                    answers: ["1", "2", "3"],
+                    correct_answer_index: 2
+                }
 
-            graph g {
-                t1
-            }
+                graph g {
+                    t1
+                }
 
-            dungeon_config c {
-                dependency_graph: g
-            }
-            """;
+                dungeon_config c {
+                    dependency_graph: g
+                }
+                """;
 
         // print currently just prints to system.out, so we need to
         // check the contents for the printed string
@@ -3727,5 +3727,29 @@ public class TestDSLInterpreter {
         var task = config.dependencyGraph().nodeIterator().next().task();
 
         Assert.assertEquals("t1", task.taskName());
+    }
+
+    @Test
+    public void testDeclareAssignmentTask() {
+        String program =
+            """
+                assign_task t1 {
+                    description: "Task1",
+                    solution: <["a", "b"], ["c", "d"], ["y", "x"], ["c", "hallo"]>
+                }
+
+                graph g {
+                    t1
+                }
+
+                dungeon_config c {
+                    dependency_graph: g
+                }
+            """;
+
+        DSLInterpreter interpreter = new DSLInterpreter();
+        DungeonConfig config = (DungeonConfig) interpreter.getQuestConfig(program);
+        var task = config.dependencyGraph().nodeIterator().next().task();
+        boolean b = true;
     }
 }

--- a/dsl/test/interpreter/TestDSLInterpreter.java
+++ b/dsl/test/interpreter/TestDSLInterpreter.java
@@ -29,6 +29,7 @@ import semanticanalysis.FunctionSymbol;
 import semanticanalysis.SemanticAnalyzer;
 import semanticanalysis.types.*;
 
+import task.AssignTask;
 import task.QuestItem;
 import task.Quiz;
 import task.TaskContent;
@@ -3701,7 +3702,7 @@ public class TestDSLInterpreter {
     @Test
     public void testNameSymbol() {
         String program =
-            """
+                """
                 single_choice_task t1 {
                     description: "Task1",
                     answers: ["1", "2", "3"],
@@ -3749,9 +3750,64 @@ public class TestDSLInterpreter {
 
         DSLInterpreter interpreter = new DSLInterpreter();
         DungeonConfig config = (DungeonConfig) interpreter.getQuestConfig(program);
-        var task = config.dependencyGraph().nodeIterator().next().task();
+        var task = (AssignTask) config.dependencyGraph().nodeIterator().next().task();
 
-        // TODO: asserts
-        boolean b = true;
+        var solutionMap = task.solution();
+
+        // asserts
+        var emptyElementSet = solutionMap.get(AssignTask.EMPTY_ELEMENT);
+        Assert.assertNotEquals(null, emptyElementSet);
+        Assert.assertEquals(1, emptyElementSet.size());
+
+        var worldElement = emptyElementSet.stream().toList().get(0);
+        Assert.assertEquals("world", worldElement.content());
+
+        var aElement =
+                solutionMap.keySet().stream()
+                        .filter(e -> e.content().equals("a"))
+                        .findFirst()
+                        .get();
+        var aElementSet = solutionMap.get(aElement);
+        Assert.assertEquals(1, aElementSet.size());
+
+        var bElement = aElementSet.stream().toList().get(0);
+        Assert.assertEquals("b", bElement.content());
+
+        var cElement =
+                solutionMap.keySet().stream()
+                        .filter(e -> e.content().equals("c"))
+                        .findFirst()
+                        .get();
+        var cElementSet = solutionMap.get(cElement);
+        Assert.assertEquals(2, cElementSet.size());
+
+        var dElement = cElementSet.stream().filter(e -> e.content().equals("d")).findFirst().get();
+        Assert.assertNotNull(dElement);
+
+        var helloElement =
+                cElementSet.stream().filter(e -> e.content().equals("hallo")).findFirst().get();
+        Assert.assertNotNull(helloElement);
+
+        var yElement =
+                solutionMap.keySet().stream()
+                        .filter(e -> e.content().equals("y"))
+                        .findFirst()
+                        .get();
+        var yElementSet = solutionMap.get(yElement);
+        Assert.assertEquals(1, yElementSet.size());
+
+        var xElement = yElementSet.stream().toList().get(0);
+        Assert.assertEquals("x", xElement.content());
+
+        var derpElement =
+                solutionMap.keySet().stream()
+                        .filter(e -> e.content().equals("derp"))
+                        .findFirst()
+                        .get();
+        var derpElementSet = solutionMap.get(derpElement);
+        Assert.assertEquals(1, derpElementSet.size());
+
+        var derpElementSetEntry = derpElementSet.stream().toList().get(0);
+        Assert.assertEquals(AssignTask.EMPTY_ELEMENT, derpElementSetEntry);
     }
 }

--- a/dungeon/src/dsltypeproperties/EntityExtension.java
+++ b/dungeon/src/dsltypeproperties/EntityExtension.java
@@ -63,7 +63,7 @@ public class EntityExtension {
 
     @DSLTypeProperty(name = "task_content_component", extendedType = Entity.class)
     public static class TaskContentComponentProperty
-        implements IDSLTypeProperty<Entity, TaskContentComponent> {
+            implements IDSLTypeProperty<Entity, TaskContentComponent> {
         public static TaskContentComponentProperty instance = new TaskContentComponentProperty();
 
         private TaskContentComponentProperty() {}

--- a/dungeon/src/dsltypeproperties/EntityExtension.java
+++ b/dungeon/src/dsltypeproperties/EntityExtension.java
@@ -10,6 +10,7 @@ import semanticanalysis.types.IDSLTypeProperty;
 
 import task.Task;
 import task.components.TaskComponent;
+import task.components.TaskContentComponent;
 
 /**
  * This class implements {@link IDSLTypeProperty} for the {@link Entity} class, in order to access
@@ -56,6 +57,26 @@ public class EntityExtension {
         @Override
         public PositionComponent get(Entity instance) {
             var optionalComponent = instance.fetch(PositionComponent.class);
+            return optionalComponent.orElse(null);
+        }
+    }
+
+    @DSLTypeProperty(name = "task_content_component", extendedType = Entity.class)
+    public static class TaskContentComponentProperty
+        implements IDSLTypeProperty<Entity, TaskContentComponent> {
+        public static TaskContentComponentProperty instance = new TaskContentComponentProperty();
+
+        private TaskContentComponentProperty() {}
+
+        @Override
+        public void set(Entity instance, TaskContentComponent valueToSet) {
+            instance.removeComponent(TaskContentComponent.class);
+            instance.addComponent(valueToSet);
+        }
+
+        @Override
+        public TaskContentComponent get(Entity instance) {
+            var optionalComponent = instance.fetch(TaskContentComponent.class);
             return optionalComponent.orElse(null);
         }
     }

--- a/dungeon/src/task/AssignTask.java
+++ b/dungeon/src/task/AssignTask.java
@@ -18,6 +18,9 @@ public class AssignTask extends Task {
             GradingFunctions.assignGradingEasy();
     private Map<Element, Set<Element>> solution;
 
+    public static final Element<String> EMPTY_ELEMENT = new Element<>("");
+    public static final String EMPTY_ELEMENT_NAME = "$EMPTY_ELEMENT$";
+
     /** Create an Assignment Task with the given solution map. */
     public AssignTask() {
         super();

--- a/dungeon/src/task/Element.java
+++ b/dungeon/src/task/Element.java
@@ -1,12 +1,16 @@
 package task;
 
+import semanticanalysis.types.DSLType;
+import semanticanalysis.types.DSLTypeMember;
+
 /**
  * Generic storage for a single value that is a {@link TaskContent}.
  *
  * @param <T>
  */
+@DSLType(templateArguments = String.class)
 public class Element<T> extends TaskContent {
-    private final T content;
+    @DSLTypeMember private final T content;
 
     /**
      * Create a new element that can be used as {@link TaskContent}.
@@ -19,6 +23,10 @@ public class Element<T> extends TaskContent {
      */
     public Element(Task task, T content) {
         super(task);
+        this.content = content;
+    }
+
+    public Element(T content) {
         this.content = content;
     }
 

--- a/dungeon/src/task/components/TaskContentComponent.java
+++ b/dungeon/src/task/components/TaskContentComponent.java
@@ -2,6 +2,11 @@ package task.components;
 
 import core.Component;
 
+import dsltypeproperties.QuestItemExtension;
+import semanticanalysis.types.DSLType;
+import semanticanalysis.types.DSLTypeProperty;
+import semanticanalysis.types.IDSLTypeProperty;
+import task.Task;
 import task.TaskContent;
 
 /**
@@ -14,6 +19,7 @@ import task.TaskContent;
  *
  * <p>The collection can be queried as a stream using {@link #content()}
  */
+@DSLType
 public final class TaskContentComponent implements Component {
 
     private TaskContent content;
@@ -42,5 +48,22 @@ public final class TaskContentComponent implements Component {
     /** Set the internal represented {@link TaskContent}. */
     public void content(TaskContent content) {
         this.content = content;
+    }
+
+    @DSLTypeProperty(name = "content", extendedType = TaskContentComponent.class)
+    public static class ContentProperty implements IDSLTypeProperty<TaskContentComponent, TaskContent> {
+        public static TaskContentComponent.ContentProperty instance = new TaskContentComponent.ContentProperty();
+
+        private ContentProperty() {}
+
+        @Override
+        public void set(TaskContentComponent instance, TaskContent valueToSet) {
+            instance.content(valueToSet);
+        }
+
+        @Override
+        public TaskContent get(TaskContentComponent instance) {
+            return instance.content();
+        }
     }
 }

--- a/dungeon/src/task/components/TaskContentComponent.java
+++ b/dungeon/src/task/components/TaskContentComponent.java
@@ -2,11 +2,10 @@ package task.components;
 
 import core.Component;
 
-import dsltypeproperties.QuestItemExtension;
 import semanticanalysis.types.DSLType;
 import semanticanalysis.types.DSLTypeProperty;
 import semanticanalysis.types.IDSLTypeProperty;
-import task.Task;
+
 import task.TaskContent;
 
 /**
@@ -51,8 +50,10 @@ public final class TaskContentComponent implements Component {
     }
 
     @DSLTypeProperty(name = "content", extendedType = TaskContentComponent.class)
-    public static class ContentProperty implements IDSLTypeProperty<TaskContentComponent, TaskContent> {
-        public static TaskContentComponent.ContentProperty instance = new TaskContentComponent.ContentProperty();
+    public static class ContentProperty
+            implements IDSLTypeProperty<TaskContentComponent, TaskContent> {
+        public static TaskContentComponent.ContentProperty instance =
+                new TaskContentComponent.ContentProperty();
 
         private ContentProperty() {}
 

--- a/dungeon/src/task/taskdsltypes/AssignTaskDSLType.java
+++ b/dungeon/src/task/taskdsltypes/AssignTaskDSLType.java
@@ -116,7 +116,4 @@ public class AssignTaskDSLType {
             return Arrays.stream(arr).toList();
         }
     }
-
-    // TODO: get term content
-    // TODO: get definition content
 }

--- a/dungeon/src/task/taskdsltypes/AssignTaskDSLType.java
+++ b/dungeon/src/task/taskdsltypes/AssignTaskDSLType.java
@@ -4,6 +4,7 @@ import reporting.GradingFunctions;
 import semanticanalysis.types.DSLTypeAdapter;
 import semanticanalysis.types.DSLTypeMember;
 
+import semanticanalysis.types.DSLTypeNameMember;
 import task.AssignTask;
 import task.Element;
 import task.Task;
@@ -18,12 +19,14 @@ public class AssignTaskDSLType {
 
     @DSLTypeAdapter(name = "assign_task")
     public static AssignTask buildAssignTask(
+            @DSLTypeNameMember String name,
             @DSLTypeMember(name = "description") String description,
             @DSLTypeMember(name = "solution") Set<List<Element<String>>> solution,
             @DSLTypeMember(name = "grading_function") BiFunction<Task, Set<TaskContent>, Float> gradingFunction) {
 
         AssignTask task = new AssignTask();
         task.taskText(description);
+        task.taskName(name);
 
         // set scoring function either to parameter or default value
         task.scoringFunction(Objects.requireNonNullElseGet(gradingFunction, GradingFunctions::assignGradingEasy));

--- a/dungeon/src/task/taskdsltypes/AssignTaskDSLType.java
+++ b/dungeon/src/task/taskdsltypes/AssignTaskDSLType.java
@@ -1,12 +1,16 @@
 package task.taskdsltypes;
 
+import reporting.GradingFunctions;
 import semanticanalysis.types.DSLTypeAdapter;
 import semanticanalysis.types.DSLTypeMember;
 
 import task.AssignTask;
 import task.Element;
+import task.Task;
+import task.TaskContent;
 
 import java.util.*;
+import java.util.function.BiFunction;
 
 public class AssignTaskDSLType {
     public static Element<String> EMPTY_ELEMENT = new Element<>("");
@@ -15,8 +19,14 @@ public class AssignTaskDSLType {
     @DSLTypeAdapter(name = "assign_task")
     public static AssignTask buildAssignTask(
             @DSLTypeMember(name = "description") String description,
-            @DSLTypeMember(name = "solution") Set<List<Element<String>>> solution) {
+            @DSLTypeMember(name = "solution") Set<List<Element<String>>> solution,
+            @DSLTypeMember(name = "grading_function") BiFunction<Task, Set<TaskContent>, Float> gradingFunction) {
+
+        // TODO: description?!
         AssignTask task = new AssignTask();
+
+        // set scoring function either to parameter or default value
+        task.scoringFunction(Objects.requireNonNullElseGet(gradingFunction, GradingFunctions::assignGradingEasy));
 
         // TODO: handle EMPTY_ELEMENT_NAME
 

--- a/dungeon/src/task/taskdsltypes/AssignTaskDSLType.java
+++ b/dungeon/src/task/taskdsltypes/AssignTaskDSLType.java
@@ -2,21 +2,23 @@ package task.taskdsltypes;
 
 import semanticanalysis.types.DSLTypeAdapter;
 import semanticanalysis.types.DSLTypeMember;
-import semanticanalysis.types.IDSLExtensionMethod;
+
 import task.AssignTask;
 import task.Element;
-import task.TaskContent;
-import task.quizquestion.SingleChoice;
 
 import java.util.*;
 
 public class AssignTaskDSLType {
+    public static Element<String> EMPTY_ELEMENT = new Element<>("");
+    public static String EMPTY_ELEMENT_NAME = "$EMPTY_ELEMENT$";
+
     @DSLTypeAdapter(name = "assign_task")
     public static AssignTask buildAssignTask(
-        @DSLTypeMember(name = "description") String description,
-        @DSLTypeMember(name = "solution") Set<List<Element<String>>> solution
-    ) {
+            @DSLTypeMember(name = "description") String description,
+            @DSLTypeMember(name = "solution") Set<List<Element<String>>> solution) {
         AssignTask task = new AssignTask();
+
+        // TODO: handle EMPTY_ELEMENT_NAME
 
         // scan for duplicates
         HashMap<String, Element<String>> elementMap = new HashMap<>();
@@ -28,6 +30,8 @@ public class AssignTaskDSLType {
                     // get element from element map
                     var substituationElement = elementMap.get(content);
                     substitutionMap.put(element, substituationElement);
+                } else if (content.equals(EMPTY_ELEMENT_NAME)) {
+                    substitutionMap.put(element, EMPTY_ELEMENT);
                 } else {
                     elementMap.put(content, element);
                 }
@@ -59,9 +63,11 @@ public class AssignTaskDSLType {
             }
 
             if (definitionElementToTermElement.containsKey(definitionElement)) {
-                var definitionElementsAssignedTermElement = definitionElementToTermElement.get(definitionElement);
+                var definitionElementsAssignedTermElement =
+                        definitionElementToTermElement.get(definitionElement);
                 if (!definitionElementsAssignedTermElement.equals(termElement)) {
-                    throw new RuntimeException("Definition element was assigned to two different term elements!");
+                    throw new RuntimeException(
+                            "Definition element was assigned to two different term elements!");
                 }
             }
 

--- a/dungeon/src/task/taskdsltypes/AssignTaskDSLType.java
+++ b/dungeon/src/task/taskdsltypes/AssignTaskDSLType.java
@@ -101,9 +101,9 @@ public class AssignTaskDSLType {
      * instance
      */
     @DSLExtensionMethod(name = "get_solution", extendedType = AssignTask.class)
-    public static class GetContentMethod
+    public static class GetSolutionMethod
             implements IDSLExtensionMethod<AssignTask, Map<Element, Set<Element>>> {
-        public static GetContentMethod instance = new GetContentMethod();
+        public static GetSolutionMethod instance = new GetSolutionMethod();
 
         @Override
         public Map<Element, Set<Element>> call(AssignTask instance, List<Object> params) {

--- a/dungeon/src/task/taskdsltypes/AssignTaskDSLType.java
+++ b/dungeon/src/task/taskdsltypes/AssignTaskDSLType.java
@@ -1,35 +1,39 @@
 package task.taskdsltypes;
 
-import reporting.GradingFunctions;
-import semanticanalysis.types.DSLTypeAdapter;
-import semanticanalysis.types.DSLTypeMember;
+import static task.AssignTask.EMPTY_ELEMENT;
 
-import semanticanalysis.types.DSLTypeNameMember;
+import reporting.GradingFunctions;
+
+import semanticanalysis.types.*;
+
 import task.AssignTask;
 import task.Element;
 import task.Task;
 import task.TaskContent;
 
+import java.lang.reflect.Type;
 import java.util.*;
 import java.util.function.BiFunction;
 
 public class AssignTaskDSLType {
-    public static Element<String> EMPTY_ELEMENT = new Element<>("");
-    public static String EMPTY_ELEMENT_NAME = "$EMPTY_ELEMENT$";
+    public static final String EMPTY_ELEMENT_NAME = AssignTask.EMPTY_ELEMENT_NAME;
 
     @DSLTypeAdapter(name = "assign_task")
     public static AssignTask buildAssignTask(
             @DSLTypeNameMember String name,
             @DSLTypeMember(name = "description") String description,
             @DSLTypeMember(name = "solution") Set<List<Element<String>>> solution,
-            @DSLTypeMember(name = "grading_function") BiFunction<Task, Set<TaskContent>, Float> gradingFunction) {
+            @DSLTypeMember(name = "grading_function")
+                    BiFunction<Task, Set<TaskContent>, Float> gradingFunction) {
 
         AssignTask task = new AssignTask();
         task.taskText(description);
         task.taskName(name);
 
         // set scoring function either to parameter or default value
-        task.scoringFunction(Objects.requireNonNullElseGet(gradingFunction, GradingFunctions::assignGradingEasy));
+        task.scoringFunction(
+                Objects.requireNonNullElseGet(
+                        gradingFunction, GradingFunctions::assignGradingEasy));
 
         // TODO: handle EMPTY_ELEMENT_NAME
 
@@ -93,31 +97,26 @@ public class AssignTaskDSLType {
     }
 
     /**
-     * {@link IDSLExtensionMethod} to get the stored {@link TaskContent} of a {@link SingleChoice}
+     * {@link IDSLExtensionMethod} to get the stored {@link TaskContent} of a {@link AssignTask}
      * instance
      */
-    /*
-    @DSLExtensionMethod(name = "get_content", extendedType = SingleChoice.class)
+    @DSLExtensionMethod(name = "get_solution", extendedType = AssignTask.class)
     public static class GetContentMethod
-        implements IDSLExtensionMethod<SingleChoice, List<TaskContent>> {
+            implements IDSLExtensionMethod<AssignTask, Map<Element, Set<Element>>> {
         public static GetContentMethod instance = new GetContentMethod();
 
         @Override
-        public List<TaskContent> call(SingleChoice instance, List<Object> params) {
-            // This has to return an ArrayList. Calling the `.toList()`-Method on the result of
-            // the `map()`-call bellow will create an
-            // `java.util.ImmutableCollections$ListN`-instance,
-            // for which the TypeBuilder cannot create a corresponding dsl-type.
-            List<TaskContent> returnList = new ArrayList<>();
-            instance.contentStream().forEach(returnList::add);
-            return returnList;
+        public Map<Element, Set<Element>> call(AssignTask instance, List<Object> params) {
+            return instance.solution();
         }
 
         @Override
-        public List<Class<?>> getParameterTypes() {
-            var arr = new Class<?>[]{};
+        public List<Type> getParameterTypes() {
+            var arr = new Type[] {};
             return Arrays.stream(arr).toList();
         }
     }
-     */
+
+    // TODO: get term content
+    // TODO: get definition content
 }

--- a/dungeon/src/task/taskdsltypes/AssignTaskDSLType.java
+++ b/dungeon/src/task/taskdsltypes/AssignTaskDSLType.java
@@ -1,0 +1,104 @@
+package task.taskdsltypes;
+
+import semanticanalysis.types.DSLTypeAdapter;
+import semanticanalysis.types.DSLTypeMember;
+import semanticanalysis.types.IDSLExtensionMethod;
+import task.AssignTask;
+import task.Element;
+import task.TaskContent;
+import task.quizquestion.SingleChoice;
+
+import java.util.*;
+
+public class AssignTaskDSLType {
+    @DSLTypeAdapter(name = "assign_task")
+    public static AssignTask buildAssignTask(
+        @DSLTypeMember(name = "description") String description,
+        @DSLTypeMember(name = "solution") Set<List<Element<String>>> solution
+    ) {
+        AssignTask task = new AssignTask();
+
+        // scan for duplicates
+        HashMap<String, Element<String>> elementMap = new HashMap<>();
+        HashMap<Element<String>, Element<String>> substitutionMap = new HashMap<>();
+        for (var elementList : solution) {
+            for (var element : elementList) {
+                String content = element.content();
+                if (elementMap.containsKey(content)) {
+                    // get element from element map
+                    var substituationElement = elementMap.get(content);
+                    substitutionMap.put(element, substituationElement);
+                } else {
+                    elementMap.put(content, element);
+                }
+            }
+        }
+
+        // build solution map (ignore all elements after first and second)
+        HashMap<Element, Set<Element>> solutionMap = new HashMap<>();
+
+        // each definition element (the one on the right side) can only be assigned to
+        // one term element
+        HashMap<Element, Element> definitionElementToTermElement = new HashMap<>();
+        for (var elementList : solution) {
+            if (elementList.size() < 2) {
+                throw new RuntimeException("Element count in solution List to small!!");
+            }
+            var termElement = elementList.get(0);
+            if (substitutionMap.containsKey(termElement)) {
+                termElement = substitutionMap.get(termElement);
+            }
+            if (!solutionMap.containsKey(termElement)) {
+                solutionMap.put(termElement, new HashSet<>());
+            }
+            var definitionSet = solutionMap.get(termElement);
+
+            var definitionElement = elementList.get(1);
+            if (substitutionMap.containsKey(definitionElement)) {
+                definitionElement = substitutionMap.get(definitionElement);
+            }
+
+            if (definitionElementToTermElement.containsKey(definitionElement)) {
+                var definitionElementsAssignedTermElement = definitionElementToTermElement.get(definitionElement);
+                if (!definitionElementsAssignedTermElement.equals(termElement)) {
+                    throw new RuntimeException("Definition element was assigned to two different term elements!");
+                }
+            }
+
+            definitionSet.add(definitionElement);
+            definitionElementToTermElement.put(definitionElement, termElement);
+        }
+
+        task.solution(solutionMap);
+        return task;
+    }
+
+    /**
+     * {@link IDSLExtensionMethod} to get the stored {@link TaskContent} of a {@link SingleChoice}
+     * instance
+     */
+    /*
+    @DSLExtensionMethod(name = "get_content", extendedType = SingleChoice.class)
+    public static class GetContentMethod
+        implements IDSLExtensionMethod<SingleChoice, List<TaskContent>> {
+        public static GetContentMethod instance = new GetContentMethod();
+
+        @Override
+        public List<TaskContent> call(SingleChoice instance, List<Object> params) {
+            // This has to return an ArrayList. Calling the `.toList()`-Method on the result of
+            // the `map()`-call bellow will create an
+            // `java.util.ImmutableCollections$ListN`-instance,
+            // for which the TypeBuilder cannot create a corresponding dsl-type.
+            List<TaskContent> returnList = new ArrayList<>();
+            instance.contentStream().forEach(returnList::add);
+            return returnList;
+        }
+
+        @Override
+        public List<Class<?>> getParameterTypes() {
+            var arr = new Class<?>[]{};
+            return Arrays.stream(arr).toList();
+        }
+    }
+     */
+}

--- a/dungeon/src/task/taskdsltypes/AssignTaskDSLType.java
+++ b/dungeon/src/task/taskdsltypes/AssignTaskDSLType.java
@@ -35,8 +35,6 @@ public class AssignTaskDSLType {
                 Objects.requireNonNullElseGet(
                         gradingFunction, GradingFunctions::assignGradingEasy));
 
-        // TODO: handle EMPTY_ELEMENT_NAME
-
         // scan for duplicates
         HashMap<String, Element<String>> elementMap = new HashMap<>();
         HashMap<Element<String>, Element<String>> substitutionMap = new HashMap<>();

--- a/dungeon/src/task/taskdsltypes/AssignTaskDSLType.java
+++ b/dungeon/src/task/taskdsltypes/AssignTaskDSLType.java
@@ -22,8 +22,8 @@ public class AssignTaskDSLType {
             @DSLTypeMember(name = "solution") Set<List<Element<String>>> solution,
             @DSLTypeMember(name = "grading_function") BiFunction<Task, Set<TaskContent>, Float> gradingFunction) {
 
-        // TODO: description?!
         AssignTask task = new AssignTask();
+        task.taskText(description);
 
         // set scoring function either to parameter or default value
         task.scoringFunction(Objects.requireNonNullElseGet(gradingFunction, GradingFunctions::assignGradingEasy));

--- a/game/src/contrib/components/InteractionComponent.java
+++ b/game/src/contrib/components/InteractionComponent.java
@@ -2,6 +2,7 @@ package contrib.components;
 
 import core.Component;
 import core.Entity;
+import semanticanalysis.types.DSLType;
 
 import java.util.function.BiConsumer;
 
@@ -21,6 +22,7 @@ import java.util.function.BiConsumer;
  *
  * <p>The interaction radius can be queried with {@link #radius()}.
  */
+@DSLType
 public final class InteractionComponent implements Component {
     public static final int DEFAULT_INTERACTION_RADIUS = 5;
     public static final boolean DEFAULT_REPEATABLE = true;

--- a/game/src/contrib/components/InteractionComponent.java
+++ b/game/src/contrib/components/InteractionComponent.java
@@ -2,6 +2,7 @@ package contrib.components;
 
 import core.Component;
 import core.Entity;
+
 import semanticanalysis.types.DSLType;
 
 import java.util.function.BiConsumer;

--- a/game/src/contrib/components/InventoryComponent.java
+++ b/game/src/contrib/components/InventoryComponent.java
@@ -6,6 +6,7 @@ import contrib.item.Item;
 
 import core.Component;
 import core.utils.logging.CustomLogLevel;
+
 import semanticanalysis.types.DSLType;
 
 import java.util.Arrays;
@@ -48,7 +49,6 @@ public final class InventoryComponent implements Component {
     public InventoryComponent(int maxSize) {
         inventory = new Item[maxSize];
     }
-
 
     /**
      * Add the given item to the inventory.

--- a/game/src/contrib/components/InventoryComponent.java
+++ b/game/src/contrib/components/InventoryComponent.java
@@ -6,6 +6,7 @@ import contrib.item.Item;
 
 import core.Component;
 import core.utils.logging.CustomLogLevel;
+import semanticanalysis.types.DSLType;
 
 import java.util.Arrays;
 import java.util.Objects;
@@ -28,10 +29,16 @@ import java.util.stream.Collectors;
  *
  * <p>The number of items in the inventory can be retrieved using {@link #count()}.
  */
+@DSLType
 public final class InventoryComponent implements Component {
 
+    private static final int DEFAULT_MAX_SIZE = 20;
     private final Item[] inventory;
     private final Logger LOGGER = Logger.getLogger(this.getClass().getName());
+
+    public InventoryComponent() {
+        inventory = new Item[DEFAULT_MAX_SIZE];
+    }
 
     /**
      * Create a new {@link InventoryComponent} with the given size.
@@ -41,6 +48,7 @@ public final class InventoryComponent implements Component {
     public InventoryComponent(int maxSize) {
         inventory = new Item[maxSize];
     }
+
 
     /**
      * Add the given item to the inventory.


### PR DESCRIPTION
Fixes #802 

Fügt den `AssignTaskDSLType` Adaptertyp hinzu (`AssignTask` heißt schon die tatsächliche `Task`-Subklasse, daher kann das Namensschema nicht konsistent zu `SingleChoiceTask` und `MultipleChoiceTask` gehalten werden).
Betrachtet die Eingabe der Zuordnungsregeln als ein set aus listen. In der Builder Methode von `AssignTaskDSLType` werden duplizierte `Element`-Instanzen (die den gleichen Wert haben) aussortiert. Der Einfachheit halber wird festgelegt, dass ein Element, was aus der DSL heraus erstellt wird, nur Strings halten kann, alles andere wäre schöner, macht nur aktuell etwas Probleme mit dem DSL Typsystem (müsste irgendwie abbilden, dass es egal ist, was der Datentyp vom `content` Member von `Element` ist).
Implementiert DSL `map` Typen. Fügt einen Szenariobuilder test für `AssignTask` hinzu.
