### PR TITLE
[DSL] Named Aggregate Value ermöglichen -> erlaubt die Benennung von `Task` Objekten mit dem Namen des DSL-Identifiers.

### DIFF
--- a/dsl/src/interpreter/DSLInterpreter.java
+++ b/dsl/src/interpreter/DSLInterpreter.java
@@ -672,6 +672,13 @@ public class DSLInterpreter implements AstVisitor<Object> {
             }
 
             memoryStack.pop();
+
+            Value nameValue = objectsValue.getMemorySpace().resolve(AggregateType.NAME_SYMBOL_NAME);
+            if (nameValue != Value.NONE) {
+                Value nameToSet = new Value(BuiltInType.stringType, node.getIdName());
+                setValue(nameValue, nameToSet);
+            }
+
             // convert from memorySpace to concrete object
             Object createdObject = createObjectFromValue((AggregateValue) objectsValue);
             EncapsulatedObject encapsulatedObject =

--- a/dsl/src/semanticanalysis/types/AggregateType.java
+++ b/dsl/src/semanticanalysis/types/AggregateType.java
@@ -4,6 +4,7 @@ import semanticanalysis.IScope;
 import semanticanalysis.ScopedSymbol;
 
 public class AggregateType extends ScopedSymbol implements IType {
+    public static String NAME_SYMBOL_NAME = "$NAME$";
 
     protected Class<?> originType;
 

--- a/dsl/src/semanticanalysis/types/DSLType.java
+++ b/dsl/src/semanticanalysis/types/DSLType.java
@@ -16,3 +16,4 @@ public @interface DSLType {
      */
     public String name() default "";
 }
+

--- a/dsl/src/semanticanalysis/types/DSLType.java
+++ b/dsl/src/semanticanalysis/types/DSLType.java
@@ -16,4 +16,3 @@ public @interface DSLType {
      */
     public String name() default "";
 }
-

--- a/dsl/src/semanticanalysis/types/DSLTypeNameMember.java
+++ b/dsl/src/semanticanalysis/types/DSLTypeNameMember.java
@@ -7,4 +7,4 @@ import java.lang.annotation.Target;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.FIELD, ElementType.PARAMETER, ElementType.RECORD_COMPONENT})
-public @interface DSLTypeNameMember { }
+public @interface DSLTypeNameMember {}

--- a/dsl/src/semanticanalysis/types/DSLTypeNameMember.java
+++ b/dsl/src/semanticanalysis/types/DSLTypeNameMember.java
@@ -1,0 +1,10 @@
+package semanticanalysis.types;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD, ElementType.PARAMETER, ElementType.RECORD_COMPONENT})
+public @interface DSLTypeNameMember { }

--- a/dsl/src/semanticanalysis/types/TypeBuilder.java
+++ b/dsl/src/semanticanalysis/types/TypeBuilder.java
@@ -387,7 +387,12 @@ public class TypeBuilder {
     // create a symbol in parentType for given field, representing data in parentClass
     protected Symbol createDataMemberSymbol(
             Field field, Class<?> parentClass, AggregateType parentType, IScope globalScope) {
-        String fieldName = getDSLFieldName(field);
+        String fieldName;
+        if (field.isAnnotationPresent(DSLTypeNameMember.class)) {
+            fieldName = AggregateType.NAME_SYMBOL_NAME;
+        } else {
+            fieldName = getDSLFieldName(field);
+        }
 
         Class<?> fieldsType = field.getType();
 
@@ -522,18 +527,10 @@ public class TypeBuilder {
             this.currentLookedUpTypes.add(clazz);
             for (Field field : clazz.getDeclaredFields()) {
                 // bind new Symbol
-                if (field.isAnnotationPresent(DSLTypeMember.class)) {
+                if (field.isAnnotationPresent(DSLTypeMember.class) || field.isAnnotationPresent(DSLTypeNameMember.class)) {
                     var fieldSymbol =
                             createDataMemberSymbol(field, clazz, aggregateType, globalScope);
                     aggregateType.bind(fieldSymbol);
-                }
-                if (field.isAnnotationPresent(DSLTypeNameMember.class)) {
-                    // TODO: or do it in createDataMemberSymbol!
-                    /*
-                    var fieldSymbol =
-                        createDataMemberSymbol(field, clazz, aggregateType, globalScope);
-                    aggregateType.bind(fieldSymbol);
-                    */
                 }
                 if (field.isAnnotationPresent(DSLCallback.class)) {
                     var callbackSymbol =

--- a/dsl/src/semanticanalysis/types/TypeBuilder.java
+++ b/dsl/src/semanticanalysis/types/TypeBuilder.java
@@ -527,7 +527,8 @@ public class TypeBuilder {
             this.currentLookedUpTypes.add(clazz);
             for (Field field : clazz.getDeclaredFields()) {
                 // bind new Symbol
-                if (field.isAnnotationPresent(DSLTypeMember.class) || field.isAnnotationPresent(DSLTypeNameMember.class)) {
+                if (field.isAnnotationPresent(DSLTypeMember.class)
+                        || field.isAnnotationPresent(DSLTypeNameMember.class)) {
                     var fieldSymbol =
                             createDataMemberSymbol(field, clazz, aggregateType, globalScope);
                     aggregateType.bind(fieldSymbol);

--- a/dsl/src/semanticanalysis/types/TypeBuilder.java
+++ b/dsl/src/semanticanalysis/types/TypeBuilder.java
@@ -280,7 +280,13 @@ public class TypeBuilder {
                 }
             }
 
-            String parameterName = getDSLParameterName(parameter);
+            String parameterName;
+            if (parameter.isAnnotationPresent(DSLTypeNameMember.class)) {
+                parameterName = AggregateType.NAME_SYMBOL_NAME;
+            } else {
+                parameterName = getDSLParameterName(parameter);
+            }
+
             Symbol parameterSymbol = new Symbol(parameterName, typeAdapter, paramDSLType);
             typeAdapter.bind(parameterSymbol);
         }
@@ -520,6 +526,14 @@ public class TypeBuilder {
                     var fieldSymbol =
                             createDataMemberSymbol(field, clazz, aggregateType, globalScope);
                     aggregateType.bind(fieldSymbol);
+                }
+                if (field.isAnnotationPresent(DSLTypeNameMember.class)) {
+                    // TODO: or do it in createDataMemberSymbol!
+                    /*
+                    var fieldSymbol =
+                        createDataMemberSymbol(field, clazz, aggregateType, globalScope);
+                    aggregateType.bind(fieldSymbol);
+                    */
                 }
                 if (field.isAnnotationPresent(DSLCallback.class)) {
                     var callbackSymbol =

--- a/dsl/src/semanticanalysis/types/TypeInstantiator.java
+++ b/dsl/src/semanticanalysis/types/TypeInstantiator.java
@@ -207,7 +207,12 @@ public class TypeInstantiator {
                     var method = adaptedType.getBuilderMethod();
                     var parameters = new ArrayList<>(method.getParameterCount());
                     for (var parameter : method.getParameters()) {
-                        var memberName = TypeBuilder.getDSLParameterName(parameter);
+                        String memberName;
+                        if (parameter.isAnnotationPresent(DSLTypeNameMember.class)) {
+                            memberName = AggregateType.NAME_SYMBOL_NAME;
+                        } else {
+                            memberName = TypeBuilder.getDSLParameterName(parameter);
+                        }
                         var memberValue = aggregateFieldValue.getMemorySpace().resolve(memberName);
                         var internalObject = convertValueToObject(memberValue);
                         parameters.add(internalObject);

--- a/dsl/test/interpreter/TestDSLInterpreter.java
+++ b/dsl/test/interpreter/TestDSLInterpreter.java
@@ -3697,4 +3697,35 @@ public class TestDSLInterpreter {
         var score = (Float) task.scoringFunction().apply(task, tcSet);
         Assert.assertEquals((Float) 1.0f, score);
     }
+
+    @Test
+    public void testNameSymbol() {
+        String program =
+            """
+            single_choice_task t1 {
+                description: "Task1",
+                answers: ["1", "2", "3"],
+                correct_answer_index: 2
+            }
+
+            graph g {
+                t1
+            }
+
+            dungeon_config c {
+                dependency_graph: g
+            }
+            """;
+
+        // print currently just prints to system.out, so we need to
+        // check the contents for the printed string
+        var outputStream = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(outputStream));
+
+        DSLInterpreter interpreter = new DSLInterpreter();
+        DungeonConfig config = (DungeonConfig) interpreter.getQuestConfig(program);
+        var task = config.dependencyGraph().nodeIterator().next().task();
+
+        Assert.assertEquals("t1", task.taskName());
+    }
 }

--- a/dsl/test/interpreter/TestDSLInterpreter.java
+++ b/dsl/test/interpreter/TestDSLInterpreter.java
@@ -3701,7 +3701,7 @@ public class TestDSLInterpreter {
     @Test
     public void testNameSymbol() {
         String program =
-            """
+                """
             single_choice_task t1 {
                 description: "Task1",
                 answers: ["1", "2", "3"],

--- a/dsl/test/interpreter/mockecs/TestClassWithName.java
+++ b/dsl/test/interpreter/mockecs/TestClassWithName.java
@@ -1,13 +1,11 @@
 package interpreter.mockecs;
 
-import semanticanalysis.types.DSLContextMember;
 import semanticanalysis.types.DSLType;
 import semanticanalysis.types.DSLTypeNameMember;
 
 @DSLType
 public class TestClassWithName {
-    @DSLTypeNameMember
-    private String name;
+    @DSLTypeNameMember private String name;
 
-    public TestClassWithName() { }
+    public TestClassWithName() {}
 }

--- a/dsl/test/interpreter/mockecs/TestClassWithName.java
+++ b/dsl/test/interpreter/mockecs/TestClassWithName.java
@@ -1,0 +1,13 @@
+package interpreter.mockecs;
+
+import semanticanalysis.types.DSLContextMember;
+import semanticanalysis.types.DSLType;
+import semanticanalysis.types.DSLTypeNameMember;
+
+@DSLType
+public class TestClassWithName {
+    @DSLTypeNameMember
+    private String name;
+
+    public TestClassWithName() { }
+}

--- a/dungeon/src/task/Task.java
+++ b/dungeon/src/task/Task.java
@@ -176,7 +176,6 @@ public abstract class Task {
         this.taskName = taskName;
     }
 
-
     /**
      * Set the task text.
      *

--- a/dungeon/src/task/Task.java
+++ b/dungeon/src/task/Task.java
@@ -54,6 +54,7 @@ public abstract class Task {
     protected Set<TaskContent> container;
     private TaskState state;
     private String taskText;
+    private String taskName;
     private Entity managementEntity;
     private Set<Set<Entity>> entitySets = new HashSet<>();
     private float pointsToSolve;
@@ -156,6 +157,25 @@ public abstract class Task {
     public String taskText() {
         return taskText;
     }
+
+    /**
+     * Get the task name.
+     *
+     * @return task name
+     */
+    public String taskName() {
+        return taskName;
+    }
+
+    /**
+     * Set the task name.
+     *
+     * @param taskName new task name
+     */
+    public void taskName(String taskName) {
+        this.taskName = taskName;
+    }
+
 
     /**
      * Set the task text.

--- a/dungeon/src/task/taskdsltypes/MultipleChoiceTask.java
+++ b/dungeon/src/task/taskdsltypes/MultipleChoiceTask.java
@@ -2,10 +2,7 @@ package task.taskdsltypes;
 
 import reporting.GradingFunctions;
 
-import semanticanalysis.types.DSLExtensionMethod;
-import semanticanalysis.types.DSLTypeAdapter;
-import semanticanalysis.types.DSLTypeMember;
-import semanticanalysis.types.IDSLExtensionMethod;
+import semanticanalysis.types.*;
 
 import task.Quiz;
 import task.Task;
@@ -21,6 +18,7 @@ import java.util.function.BiFunction;
 public class MultipleChoiceTask {
     @DSLTypeAdapter(name = "multiple_choice_task")
     public static MultipleChoice buildQuizFromMultipleChoiceTask(
+            @DSLTypeNameMember String name,
             @DSLTypeMember(name = "description") String description,
             @DSLTypeMember(name = "answers") List<Quiz.Content> answers,
             @DSLTypeMember(name = "correct_answer_index") List<Integer> correctAnswerIndices,
@@ -29,6 +27,7 @@ public class MultipleChoiceTask {
             //  scoreFunction
             ) {
         MultipleChoice mc = new MultipleChoice(description);
+        mc.taskName(name);
 
         for (Quiz.Content answer : answers) {
             mc.addAnswer(answer);

--- a/dungeon/src/task/taskdsltypes/SingleChoiceTask.java
+++ b/dungeon/src/task/taskdsltypes/SingleChoiceTask.java
@@ -26,6 +26,7 @@ public class SingleChoiceTask {
             @DSLTypeMember(name = "grading_function")
                     BiFunction<Task, Set<TaskContent>, Float> gradingFunction) {
         SingleChoice sc = new SingleChoice(description);
+        sc.taskName(name);
 
         for (Quiz.Content answer : answers) {
             sc.addAnswer(answer);

--- a/dungeon/src/task/taskdsltypes/SingleChoiceTask.java
+++ b/dungeon/src/task/taskdsltypes/SingleChoiceTask.java
@@ -19,6 +19,7 @@ public class SingleChoiceTask {
 
     @DSLTypeAdapter(name = "single_choice_task")
     public static SingleChoice buildQuizFromSingleChoiceTask(
+            @DSLTypeNameMember String name,
             @DSLTypeMember(name = "description") String description,
             @DSLTypeMember(name = "answers") List<Quiz.Content> answers,
             @DSLTypeMember(name = "correct_answer_index") int correctAnswerIndex,


### PR DESCRIPTION
Fügt neue Annotation `DSLTypeNameMember` zur Markierung eines Members hinzu, welchem bei Instanziierung des Typen der Namenswert zugewiesen werden soll.
Fügt für Datentypen, die einen Member mit dieser Annotation haben, ein neues "$NAME$" Symbol; dem entsprechenden `Value` wird beim Bearbeiten der Objektdefinition (`DSLInterpreter::visit(ObjDefNode)`) der Name des Idenitifers der Objektdefinition hinzugefügt.