### PR TITLE
[GAME] fix bug where player was drawn behind other entities

### DIFF
--- a/game/src/core/systems/DrawSystem.java
+++ b/game/src/core/systems/DrawSystem.java
@@ -5,6 +5,7 @@ import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import core.Entity;
 import core.System;
 import core.components.DrawComponent;
+import core.components.PlayerComponent;
 import core.components.PositionComponent;
 import core.utils.components.MissingComponentException;
 import core.utils.components.draw.Animation;
@@ -12,10 +13,8 @@ import core.utils.components.draw.IPath;
 import core.utils.components.draw.Painter;
 import core.utils.components.draw.PainterConfig;
 
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * This system draws the entities on the screen.
@@ -65,7 +64,17 @@ public final class DrawSystem extends System {
      */
     @Override
     public void execute() {
-        entityStream().map(this::buildDataObject).forEach(this::draw);
+        Map<Boolean, List<Entity>> partitionedEntities =
+                entityStream()
+                        .collect(
+                                Collectors.partitioningBy(
+                                        entity -> entity.isPresent(PlayerComponent.class)));
+
+        List<Entity> players = partitionedEntities.get(true);
+        List<Entity> npcs = partitionedEntities.get(false);
+
+        npcs.forEach(entity -> draw(buildDataObject(entity)));
+        players.forEach(entity -> draw(buildDataObject(entity)));
     }
 
     private void draw(DSData dsd) {


### PR DESCRIPTION
fixes #1147 

Im `DrawSytem` sortiere ich die Entitäten in zwei Listen
- Liste `players` beinhaltet alle Entitäten mit einen `PlayerComponent`
- Liste `npcs` alle Entitäten ohne `PlayerComponent`

Ich lasse jetzt erst die `npcs` zeichnen und danach die `players`, dadurch werden diese immer "oben" gezeichnet und nicht von Schatzkisten o.ä überdeckt. 
