### PR TITLE
[DUNGEON] add easy to use method to ask and grade a quiz over the hud

### DIFF
--- a/dungeon/src/task/Quiz.java
+++ b/dungeon/src/task/Quiz.java
@@ -186,6 +186,11 @@ public abstract class Quiz extends Task {
             return type;
         }
 
+        @Override
+        public String toString() {
+            return content;
+        }
+
         /**
          * The QuizQuestionContentType enum represents the different types of content that can be
          * associated with a quiz question. The available types are TEXT, IMAGE, and TEXT_AND_IMAGE.

--- a/dungeon/src/task/Task.java
+++ b/dungeon/src/task/Task.java
@@ -326,27 +326,32 @@ public abstract class Task {
         StringBuilder msgBuilder = new StringBuilder();
         msgBuilder
                 .append("Task: ")
+                .append(id)
+                .append(System.lineSeparator())
+                .append(taskName)
+                .append(System.lineSeparator())
                 .append(taskText)
+                .append(System.lineSeparator())
                 .append(" was solved with ")
                 .append(score)
                 .append("/")
                 .append(points)
-                .append(" Points");
+                .append(" Points.")
+                .append(System.lineSeparator());
         msgBuilder.append("The task was solved");
-        if (score >= pointsToSolve) msgBuilder.append(" successfully");
-        else msgBuilder.append(" unsuccessfully");
-
-        msgBuilder.append(" Given answers: ");
+        if (score >= pointsToSolve) msgBuilder.append(" successfully.");
+        else msgBuilder.append(" unsuccessfully.");
+        msgBuilder.append(System.lineSeparator());
+        msgBuilder.append("Given answers: ");
 
         for (TaskContent answer : givenAnswers) {
-            msgBuilder.append(answer.toString());
+            msgBuilder.append(answer.toString()).append(System.lineSeparator());
         }
         String msg = msgBuilder.toString();
         LOGGER.log(CustomLogLevel.TASK, msg);
 
         if (score >= pointsToSolve) state(TaskState.FINISHED_CORRECT);
         else state(TaskState.FINISHED_WRONG);
-
         return score;
     }
 

--- a/dungeon/src/task/quizquestion/QuizUI.java
+++ b/dungeon/src/task/quizquestion/QuizUI.java
@@ -11,6 +11,7 @@ import core.Entity;
 import core.Game;
 
 import task.Quiz;
+import task.Task;
 
 import java.util.Objects;
 import java.util.function.BiFunction;
@@ -26,6 +27,20 @@ public class QuizUI {
      * = MAX_ROW_LENGTH 480 / 12 = 40
      */
     private static final int MAX_ROW_LENGTH = 40;
+
+    /**
+     * Ask a Quizquestion on the HUD and trigger the grading function, after the player confirmed
+     * the answers.
+     *
+     * @param quiz Question to ask
+     * @return the entity that stores the hud elements for the dialog window.
+     */
+    public static Entity askQuizOnHud(final Quiz quiz) {
+        return QuizUI.showQuizDialog(
+                quiz,
+                (Entity hudEntity) ->
+                        UIAnswerCallback.uiCallback(quiz, hudEntity, Task::gradeTask));
+    }
 
     /**
      * Display the Question-Content (Question and answer options (no pictures) as text, picture,

--- a/dungeon/src/task/quizquestion/UIAnswerCallback.java
+++ b/dungeon/src/task/quizquestion/UIAnswerCallback.java
@@ -57,7 +57,7 @@ public final class UIAnswerCallback {
      *
      * @see UITools
      */
-    private static BiFunction<TextDialog, String, Boolean> uiCallback(
+    static BiFunction<TextDialog, String, Boolean> uiCallback(
             Quiz quest, Entity hudEntity, BiConsumer<Task, Set<TaskContent>> dslCallback) {
         return (textDialog, id) -> {
             if (Objects.equals(id, UITools.DEFAULT_DIALOG_CONFIRM)) {

--- a/dungeon/test/manual/quizquestion/QuizQuestionUITest.java
+++ b/dungeon/test/manual/quizquestion/QuizQuestionUITest.java
@@ -10,9 +10,13 @@ import contrib.systems.HudSystem;
 import core.Game;
 
 import task.Quiz;
+import task.Task;
+import task.TaskContent;
 import task.quizquestion.*;
 
 import java.util.Random;
+import java.util.Set;
+import java.util.function.BiFunction;
 
 /**
  * This is a manual test for the QuizQuestion-UI.
@@ -20,6 +24,8 @@ import java.util.Random;
  * <p>It sets up a basic game and will show a random QuizQuestion if "F" is pressed.
  *
  * <p>Use this to check if the UI is displayed correctly.
+ *
+ * <p>Use ./gradlew runManualQuizTest
  */
 public class QuizQuestionUITest {
 
@@ -32,7 +38,15 @@ public class QuizQuestionUITest {
                         // Dialogue for quiz questions (display of quiz questions and the answer
                         // area in test
                         // mode)
-                        QuizUI.showQuizDialog(DummyQuizQuestionList.getRandomQuestion());
+                        Quiz question = DummyQuizQuestionList.getRandomQuestion();
+                        question.scoringFunction(
+                                (BiFunction<Task, Set<TaskContent>, Float>)
+                                        (task, contents) -> {
+                                            System.out.println("Given answers");
+                                            contents.forEach(System.out::println);
+                                            return 1f;
+                                        });
+                        QuizUI.askQuizOnHud(question);
                     }
                 });
 


### PR DESCRIPTION
Fügt analog zum `YesNoDialog` die Methode `QuizUI.askQuizOnHud(task)` hinzu. 
Damit kann man schnell und einfach eine Quizfrage über das HUD beantworten lassen. Die Bewertungsfunktion wird entsprechend angestoßen, nachdem der Spieler seine Antwort bestätigt. hat.