### PR TITLE
[GAME] add OK-Dialog and use it for the questlog

### DIFF
--- a/dungeon/src/starter/Starter.java
+++ b/dungeon/src/starter/Starter.java
@@ -7,7 +7,7 @@ import com.badlogic.gdx.audio.Music;
 import contrib.configuration.KeyboardConfig;
 import contrib.crafting.Crafting;
 import contrib.entities.EntityFactory;
-import contrib.hud.UITools;
+import contrib.hud.OkDialog;
 import contrib.systems.*;
 
 import core.Entity;
@@ -64,7 +64,7 @@ public class Starter {
                                                 .append(System.lineSeparator())
                                                 .append(System.lineSeparator()));
                 String questLog = questLogBuilder.toString();
-                UITools.generateNewTextDialog(questLog, "Weiter gehts!", "Questlog");
+                OkDialog.showOkDialog(questLog, "Questlog", () -> {});
             };
 
     public static void main(String[] args) throws IOException {

--- a/game/src/contrib/hud/OkDialog.java
+++ b/game/src/contrib/hud/OkDialog.java
@@ -1,0 +1,96 @@
+package contrib.hud;
+
+import com.badlogic.gdx.scenes.scene2d.ui.Dialog;
+import com.badlogic.gdx.scenes.scene2d.ui.Skin;
+
+import core.Entity;
+import core.Game;
+import core.utils.IVoidFunction;
+
+import task.quizquestion.QuizUI;
+
+import java.util.Objects;
+import java.util.function.BiFunction;
+
+/**
+ * A Dialog with a "ok" Button on the Bottom.
+ *
+ * <p>Use {@link #showOkDialog(String, String, IVoidFunction)} to create a simple dialog.
+ */
+public class OkDialog {
+
+    public static final String DEFAULT_OK_BUTTON = "ok";
+
+    /**
+     * Show a Ok-Dialog
+     *
+     * @param text text to show in the dialog
+     * @param title title of the dialog window
+     * @param onOk function to execute if "ok" is pressed
+     * @return Entity that stores the HUD components.
+     */
+    public static Entity showOkDialog(
+            final String text, final String title, final IVoidFunction onOk) {
+
+        Entity entity = showOkDialog(UITools.DEFAULT_SKIN, text, title, onOk);
+        Game.add(entity);
+        return entity;
+    }
+
+    /**
+     * Show a Yes or No Dialog.
+     *
+     * @param skin UI skin to use
+     * @param text text to show in the dialog
+     * @param title title of the dialog window
+     * @param onOk function to execute if "ok" is pressed
+     * @return Entity that stores the HUD components.
+     */
+    public static Entity showOkDialog(
+            final Skin skin, final String text, final String title, final IVoidFunction onOk) {
+        Entity entity = new Entity();
+
+        UITools.show(
+                () -> {
+                    Dialog dialog =
+                            createOkDialog(
+                                    skin,
+                                    text,
+                                    title,
+                                    createResultHandlerYesNo(entity, DEFAULT_OK_BUTTON, onOk));
+                    UITools.centerActor(dialog);
+                    return dialog;
+                },
+                entity);
+        Game.add(entity);
+        return entity;
+    }
+
+    private static Dialog createOkDialog(
+            final Skin skin,
+            final String text,
+            final String title,
+            final BiFunction<TextDialog, String, Boolean> resultHandler) {
+        Dialog textDialog = new TextDialog(title, skin, "Letter", resultHandler);
+        textDialog
+                .getContentTable()
+                .add(DialogDesign.createTextDialog(skin, QuizUI.formatStringForDialogWindow(text)))
+                .center()
+                .grow();
+        textDialog.button(DEFAULT_OK_BUTTON, DEFAULT_OK_BUTTON);
+        textDialog.pack(); // resizes to size
+        return textDialog;
+    }
+
+    private static BiFunction<TextDialog, String, Boolean> createResultHandlerYesNo(
+            final Entity entity, final String okButtonId, final IVoidFunction onOk) {
+        return (d, id) -> {
+            if (Objects.equals(id, okButtonId)) {
+                onOk.execute();
+                Game.remove(entity);
+                return true;
+            }
+            return false;
+        };
+    }
+}

--- a/game/src/contrib/hud/OkDialog.java
+++ b/game/src/contrib/hud/OkDialog.java
@@ -38,7 +38,7 @@ public class OkDialog {
     }
 
     /**
-     * Show a Yes or No Dialog.
+     * Show a Ok-Dialog.
      *
      * @param skin UI skin to use
      * @param text text to show in the dialog


### PR DESCRIPTION
fixes #1149 

fügt einen OK-Dialog hinzu (der richtig skaliert, ähnlich wie der Yes-No Dialog) und verwendet ihn für den Questlog (`gradlew start` und dann `M` drücken)