### PR TITLE
[DUNGEON] add info screen to show achieved points, played time and the scenario id

### DIFF
--- a/dungeon/src/starter/Starter.java
+++ b/dungeon/src/starter/Starter.java
@@ -25,7 +25,6 @@ import interpreter.DSLEntryPointFinder;
 import interpreter.DSLInterpreter;
 
 import task.Task;
-import task.YesNoDialog;
 
 import java.io.IOException;
 import java.util.HashSet;
@@ -104,8 +103,7 @@ public class Starter {
                                 });
 
                 String tableString = infos.toString();
-                YesNoDialog.showYesNoDialog(
-                        tableString, "Szenario ID " + scenarioID, () -> {}, () -> {});
+                OkDialog.showOkDialog(tableString, "Szenario ID " + scenarioID, () -> {});
                 // show scenario id
                 // show list for task: reached points
             };

--- a/dungeon/src/starter/WizardTaskSelector.java
+++ b/dungeon/src/starter/WizardTaskSelector.java
@@ -88,6 +88,7 @@ public class WizardTaskSelector {
         SingleChoice question = new SingleChoice("Wähle deine Mission:");
         entryPoints.forEach(ep -> question.addAnswer(new PayloadTaskContent(ep)));
         question.state(Task.TaskState.PROCESSING_ACTIVE);
+        question.taskName(" ");
         return question;
     }
 

--- a/dungeon/src/task/quizquestion/QuizUI.java
+++ b/dungeon/src/task/quizquestion/QuizUI.java
@@ -159,19 +159,24 @@ public class QuizUI {
      * @param string which should be reformatted.
      */
     public static String formatStringForDialogWindow(String string) {
-        String[] words = string.split(" ");
-        StringBuilder formattedMsg = new StringBuilder(string.length());
-        int sumLength = 0;
+        StringBuilder formattedMsg = new StringBuilder();
+        String[] lines = string.split(System.lineSeparator());
 
-        for (String word : words) {
-            sumLength += word.length();
-            formattedMsg.append(word);
-            formattedMsg.append(" ");
+        for (String line : lines) {
+            String[] words = line.split(" ");
+            int sumLength = 0;
 
-            if (sumLength > MAX_ROW_LENGTH) {
-                formattedMsg.append("\n");
-                sumLength = 0;
+            for (String word : words) {
+                sumLength += word.length();
+                formattedMsg.append(word);
+                formattedMsg.append(" ");
+
+                if (sumLength > MAX_ROW_LENGTH) {
+                    formattedMsg.append(System.lineSeparator());
+                    sumLength = 0;
+                }
             }
+            formattedMsg.append(System.lineSeparator());
         }
         return formattedMsg.toString().trim();
     }

--- a/game/src/contrib/configuration/KeyboardConfig.java
+++ b/game/src/contrib/configuration/KeyboardConfig.java
@@ -67,4 +67,6 @@ public class KeyboardConfig {
             new ConfigKey<>(new String[] {"menue", "questlog"}, new ConfigIntValue(Input.Keys.M));
     public static final ConfigKey<Integer> PAUSE =
             new ConfigKey<>(new String[] {"pause", "pause_game"}, new ConfigIntValue(Input.Keys.P));
+    public static final ConfigKey<Integer> INFOS =
+            new ConfigKey<>(new String[] {"info", "game_infos"}, new ConfigIntValue(Input.Keys.L));
 }


### PR DESCRIPTION
Fixes #1098

Fügt dem Starter einen "Info-Screen"-Button ("L") hinzu.

Daraufhin wird im Titel der Szenariocode angezeigt, bestehend aus den jeweils ersten Buchstaben der bearbeiteten Tasks (in der Reihenfolge der Bearbeitung).
Ebenfalls wird die gespielte Zeit in Minuten angezeigt.
Danach folgt eine Auflistung der bearbeiteten Tasks (sowohl korrekt als auch inkorrekt) und die erreichten Punkte.

Wenn #1151 abgeschlossen ist, plane ich, den Yes-No-Dialog durch einen OK-Dialog zu ersetzen.

<img width="150" alt="image" src="https://github.com/Programmiermethoden/Dungeon/assets/32962412/42c577d8-e80d-4a65-b601-8e2dd035c665">


---
BELWOW IS FIXED

Ich habe noch nicht verstanden, woher der Zeilenumbruch bei "wuppie2" stammt. Das HUD sollte in der Lage sein, längere Strings problemlos anzuzeigen.

Siehe:
<img width="402" alt="image" src="https://github.com/Programmiermethoden/Dungeon/assets/32962412/de80ac5c-d29d-47c4-8afc-b6e6101378e5">

Vielleicht hat @AHeinisch eine Idee?

Hinweis: Die Levelauswahl beim Zauberer ist ebenfalls als `Task` umgesetzt. Daher filtere ich die Task mit der ID 0 aus den angezeigten Informationen heraus.
