### PR TITLE
[Game] Frustum check not using offset

### DIFF
--- a/game/src/core/utils/components/draw/Painter.java
+++ b/game/src/core/utils/components/draw/Painter.java
@@ -16,12 +16,14 @@ public class Painter {
     }
 
     public void draw(Point position, String texturePath, PainterConfig config) {
-        if (CameraSystem.isPointInFrustum(position.x, position.y)) {
+        float realX = position.x + config.xOffset; // including the drawOffset
+        float realY = position.y + config.yOffset; // including the drawOffset
+        if (CameraSystem.isPointInFrustum(realX, realY)) {
             Sprite sprite = new Sprite(TextureMap.instance().textureAt(texturePath));
             // set up scaling of textures
             sprite.setSize(config.xScaling, config.yScaling);
             // where to draw the sprite
-            sprite.setPosition(position.x + config.xOffset, position.y + config.yOffset);
+            sprite.setPosition(realX, realY);
 
             // need to be called before drawing
             batch.begin();


### PR DESCRIPTION
Hinzufügen des Offsets in dem frustum check.

![frustum vorher](https://github.com/Programmiermethoden/Dungeon/assets/32952411/5d030cf2-5a1b-4df0-89e0-c0784a9a9950)

nach fix:

![frustum](https://github.com/Programmiermethoden/Dungeon/assets/32952411/0c5f1db7-4910-4a56-87ad-dc6caba3417c)


