### PR TITLE
[DUNGEON] fix bug where game would crash if no mission was selected

### DIFF
--- a/dungeon/src/starter/Starter.java
+++ b/dungeon/src/starter/Starter.java
@@ -129,12 +129,12 @@ public class Starter {
                 () -> {
                     debugKey();
                     // the player selected a Task/DSL-Entrypoint but it´s not loaded yet:
-                    if (!realGameStarted && WizardTaskSelector.selectedDSLEntryPoint != null) {
+                    if (!realGameStarted && TaskSelector.selectedDSLEntryPoint != null) {
                         realGameStarted = true;
 
                         DungeonConfig config =
                                 dslInterpreter.interpretEntryPoint(
-                                        WizardTaskSelector.selectedDSLEntryPoint);
+                                        TaskSelector.selectedDSLEntryPoint);
                         ILevel level =
                                 TaskGraphConverter.convert(
                                         config.dependencyGraph(), dslInterpreter);
@@ -149,7 +149,7 @@ public class Starter {
                 () -> {
                     createHero();
                     createSystems();
-                    Game.currentLevel(WizardTaskSelector.wizardLevel());
+                    Game.currentLevel(TaskSelector.wizardLevel());
                     setupMusic();
                 });
 
@@ -157,11 +157,10 @@ public class Starter {
         Game.userOnLevelLoad(
                 (firstTime) -> {
                     // this will be at the start of the game
-                    if (firstTime && WizardTaskSelector.selectedDSLEntryPoint == null) {
+                    if (firstTime && TaskSelector.selectedDSLEntryPoint == null) {
                         try {
                             Game.add(
-                                    WizardTaskSelector.wizard(
-                                            WizardTaskSelector.selectTaskQuestion(entryPoints)));
+                                    TaskSelector.npc(TaskSelector.selectTaskQuestion(entryPoints)));
                         } catch (IOException e) {
                             throw new RuntimeException(e);
                         }

--- a/dungeon/src/starter/Starter.java
+++ b/dungeon/src/starter/Starter.java
@@ -115,7 +115,7 @@ public class Starter {
         // some game Setup
         configGame();
         // will load the level to select the task/DSL-Entrypoint on Game start
-        wizardSelectorOnSetup(entryPoints);
+        taskSelectorOnSetup(entryPoints);
 
         // will generate the TaskDependencyGraph, execute the TaskBuilder, generate and set the
         // Level and generate the PetriNet after the player selected an DSLEntryPoint
@@ -144,16 +144,16 @@ public class Starter {
                 });
     }
 
-    private static void wizardSelectorOnSetup(Set<DSLEntryPoint> entryPoints) {
+    private static void taskSelectorOnSetup(Set<DSLEntryPoint> entryPoints) {
         Game.userOnSetup(
                 () -> {
                     createHero();
                     createSystems();
-                    Game.currentLevel(TaskSelector.wizardLevel());
+                    Game.currentLevel(TaskSelector.taskSelectorLevel());
                     setupMusic();
                 });
 
-        // load the wizard task selector level
+        // load the task selector level
         Game.userOnLevelLoad(
                 (firstTime) -> {
                     // this will be at the start of the game

--- a/dungeon/src/starter/TaskSelector.java
+++ b/dungeon/src/starter/TaskSelector.java
@@ -23,8 +23,8 @@ import java.util.Set;
 import java.util.function.BiConsumer;
 
 /**
- * This class contains static methods to create the Wizard-Level to select the tasks at the start of
- * the game.
+ * This class contains static methods to create the TaskSelector-Level to select the tasks at the
+ * start of the game.
  *
  * <p>This class is part of the {@link Starter} and should not be used otherwise. The code is
  * extracted into this class for better code readability.
@@ -32,7 +32,7 @@ import java.util.function.BiConsumer;
 public class TaskSelector {
     protected static DSLEntryPoint selectedDSLEntryPoint = null;
 
-    protected static ILevel wizardLevel() {
+    protected static ILevel taskSelectorLevel() {
         // default layout is:
         //
         // W W W W W
@@ -93,17 +93,17 @@ public class TaskSelector {
     }
 
     protected static Entity npc(SingleChoice selectionQuestion) throws IOException {
-        Entity wizard = new Entity("Selection NPC");
-        wizard.addComponent(new DrawComponent("character/blue_knight"));
-        wizard.addComponent(new PositionComponent());
-        wizard.addComponent(
+        Entity npc = new Entity("Selection NPC");
+        npc.addComponent(new DrawComponent("character/blue_knight"));
+        npc.addComponent(new PositionComponent());
+        npc.addComponent(
                 new InteractionComponent(
                         1,
                         true,
                         UIAnswerCallback.askOnInteraction(
                                 selectionQuestion, setSelectedEntryPoint())));
 
-        return wizard;
+        return npc;
     }
 
     private static BiConsumer<Task, Set<TaskContent>> setSelectedEntryPoint() {

--- a/dungeon/src/starter/TaskSelector.java
+++ b/dungeon/src/starter/TaskSelector.java
@@ -29,7 +29,7 @@ import java.util.function.BiConsumer;
  * <p>This class is part of the {@link Starter} and should not be used otherwise. The code is
  * extracted into this class for better code readability.
  */
-public class WizardTaskSelector {
+public class TaskSelector {
     protected static DSLEntryPoint selectedDSLEntryPoint = null;
 
     protected static ILevel wizardLevel() {
@@ -92,9 +92,9 @@ public class WizardTaskSelector {
         return question;
     }
 
-    protected static Entity wizard(SingleChoice selectionQuestion) throws IOException {
-        Entity wizard = new Entity("Selection Wizard");
-        wizard.addComponent(new DrawComponent("character/wizard"));
+    protected static Entity npc(SingleChoice selectionQuestion) throws IOException {
+        Entity wizard = new Entity("Selection NPC");
+        wizard.addComponent(new DrawComponent("character/blue_knight"));
         wizard.addComponent(new PositionComponent());
         wizard.addComponent(
                 new InteractionComponent(
@@ -108,6 +108,7 @@ public class WizardTaskSelector {
 
     private static BiConsumer<Task, Set<TaskContent>> setSelectedEntryPoint() {
         return (task, taskContents) -> {
+            if (taskContents.isEmpty()) return;
             selectedDSLEntryPoint =
                     ((PayloadTaskContent)
                                     taskContents.stream()


### PR DESCRIPTION
Unser kleiner Zaubrer (der jetzt nach Absprache ein blauer Ritter ist), bringt das Spiel jetzt nicht mehr zum absturz, wenn bei der Missionsauswahl keine Aufgabe ausgewählt wird. Das Fenster geht jetzt einfach zu und man muss erneut mit ihm sprechen. 
