### PR TITLE
[DUNGEON] change dungeon starter for the evaluation 

### DIFF
--- a/dungeon/src/reporting/GradingFunctions.java
+++ b/dungeon/src/reporting/GradingFunctions.java
@@ -136,7 +136,6 @@ public class GradingFunctions {
             Map<Element, Set<Element>> solution = assignTask.solution();
             int elementCount = solution.values().stream().mapToInt(Set::size).sum();
             float pointsPerAnswer = assignTask.points() / elementCount;
-            System.out.println(pointsPerAnswer);
             float reachedPoints = 0f;
 
             Element wrap = (Element) containers.stream().findFirst().orElseThrow();

--- a/dungeon/src/starter/Starter.java
+++ b/dungeon/src/starter/Starter.java
@@ -15,8 +15,8 @@ import core.Entity;
 import core.Game;
 import core.components.PlayerComponent;
 import core.level.elements.ILevel;
-
 import core.utils.components.MissingComponentException;
+
 import dungeonFiles.DSLEntryPoint;
 import dungeonFiles.DslFileLoader;
 import dungeonFiles.DungeonConfig;
@@ -195,7 +195,9 @@ public class Starter {
                             fetch ->
                                     fetch.registerCallback(
                                             KeyboardConfig.INFOS.value(), showInfos, false, true));
-            hero.fetch(HealthComponent.class).orElseThrow(()-> MissingComponentException.build(hero,HealthComponent.class)).godMode(true);
+            hero.fetch(HealthComponent.class)
+                    .orElseThrow(() -> MissingComponentException.build(hero, HealthComponent.class))
+                    .godMode(true);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
@@ -219,10 +221,8 @@ public class Starter {
         Game.add(new AISystem());
         Game.add(new CollisionSystem());
         Game.add(new HealthSystem());
-        Game.add(new XPSystem());
         Game.add(new ProjectileSystem());
         Game.add(new HealthbarSystem());
-        Game.add(new HeroUISystem());
         Game.add(new HudSystem());
         Game.add(new SpikeSystem());
         Game.add(new IdleSoundSystem());

--- a/dungeon/src/starter/Starter.java
+++ b/dungeon/src/starter/Starter.java
@@ -1,7 +1,6 @@
 package starter;
 
 import com.badlogic.gdx.Gdx;
-import com.badlogic.gdx.Input;
 import com.badlogic.gdx.audio.Music;
 
 import contrib.components.HealthComponent;
@@ -129,7 +128,6 @@ public class Starter {
     private static void onEntryPointSelection() {
         Game.userOnFrame(
                 () -> {
-                    debugKey();
                     // the player selected a Task/DSL-Entrypoint but it´s not loaded yet:
                     if (!realGameStarted && TaskSelector.selectedDSLEntryPoint != null) {
                         realGameStarted = true;
@@ -233,16 +231,5 @@ public class Starter {
         backgroundMusic.setLooping(true);
         backgroundMusic.play();
         backgroundMusic.setVolume(.1f);
-    }
-
-    private static void debugKey() {
-        if (Gdx.input.isKeyJustPressed(Input.Keys.F)) {
-            Task.allTasks()
-                    .filter(t -> t.state() == Task.TaskState.PROCESSING_ACTIVE)
-                    .findFirst()
-                    .get()
-                    .state(Task.TaskState.FINISHED_CORRECT);
-            System.out.println(Task.allTasks());
-        }
     }
 }

--- a/dungeon/src/starter/Starter.java
+++ b/dungeon/src/starter/Starter.java
@@ -4,6 +4,7 @@ import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input;
 import com.badlogic.gdx.audio.Music;
 
+import contrib.components.HealthComponent;
 import contrib.configuration.KeyboardConfig;
 import contrib.crafting.Crafting;
 import contrib.entities.EntityFactory;
@@ -15,6 +16,7 @@ import core.Game;
 import core.components.PlayerComponent;
 import core.level.elements.ILevel;
 
+import core.utils.components.MissingComponentException;
 import dungeonFiles.DSLEntryPoint;
 import dungeonFiles.DslFileLoader;
 import dungeonFiles.DungeonConfig;
@@ -193,7 +195,7 @@ public class Starter {
                             fetch ->
                                     fetch.registerCallback(
                                             KeyboardConfig.INFOS.value(), showInfos, false, true));
-
+            hero.fetch(HealthComponent.class).orElseThrow(()-> MissingComponentException.build(hero,HealthComponent.class)).godMode(true);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/dungeon/src/starter/Starter.java
+++ b/dungeon/src/starter/Starter.java
@@ -28,6 +28,7 @@ import interpreter.DSLInterpreter;
 import task.Task;
 
 import java.io.IOException;
+import java.text.DecimalFormat;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -97,7 +98,9 @@ public class Starter {
                                     if (task.id() != 0) { // Exclude task with ID 0
                                         infos.append(task.taskName())
                                                 .append(" ")
-                                                .append(task.achievedPoints())
+                                                .append(
+                                                        new DecimalFormat("#.#")
+                                                                .format(task.achievedPoints()))
                                                 .append(" P")
                                                 .append(System.lineSeparator());
                                     }

--- a/game/src/contrib/entities/EntityFactory.java
+++ b/game/src/contrib/entities/EntityFactory.java
@@ -22,7 +22,6 @@ import contrib.utils.components.skill.SkillTools;
 import core.Entity;
 import core.Game;
 import core.components.*;
-import core.utils.Constants;
 import core.utils.Point;
 import core.utils.Tuple;
 import core.utils.components.MissingComponentException;
@@ -41,6 +40,7 @@ import java.util.stream.IntStream;
  * static methods to construct various types of entities with different components.
  */
 public class EntityFactory {
+    public static final int DEFAULT_INVENTORY_SIZE = 10;
     private static final Random RANDOM = new Random();
     private static final String HERO_FILE_PATH = "character/wizard";
     private static final float X_SPEED_HERO = 7.5f;
@@ -130,7 +130,7 @@ public class EntityFactory {
         hero.addComponent(new XPComponent((e) -> {}));
         PlayerComponent pc = new PlayerComponent();
         hero.addComponent(pc);
-        InventoryComponent ic = new InventoryComponent(Constants.DEFAULT_INVENTORY_SIZE);
+        InventoryComponent ic = new InventoryComponent(DEFAULT_INVENTORY_SIZE);
         hero.addComponent(ic);
         Skill fireball =
                 new Skill(new FireballSkill(SkillTools::cursorPositionAsPoint), FIREBALL_COOL_DOWN);

--- a/game/src/core/utils/Constants.java
+++ b/game/src/core/utils/Constants.java
@@ -44,7 +44,6 @@ public final class Constants {
     public static final String DEFAULT_BUTTON_MESSAGE = "OK ";
     public static final String QUIZ_MESSAGE_TASK = "Aufgabestellung";
     public static final String QUIZ_MESSAGE_SOLUTION = "Lösung";
-    public static final int DEFAULT_INVENTORY_SIZE = 5;
     public static final float DEFAULT_ITEM_PICKUP_RADIUS = 2.0f;
     public static final float DEFAULT_FRICTION = 0.8f;
 


### PR DESCRIPTION
Dieser PR passt den Dungeon-Starter so an, dass er für die Evaluierung verwende werden kann.

Key änderungen sind
* Godmode für den Spieler aktiviert
* Debug Funktionen deaktiviert/entfernt
* Nicht verwendete Syteme enfernt
* Floats werden jetzt auf eine Nachkommerstelle gerundet im HUD angezeigt