### PR TITLE
[DUNGEON/GAME| fix bugs found at evaluation

### DIFF
--- a/dungeon/src/starter/Starter.java
+++ b/dungeon/src/starter/Starter.java
@@ -1,9 +1,11 @@
 package starter;
 
 import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Input;
 import com.badlogic.gdx.audio.Music;
 
 import contrib.components.HealthComponent;
+import contrib.components.InventoryComponent;
 import contrib.configuration.KeyboardConfig;
 import contrib.crafting.Crafting;
 import contrib.entities.EntityFactory;
@@ -25,10 +27,12 @@ import graphconverter.TaskGraphConverter;
 import interpreter.DSLEntryPointFinder;
 import interpreter.DSLInterpreter;
 
+import task.QuestItem;
 import task.Task;
 
 import java.io.IOException;
 import java.text.DecimalFormat;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -133,6 +137,26 @@ public class Starter {
     private static void onEntryPointSelection() {
         Game.userOnFrame(
                 () -> {
+                    if (Gdx.input.isKeyJustPressed(Input.Keys.O)) {
+                        System.out.println(
+                                Game.hero().get().fetch(InventoryComponent.class).get().count());
+                        Arrays.stream(
+                                        Game.hero()
+                                                .get()
+                                                .fetch(InventoryComponent.class)
+                                                .get()
+                                                .items())
+                                .filter(i -> i != null)
+                                .forEach(i -> System.out.println(i.toString()));
+                        Arrays.stream(
+                                        Game.hero()
+                                                .get()
+                                                .fetch(InventoryComponent.class)
+                                                .get()
+                                                .items())
+                                .filter(i -> i != null)
+                                .forEach(i -> System.out.println(i instanceof QuestItem));
+                    }
 
                     // the player selected a Task/DSL-Entrypoint but it´s not loaded yet:
                     if (!realGameStarted && TaskSelector.selectedDSLEntryPoint != null) {

--- a/dungeon/src/starter/Starter.java
+++ b/dungeon/src/starter/Starter.java
@@ -1,11 +1,9 @@
 package starter;
 
 import com.badlogic.gdx.Gdx;
-import com.badlogic.gdx.Input;
 import com.badlogic.gdx.audio.Music;
 
 import contrib.components.HealthComponent;
-import contrib.components.InventoryComponent;
 import contrib.configuration.KeyboardConfig;
 import contrib.crafting.Crafting;
 import contrib.entities.EntityFactory;
@@ -27,12 +25,10 @@ import graphconverter.TaskGraphConverter;
 import interpreter.DSLEntryPointFinder;
 import interpreter.DSLInterpreter;
 
-import task.QuestItem;
 import task.Task;
 
 import java.io.IOException;
 import java.text.DecimalFormat;
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -137,27 +133,6 @@ public class Starter {
     private static void onEntryPointSelection() {
         Game.userOnFrame(
                 () -> {
-                    if (Gdx.input.isKeyJustPressed(Input.Keys.O)) {
-                        System.out.println(
-                                Game.hero().get().fetch(InventoryComponent.class).get().count());
-                        Arrays.stream(
-                                        Game.hero()
-                                                .get()
-                                                .fetch(InventoryComponent.class)
-                                                .get()
-                                                .items())
-                                .filter(i -> i != null)
-                                .forEach(i -> System.out.println(i.toString()));
-                        Arrays.stream(
-                                        Game.hero()
-                                                .get()
-                                                .fetch(InventoryComponent.class)
-                                                .get()
-                                                .items())
-                                .filter(i -> i != null)
-                                .forEach(i -> System.out.println(i instanceof QuestItem));
-                    }
-
                     // the player selected a Task/DSL-Entrypoint but it´s not loaded yet:
                     if (!realGameStarted && TaskSelector.selectedDSLEntryPoint != null) {
                         realGameStarted = true;

--- a/dungeon/src/task/Task.java
+++ b/dungeon/src/task/Task.java
@@ -447,7 +447,6 @@ public abstract class Task {
                                         .content()
                                         .task()
                                         .equals(t)) {
-                                    // item.drop(hero, pc.position());
                                     ic.remove(item);
                                 }
                             }

--- a/dungeon/src/task/Task.java
+++ b/dungeon/src/task/Task.java
@@ -447,7 +447,7 @@ public abstract class Task {
                                         .content()
                                         .task()
                                         .equals(t)) {
-                                    item.drop(hero, pc.position());
+                                    //item.drop(hero, pc.position());
                                     ic.remove(item);
                                 }
                             }

--- a/dungeon/src/task/Task.java
+++ b/dungeon/src/task/Task.java
@@ -447,7 +447,7 @@ public abstract class Task {
                                         .content()
                                         .task()
                                         .equals(t)) {
-                                    //item.drop(hero, pc.position());
+                                    // item.drop(hero, pc.position());
                                     ic.remove(item);
                                 }
                             }

--- a/game/src/contrib/entities/WorldItemBuilder.java
+++ b/game/src/contrib/entities/WorldItemBuilder.java
@@ -27,7 +27,7 @@ public class WorldItemBuilder {
 
         droppedItem.addComponent(
                 new InteractionComponent(
-                        Constants.DEFAULT_ITEM_PICKUP_RADIUS, false, item::collect));
+                        Constants.DEFAULT_ITEM_PICKUP_RADIUS, true, item::collect));
 
         return droppedItem;
     }

--- a/game/src/core/systems/PositionSystem.java
+++ b/game/src/core/systems/PositionSystem.java
@@ -4,6 +4,7 @@ import core.Entity;
 import core.Game;
 import core.System;
 import core.components.PositionComponent;
+import core.level.utils.Coordinate;
 import core.level.utils.LevelElement;
 import core.utils.components.MissingComponentException;
 
@@ -36,7 +37,15 @@ public class PositionSystem extends System {
     }
 
     private void randomPosition(PSData data) {
-        if (Game.currentLevel() != null) data.pc.position(Game.randomTile(LevelElement.FLOOR));
+        if (Game.currentLevel() != null) {
+            Coordinate c = Game.randomTile(LevelElement.FLOOR).coordinate();
+            boolean b =
+                    entityStream()
+                            .map(this::buildDataObject)
+                            .anyMatch(psData -> psData.pc().position().toCoordinate().equals(c));
+            if (!b) data.pc().position(c.toPoint());
+            else randomPosition(data);
+        }
     }
 
     private PSData buildDataObject(Entity e) {

--- a/game/src/core/systems/VelocitySystem.java
+++ b/game/src/core/systems/VelocitySystem.java
@@ -4,7 +4,6 @@ import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.math.Vector2;
 
 import contrib.components.ProjectileComponent;
-import contrib.hud.UITools;
 
 import core.Entity;
 import core.Game;
@@ -110,7 +109,6 @@ public final class VelocitySystem extends System {
             // for some reason the entity is out of bound
             vsd.pc().position(PositionComponent.ILLEGAL_POSITION);
             LOGGER.warning("Entity " + e + " is out of bound");
-            UITools.generateNewTextDialog(e.toString(), "ok", vsd.e().toString());
         }
     }
 

--- a/game/test/core/systems/PositionSystemTest.java
+++ b/game/test/core/systems/PositionSystemTest.java
@@ -8,6 +8,7 @@ import core.components.PositionComponent;
 import core.level.Tile;
 import core.level.elements.ILevel;
 import core.level.elements.tile.FloorTile;
+import core.level.utils.Coordinate;
 import core.level.utils.LevelElement;
 import core.utils.Point;
 
@@ -39,6 +40,7 @@ public class PositionSystemTest {
 
         Mockito.when(level.randomTile(LevelElement.FLOOR)).thenReturn(mock);
         Mockito.when(mock.position()).thenReturn(point);
+        Mockito.when(mock.coordinate()).thenReturn(new Coordinate(3, 3));
     }
 
     @After


### PR DESCRIPTION
Fixes, die ich für die Evaluierung mache (hoffentlich bis die zweite Gruppe dran ist):

* Fixt Bug, der dafür gesorgt hat, dass man nicht mehrfach mit Items auf den Boden interagieren konnte. Das führte dazu, dass man, wenn man einmal mit vollem Inventar versucht hat, das Item aufzuheben, das Item nie mehr aufheben konnte.
* Fixt Bug, bei dem manchmal Entitäten zufällig aufeinander platziert wurden. Wenn so ein Item auf einer Kiste lag, konnte man das Item nicht aufheben, da immer die Kiste aufging.
* Fixt Bug, der das Spiel zum Absturz gebracht hat, wenn eine Entität (aus noch unbekannten Gründen) out of bounds lag.
* löscht jetzt alte questitems aus dem Spielerinventar anstelle sie nur fallen zu lassen (die Studis haben die dann immer wieder aufgesammelt und waren genervt sie wieder fallen zu lassen): 