### PR TITLE
[DUNGEON] show correct answers after question was answered false

### DIFF
--- a/dungeon/src/task/AssignTask.java
+++ b/dungeon/src/task/AssignTask.java
@@ -6,6 +6,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.BiFunction;
+import java.util.function.Consumer;
 
 /**
  * Assignment Task.
@@ -44,5 +45,29 @@ public class AssignTask extends Task {
      */
     public Map<Element, Set<Element>> solution() {
         return new HashMap<>(solution);
+    }
+
+    @Override
+    public String correctAnswersAsString() {
+        StringBuilder answers = new StringBuilder();
+        solution.keySet()
+                .forEach(
+                        new Consumer<Element>() {
+                            @Override
+                            public void accept(Element element) {
+                                if (!element.content().toString().isBlank())
+                                    answers.append(element.content().toString()).append(": ");
+                                else answers.append("Nicht zuzuordnen: ");
+                                solution.get(element)
+                                        .forEach(
+                                                e ->
+                                                        answers.append(e.content().toString())
+                                                                .append(", "));
+                                answers.deleteCharAt(answers.length() - 2); // remove last ","
+                                answers.append(System.lineSeparator());
+                            }
+                        });
+
+        return answers.toString();
     }
 }

--- a/dungeon/src/task/Quiz.java
+++ b/dungeon/src/task/Quiz.java
@@ -121,6 +121,14 @@ public abstract class Quiz extends Task {
         return question;
     }
 
+    @Override
+    public String correctAnswersAsString() {
+        StringBuilder answers = new StringBuilder();
+        correctAnswerIndices.forEach(
+                i -> answers.append(contentByIndex(i).toString()).append(System.lineSeparator()));
+        return answers.toString();
+    }
+
     /**
      * Content for a {@link Quiz}-
      *

--- a/dungeon/src/task/ReplacementTask.java
+++ b/dungeon/src/task/ReplacementTask.java
@@ -38,10 +38,26 @@ public class ReplacementTask extends Task {
         return new ArrayList<>(rules);
     }
 
+    @Override
+    public String correctAnswersAsString() {
+        StringBuilder answers = new StringBuilder();
+        solution.forEach(
+                s -> answers.append(s.content().toString()).append(System.lineSeparator()));
+        answers.append("Ersetzungsregeln").append(System.lineSeparator());
+        rules.forEach(r -> answers.append(r.toString()).append(System.lineSeparator()));
+        return answers.toString();
+    }
+
     /**
      * Rules for how elements can be replaced by each other.
      *
      * <p>This is basically an abstract implementation of {@link contrib.crafting.Recipe}.
      */
-    public record Rule(boolean ordered, Element[] input, Element[] output) {}
+    public record Rule(boolean ordered, Element[] input, Element[] output) {
+        @Override
+        public String toString() {
+            // todo
+            return "There is no String represnation for the rules yet.";
+        }
+    }
 }

--- a/dungeon/src/task/Task.java
+++ b/dungeon/src/task/Task.java
@@ -508,6 +508,13 @@ public abstract class Task {
     }
 
     /**
+     * Get a String represnation of the correct answers, to show on the HUD.
+     *
+     * @return String represnation of the correct answers
+     */
+    public abstract String correctAnswersAsString();
+
+    /**
      * Status that a task can assume.
      *
      * <p>ACTIVE - The task can be actively worked on.

--- a/dungeon/src/task/YesNoDialog.java
+++ b/dungeon/src/task/YesNoDialog.java
@@ -159,7 +159,16 @@ public class YesNoDialog {
             if (t.state() == Task.TaskState.FINISHED_CORRECT) output.append("korrekt ");
             else output.append("falsch ");
             output.append("gelöst");
-            OkDialog.showOkDialog(output.toString(), "Ergebnis", () -> {});
+            OkDialog.showOkDialog(
+                    output.toString(),
+                    "Ergebnis",
+                    () -> {
+                        // if task was finisehd wrong show correct answers
+                        if (score < t.points()) {
+                            OkDialog.showOkDialog(
+                                    t.correctAnswersAsString(), "Korrekte Antwort", () -> {});
+                        }
+                    });
         };
     }
 }

--- a/dungeon/src/task/quizquestion/QuizUI.java
+++ b/dungeon/src/task/quizquestion/QuizUI.java
@@ -63,7 +63,18 @@ public class QuizUI {
                                         else output.append("falsch ");
                                         output.append("gelöst");
                                         OkDialog.showOkDialog(
-                                                output.toString(), "Ergebnis", () -> {});
+                                                output.toString(),
+                                                "Ergebnis",
+                                                () -> {
+                                                    // if task was finisehd wrong show correct
+                                                    // answers
+                                                    if (score < task.points()) {
+                                                        OkDialog.showOkDialog(
+                                                                task.correctAnswersAsString(),
+                                                                "Korrekte Antwort",
+                                                                () -> {});
+                                                    }
+                                                });
                                     }
                                 }));
     }

--- a/dungeon/test/petriNet/PetriNetFactoryTest.java
+++ b/dungeon/test/petriNet/PetriNetFactoryTest.java
@@ -296,5 +296,10 @@ public class PetriNetFactoryTest {
         // assertEquals(Task.TaskState.INACTIVE, pre1.state());
     }
 
-    private static class DummyTask extends Task {}
+    private static class DummyTask extends Task {
+        @Override
+        public String correctAnswersAsString() {
+            return null;
+        }
+    }
 }

--- a/dungeon/test/petriNet/PlaceTest.java
+++ b/dungeon/test/petriNet/PlaceTest.java
@@ -119,5 +119,10 @@ public class PlaceTest {
         Mockito.verify(transitionB).notify(place);
     }
 
-    private static class DummyTask extends Task {}
+    private static class DummyTask extends Task {
+        @Override
+        public String correctAnswersAsString() {
+            return null;
+        }
+    }
 }

--- a/dungeon/test/task/TaskContentDoorOpenerTest.java
+++ b/dungeon/test/task/TaskContentDoorOpenerTest.java
@@ -50,5 +50,10 @@ public class TaskContentDoorOpenerTest {
         assertTrue(door.isOpen());
     }
 
-    private static class DummyTask extends Task {}
+    private static class DummyTask extends Task {
+        @Override
+        public String correctAnswersAsString() {
+            return null;
+        }
+    }
 }

--- a/dungeon/test/task/TaskTest.java
+++ b/dungeon/test/task/TaskTest.java
@@ -124,5 +124,10 @@ public class TaskTest {
         assertTrue(t1.id() != t2.id());
     }
 
-    private static class DummyTask extends Task {}
+    private static class DummyTask extends Task {
+        @Override
+        public String correctAnswersAsString() {
+            return null;
+        }
+    }
 }


### PR DESCRIPTION
fixes #1177 

Nachdem ein Task nicht 100% korrekt gelöst wurde, wird ein Fenster geöffnet, welches dann die richtige Lösung zeigt.

Dafür wurde die abstrakte Methode `correctAnswersAsString` in `Task` hinzugefügt.
Da wir noch keine vollständige Implementierung für die Crafting Aufgaben haben, hab ich auch keine konkrete Idee wie die Ersetzungsregeln aufzuzeigen sind.

Für SC,MC ist die Darstellung: 

<img width="224" alt="image" src="https://github.com/Programmiermethoden/Dungeon/assets/32962412/179f39e8-3c5f-41b7-8b23-742ea18eae2c">



Für AssignTask ist die Darsellung: 

<img width="316" alt="Bildschirmfoto 2023-11-07 um 14 02 00" src="https://github.com/Programmiermethoden/Dungeon/assets/32962412/289e06d8-fd4b-42de-a19a-b87d5ee2c3e1">
