### PR TITLE
[DUNGEON] add Anzeige für Erklärungstext und korrekte Antwort an, falls ein Task falsch bearbeitet wurde

### DIFF
--- a/dungeon/src/task/Task.java
+++ b/dungeon/src/task/Task.java
@@ -68,7 +68,6 @@ public abstract class Task {
     private String taskText;
     private String scenarioText;
     private String taskName;
-    private String explanation;
     private Entity managementEntity;
     private Set<Set<Entity>> entitySets = new HashSet<>();
     private float pointsToSolve;
@@ -211,24 +210,6 @@ public abstract class Task {
      */
     public String taskName() {
         return taskName;
-    }
-
-    /**
-     * Get the task explanation.
-     *
-     * @return task explanation
-     */
-    public String taskExplanation() {
-        return explanation;
-    }
-
-    /**
-     * Set the task explanation.
-     *
-     * @return task explanation
-     */
-    public void taskExplanation(String explanation) {
-        this.explanation = explanation;
     }
 
     /**

--- a/dungeon/src/task/Task.java
+++ b/dungeon/src/task/Task.java
@@ -1,11 +1,9 @@
 package task;
 
 import contrib.components.InventoryComponent;
-import contrib.item.Item;
 
 import core.Entity;
 import core.Game;
-import core.components.PositionComponent;
 import core.utils.MissingHeroException;
 import core.utils.components.MissingComponentException;
 
@@ -22,7 +20,6 @@ import java.nio.file.Paths;
 import java.text.SimpleDateFormat;
 import java.util.*;
 import java.util.function.BiFunction;
-import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.logging.FileHandler;
 import java.util.logging.Logger;
@@ -55,6 +52,7 @@ public abstract class Task {
     private static final Set<Task> ALL_TASKS = new HashSet<>();
     private static final List<Task> SOLVED_TASK_IN_ORDER = new ArrayList<>();
     private static final String DEFAULT_TASK_TEXT = "No task description provided";
+    public static final String DEFAULT_EXPLANATION = "No explanation provided";
     private static final TaskState DEFAULT_TASK_STATE = TaskState.INACTIVE;
     private static final float DEFAULT_POINTS = 1f;
     private static final float DEFAULT_POINTS_TO_SOLVE = DEFAULT_POINTS;
@@ -73,6 +71,8 @@ public abstract class Task {
     private Entity managementEntity;
     private Set<Set<Entity>> entitySets = new HashSet<>();
     private float pointsToSolve;
+
+    private String explanation = DEFAULT_EXPLANATION;
 
     private float achievedPoints;
 
@@ -228,6 +228,25 @@ public abstract class Task {
      */
     public void scenarioText(String scenarioText) {
         this.scenarioText = scenarioText;
+    }
+
+    /**
+     * Set the explanation on how to solve the task, that will be shown after a task was solved with
+     * mistakes.
+     *
+     * @param explanation Text that explains how to solve the task.
+     */
+    public void explanation(String explanation) {
+        this.explanation = explanation;
+    }
+
+    /**
+     * Get an explanation on how to solve the task.
+     *
+     * @return Explanation on how to solve the task.
+     */
+    public String explanation() {
+        return explanation;
     }
 
     /**
@@ -430,25 +449,16 @@ public abstract class Task {
                                 () ->
                                         MissingComponentException.build(
                                                 hero, InventoryComponent.class));
-        PositionComponent pc =
-                hero.fetch(PositionComponent.class)
-                        .orElseThrow(
-                                () ->
-                                        MissingComponentException.build(
-                                                hero, PositionComponent.class));
         Task t = this;
         ic.items(QuestItem.class)
                 .forEach(
-                        new Consumer<>() {
-                            @Override
-                            public void accept(Item item) {
-                                if (((QuestItem) item)
-                                        .taskContentComponent()
-                                        .content()
-                                        .task()
-                                        .equals(t)) {
-                                    ic.remove(item);
-                                }
+                        item -> {
+                            if (((QuestItem) item)
+                                    .taskContentComponent()
+                                    .content()
+                                    .task()
+                                    .equals(t)) {
+                                ic.remove(item);
                             }
                         });
     }
@@ -466,7 +476,7 @@ public abstract class Task {
      * Set the amount of points that this task is worth.
      *
      * @param points points that this task is worth.
-     * @param pointsToSolve amount of points that is needed to solve this task sucessfully.
+     * @param pointsToSolve amount of points that is needed to solve this task successfully.
      */
     public void points(float points, float pointsToSolve) {
         this.points = points;
@@ -485,7 +495,11 @@ public abstract class Task {
                 .filter(
                         e -> {
                             TaskContentComponent taskContentComponent =
-                                    e.fetch(TaskContentComponent.class).get();
+                                    e.fetch(TaskContentComponent.class)
+                                            .orElseThrow(
+                                                    () ->
+                                                            MissingComponentException.build(
+                                                                    e, TaskContentComponent.class));
                             return taskContentComponent.content().equals(taskContent);
                         })
                 .findFirst();
@@ -508,9 +522,9 @@ public abstract class Task {
     }
 
     /**
-     * Get a String represnation of the correct answers, to show on the HUD.
+     * Get a String representation of the correct answers, to show on the HUD.
      *
-     * @return String represnation of the correct answers
+     * @return String representation of the correct answers
      */
     public abstract String correctAnswersAsString();
 

--- a/dungeon/src/task/Task.java
+++ b/dungeon/src/task/Task.java
@@ -68,6 +68,7 @@ public abstract class Task {
     private String taskText;
     private String scenarioText;
     private String taskName;
+    private String explanation;
     private Entity managementEntity;
     private Set<Set<Entity>> entitySets = new HashSet<>();
     private float pointsToSolve;
@@ -210,6 +211,24 @@ public abstract class Task {
      */
     public String taskName() {
         return taskName;
+    }
+
+    /**
+     * Get the task explanation.
+     *
+     * @return task explanation
+     */
+    public String taskExplanation() {
+        return explanation;
+    }
+
+    /**
+     * Set the task explanation.
+     *
+     * @return task explanation
+     */
+    public void taskExplanation(String explanation) {
+        this.explanation = explanation;
     }
 
     /**

--- a/dungeon/src/task/YesNoDialog.java
+++ b/dungeon/src/task/YesNoDialog.java
@@ -165,8 +165,19 @@ public class YesNoDialog {
                     () -> {
                         // if task was finisehd wrong show correct answers
                         if (score < t.points()) {
-                            OkDialog.showOkDialog(
-                                    t.correctAnswersAsString(), "Korrekte Antwort", () -> {});
+                            if (!t.explanation().equals(Task.DEFAULT_EXPLANATION)) {
+                                OkDialog.showOkDialog(
+                                        t.explanation(),
+                                        "Erklärung",
+                                        () ->
+                                                OkDialog.showOkDialog(
+                                                        t.correctAnswersAsString(),
+                                                        "Korrekte Antwort",
+                                                        () -> {}));
+                            } else {
+                                OkDialog.showOkDialog(
+                                        t.correctAnswersAsString(), "Korrekte Antwort", () -> {});
+                            }
                         }
                     });
         };

--- a/dungeon/src/task/YesNoDialog.java
+++ b/dungeon/src/task/YesNoDialog.java
@@ -159,24 +159,26 @@ public class YesNoDialog {
             if (t.state() == Task.TaskState.FINISHED_CORRECT) output.append("korrekt ");
             else output.append("falsch ");
             output.append("gelöst");
+
+            IVoidFunction showCorrectAnswer =
+                    () ->
+                            OkDialog.showOkDialog(
+                                    "'" + t.correctAnswersAsString() + "'",
+                                    "Korrekte Antwort",
+                                    () -> {});
+
             OkDialog.showOkDialog(
                     output.toString(),
                     "Ergebnis",
                     () -> {
-                        // if task was finisehd wrong show correct answers
+                        // if task was finished wrong show correct answers
                         if (score < t.points()) {
-                            if (!t.explanation().equals(Task.DEFAULT_EXPLANATION)) {
+                            if (!t.explanation().isBlank()
+                                    && !t.explanation().equals(Task.DEFAULT_EXPLANATION)) {
                                 OkDialog.showOkDialog(
-                                        t.explanation(),
-                                        "Erklärung",
-                                        () ->
-                                                OkDialog.showOkDialog(
-                                                        t.correctAnswersAsString(),
-                                                        "Korrekte Antwort",
-                                                        () -> {}));
+                                        t.explanation(), "Erklärung", showCorrectAnswer);
                             } else {
-                                OkDialog.showOkDialog(
-                                        t.correctAnswersAsString(), "Korrekte Antwort", () -> {});
+                                showCorrectAnswer.execute();
                             }
                         }
                     });

--- a/dungeon/src/task/quizquestion/QuizUI.java
+++ b/dungeon/src/task/quizquestion/QuizUI.java
@@ -10,6 +10,7 @@ import contrib.hud.UITools;
 
 import core.Entity;
 import core.Game;
+import core.utils.IVoidFunction;
 
 import task.Quiz;
 import task.Task;
@@ -58,29 +59,32 @@ public class QuizUI {
                                     else output.append("falsch ");
                                     output.append("gelöst");
 
+                                    IVoidFunction showCorrectAnswer =
+                                            () ->
+                                                    OkDialog.showOkDialog(
+                                                            "'"
+                                                                    + task.correctAnswersAsString()
+                                                                    + "'",
+                                                            "Korrekte Antwort",
+                                                            () -> {});
+
                                     OkDialog.showOkDialog(
                                             output.toString(),
                                             "Ergebnis",
                                             () -> {
-                                                // if task was finisehd wrong show correct
-                                                // answers
+                                                // if task was finished wrong show correct answers
                                                 if (score < task.points()) {
-                                                    if (!task.explanation()
-                                                            .equals(Task.DEFAULT_EXPLANATION)) {
+                                                    if (!task.explanation().isBlank()
+                                                            && !task.explanation()
+                                                                    .equals(
+                                                                            Task
+                                                                                    .DEFAULT_EXPLANATION)) {
                                                         OkDialog.showOkDialog(
                                                                 task.explanation(),
                                                                 "Erklärung",
-                                                                () ->
-                                                                        OkDialog.showOkDialog(
-                                                                                task
-                                                                                        .correctAnswersAsString(),
-                                                                                "Korrekte Antwort",
-                                                                                () -> {}));
+                                                                showCorrectAnswer);
                                                     } else {
-                                                        OkDialog.showOkDialog(
-                                                                task.correctAnswersAsString(),
-                                                                "Korrekte Antwort",
-                                                                () -> {});
+                                                        showCorrectAnswer.execute();
                                                     }
                                                 }
                                             });

--- a/dungeon/src/task/quizquestion/QuizUI.java
+++ b/dungeon/src/task/quizquestion/QuizUI.java
@@ -13,11 +13,8 @@ import core.Game;
 
 import task.Quiz;
 import task.Task;
-import task.TaskContent;
 
 import java.util.Objects;
-import java.util.Set;
-import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
@@ -46,36 +43,47 @@ public class QuizUI {
                         UIAnswerCallback.uiCallback(
                                 quiz,
                                 hudEntity,
-                                new BiConsumer<Task, Set<TaskContent>>() {
-                                    @Override
-                                    public void accept(Task task, Set<TaskContent> taskContents) {
-                                        float score = task.gradeTask(taskContents);
-                                        StringBuilder output = new StringBuilder();
-                                        output.append("Du hast ")
-                                                .append(score)
-                                                .append("/")
-                                                .append(task.points())
-                                                .append(" Punkte erreicht")
-                                                .append(System.lineSeparator())
-                                                .append("Die Aufgabe ist damit ");
-                                        if (task.state() == Task.TaskState.FINISHED_CORRECT)
-                                            output.append("korrekt ");
-                                        else output.append("falsch ");
-                                        output.append("gelöst");
-                                        OkDialog.showOkDialog(
-                                                output.toString(),
-                                                "Ergebnis",
-                                                () -> {
-                                                    // if task was finisehd wrong show correct
-                                                    // answers
-                                                    if (score < task.points()) {
+                                (task, taskContents) -> {
+                                    float score = task.gradeTask(taskContents);
+                                    StringBuilder output = new StringBuilder();
+                                    output.append("Du hast ")
+                                            .append(score)
+                                            .append("/")
+                                            .append(task.points())
+                                            .append(" Punkte erreicht")
+                                            .append(System.lineSeparator())
+                                            .append("Die Aufgabe ist damit ");
+                                    if (task.state() == Task.TaskState.FINISHED_CORRECT)
+                                        output.append("korrekt ");
+                                    else output.append("falsch ");
+                                    output.append("gelöst");
+
+                                    OkDialog.showOkDialog(
+                                            output.toString(),
+                                            "Ergebnis",
+                                            () -> {
+                                                // if task was finisehd wrong show correct
+                                                // answers
+                                                if (score < task.points()) {
+                                                    if (!task.explanation()
+                                                            .equals(Task.DEFAULT_EXPLANATION)) {
+                                                        OkDialog.showOkDialog(
+                                                                task.explanation(),
+                                                                "Erklärung",
+                                                                () ->
+                                                                        OkDialog.showOkDialog(
+                                                                                task
+                                                                                        .correctAnswersAsString(),
+                                                                                "Korrekte Antwort",
+                                                                                () -> {}));
+                                                    } else {
                                                         OkDialog.showOkDialog(
                                                                 task.correctAnswersAsString(),
                                                                 "Korrekte Antwort",
                                                                 () -> {});
                                                     }
-                                                });
-                                    }
+                                                }
+                                            });
                                 }));
     }
 

--- a/dungeon/src/task/taskdsltypes/AssignTaskDSLType.java
+++ b/dungeon/src/task/taskdsltypes/AssignTaskDSLType.java
@@ -34,7 +34,7 @@ public class AssignTaskDSLType {
         AssignTask task = new AssignTask();
         task.taskText(description);
         task.taskName(name);
-        task.taskExplanation(explanation);
+        task.explanation(explanation);
 
         if (points > 0.0f && pointsToPass > 0.0f) {
             task.points(points, pointsToPass);

--- a/dungeon/src/task/taskdsltypes/AssignTaskDSLType.java
+++ b/dungeon/src/task/taskdsltypes/AssignTaskDSLType.java
@@ -27,12 +27,14 @@ public class AssignTaskDSLType {
             @DSLTypeMember(name = "points") float points,
             @DSLTypeMember(name = "points_to_pass") float pointsToPass,
             @DSLTypeMember(name = "solution") Set<List<Element<String>>> solution,
+            @DSLTypeMember(name = "explanation") String explanation,
             @DSLTypeMember(name = "grading_function")
                     BiFunction<Task, Set<TaskContent>, Float> gradingFunction) {
 
         AssignTask task = new AssignTask();
         task.taskText(description);
         task.taskName(name);
+        task.taskExplanation(explanation);
 
         if (points > 0.0f && pointsToPass > 0.0f) {
             task.points(points, pointsToPass);

--- a/dungeon/src/task/taskdsltypes/MultipleChoiceTask.java
+++ b/dungeon/src/task/taskdsltypes/MultipleChoiceTask.java
@@ -25,12 +25,14 @@ public class MultipleChoiceTask {
             @DSLTypeMember(name = "points") float points,
             @DSLTypeMember(name = "points_to_pass") float pointsToPass,
             @DSLTypeMember(name = "correct_answer_index") List<Integer> correctAnswerIndices,
+            @DSLTypeMember(name = "explanation") String explanation,
             @DSLTypeMember(name = "grading_function")
                     BiFunction<Task, Set<TaskContent>, Float> gradingFunction
             //  scoreFunction
             ) {
         MultipleChoice mc = new MultipleChoice(description);
         mc.taskName(name);
+        mc.taskExplanation(explanation);
 
         if (points > 0.0f && pointsToPass > 0.0f) {
             mc.points(points, pointsToPass);

--- a/dungeon/src/task/taskdsltypes/MultipleChoiceTask.java
+++ b/dungeon/src/task/taskdsltypes/MultipleChoiceTask.java
@@ -32,7 +32,7 @@ public class MultipleChoiceTask {
             ) {
         MultipleChoice mc = new MultipleChoice(description);
         mc.taskName(name);
-        mc.taskExplanation(explanation);
+        mc.explanation(explanation);
 
         if (points > 0.0f && pointsToPass > 0.0f) {
             mc.points(points, pointsToPass);

--- a/dungeon/src/task/taskdsltypes/SingleChoiceTask.java
+++ b/dungeon/src/task/taskdsltypes/SingleChoiceTask.java
@@ -26,10 +26,12 @@ public class SingleChoiceTask {
             @DSLTypeMember(name = "points") float points,
             @DSLTypeMember(name = "points_to_pass") float pointsToPass,
             @DSLTypeMember(name = "correct_answer_index") int correctAnswerIndex,
+            @DSLTypeMember(name = "explanation") String explanation,
             @DSLTypeMember(name = "grading_function")
                     BiFunction<Task, Set<TaskContent>, Float> gradingFunction) {
         SingleChoice sc = new SingleChoice(description);
         sc.taskName(name);
+        sc.taskExplanation(explanation);
 
         if (points > 0.0f && pointsToPass > 0.0f) {
             sc.points(points, pointsToPass);

--- a/dungeon/src/task/taskdsltypes/SingleChoiceTask.java
+++ b/dungeon/src/task/taskdsltypes/SingleChoiceTask.java
@@ -31,7 +31,7 @@ public class SingleChoiceTask {
                     BiFunction<Task, Set<TaskContent>, Float> gradingFunction) {
         SingleChoice sc = new SingleChoice(description);
         sc.taskName(name);
-        sc.taskExplanation(explanation);
+        sc.explanation(explanation);
 
         if (points > 0.0f && pointsToPass > 0.0f) {
             sc.points(points, pointsToPass);


### PR DESCRIPTION
fixes #1178 
Erweitert `Task` um ein Feld zur Erklärung wie eine Aufgabe gelöst werden muss (also auf fachlicher ebene).
Wenn eine Task im Spiel nicht 100% richtig gelöst wird, dann wird nach der Anzeige der erreichten Punkte, die Erklärung angezeigt und danach die richtige Lösung.

Wenn keine Erklärung gesetzt ist, wird nach den erreichten Punkten sofort die richtige Lösung angezeigt



@malt-r du müsstest das jetzt nur noch in der DSL einbauen