### PR TITLE
[GAME] Abhängigkeiten zu `contrib` in `DrawComponentTest` entfernt

### DIFF
--- a/game/test/core/components/DrawComponentTest.java
+++ b/game/test/core/components/DrawComponentTest.java
@@ -2,8 +2,6 @@ package core.components;
 
 import static org.junit.Assert.*;
 
-import contrib.utils.components.draw.ChestAnimations;
-
 import core.utils.components.draw.CoreAnimations;
 
 import org.junit.Before;
@@ -65,6 +63,6 @@ public class DrawComponentTest {
     @Test
     public void hasAnimations() {
         assertTrue(animationComponent.hasAnimation(CoreAnimations.RUN_LEFT));
-        assertFalse(animationComponent.hasAnimation(ChestAnimations.OPENING));
+        assertFalse(animationComponent.hasAnimation(CoreAnimations.RUN_DOWN));
     }
 }


### PR DESCRIPTION
fixes #1188

Der `DrawComponentTest` hat mit einer Animation getestet, die Im `contrib` Package lag. Diese wurde mit einer Animation ersetzt, die im `core` Package liegt.