### PR TITLE
[DSL] Fix Fehlkonfiguration QuestChest

### DIFF
--- a/dungeon/src/dsltypeproperties/EntityExtension.java
+++ b/dungeon/src/dsltypeproperties/EntityExtension.java
@@ -214,7 +214,7 @@ public class EntityExtension {
 
             UIComponent uiComponent =
                     new UIComponent(
-                            new GUICombination(new InventoryGUI(otherIc), inventory), false);
+                            new GUICombination(new InventoryGUI(otherIc), inventory), true);
             uiComponent.onClose(
                     () ->
                             chest.fetch(DrawComponent.class)

--- a/dungeon/src/dsltypeproperties/EntityExtension.java
+++ b/dungeon/src/dsltypeproperties/EntityExtension.java
@@ -242,7 +242,7 @@ public class EntityExtension {
                                                             ChestAnimations.OPEN_EMPTY);
                                                 }
                                             }));
-            chest.addComponent(uiComponent);
+            other.addComponent(uiComponent);
             chest.fetch(DrawComponent.class)
                     .ifPresent(
                             interactedDC -> {

--- a/dungeon/src/dsltypeproperties/EntityExtension.java
+++ b/dungeon/src/dsltypeproperties/EntityExtension.java
@@ -213,8 +213,7 @@ public class EntityExtension {
             }
 
             UIComponent uiComponent =
-                    new UIComponent(
-                            new GUICombination(new InventoryGUI(otherIc), inventory), true);
+                    new UIComponent(new GUICombination(new InventoryGUI(otherIc), inventory), true);
             uiComponent.onClose(
                     () ->
                             chest.fetch(DrawComponent.class)

--- a/dungeon/src/dsltypeproperties/EntityExtension.java
+++ b/dungeon/src/dsltypeproperties/EntityExtension.java
@@ -214,7 +214,7 @@ public class EntityExtension {
 
             UIComponent uiComponent =
                     new UIComponent(
-                            new GUICombination(inventory, new InventoryGUI(otherIc)), false);
+                            new GUICombination(new InventoryGUI(otherIc), inventory), false);
             uiComponent.onClose(
                     () ->
                             chest.fetch(DrawComponent.class)


### PR DESCRIPTION
Fixes #1172 

Aus Issue:

Folgende "Fehler" sind aufgetreten

- [x] Bug: In HUD von QuestChest kann man mit I das Inventar öffnen
- [x] Bug: HUD von QuestChest ist vertauscht (normalerweise ist das Truhen HUD rechts und das Hero HUD links)
- [ ] Bug: HUD von QuestChest, man kann nicht (immer?) die Itembeschreibung lesen (aktuell nicht explizit gefixt, allerdings auch nicht mehr reproduzierbar)

Weitere Bugs, die mir aufgefallen sind:
- [x] Bug: Hero kann sich während geöffnetem QuestChest-Inventar bewegen, bei regulären `Chest`s ist das nicht so.