### PR TITLE
[DSL/GAME] Erklärungs-Attribut zu tasks hinzufügen und optional bei falscher Antwort anzeigen

### DIFF
--- a/dungeon/assets/scripts/evaluation.dng
+++ b/dungeon/assets/scripts/evaluation.dng
@@ -142,7 +142,8 @@ single_choice_task task1_a {
   "Man kann nicht auf den  Betriebssystemen Windows, MACOS und Linux in Python programmieren.",
   "Man kann in Python-Programmen die Zeilen einrücken, wie man möchte.", "Schlüsselfelder eignen sich nicht zum Indizieren von Daten.",
   "Keine davon ist richtig."],
-  correct_answer_index: 3
+  correct_answer_index: 3,
+  explanation: "Von den möglichen fachlichen Antworten ist keine korrekt."
 }
 
 

--- a/dungeon/src/task/Task.java
+++ b/dungeon/src/task/Task.java
@@ -70,6 +70,7 @@ public abstract class Task {
     private String taskText;
     private String scenarioText;
     private String taskName;
+    private String explanation;
     private Entity managementEntity;
     private Set<Set<Entity>> entitySets = new HashSet<>();
     private float pointsToSolve;
@@ -210,6 +211,24 @@ public abstract class Task {
      */
     public String taskName() {
         return taskName;
+    }
+
+    /**
+     * Get the task explanation.
+     *
+     * @return task explanation
+     */
+    public String taskExplanation() {
+        return explanation;
+    }
+
+    /**
+     * Set the task explanation.
+     *
+     * @return task explanation
+     */
+    public void taskExplanation(String explanation) {
+        this.explanation = explanation;
     }
 
     /**

--- a/dungeon/src/task/YesNoDialog.java
+++ b/dungeon/src/task/YesNoDialog.java
@@ -159,14 +159,27 @@ public class YesNoDialog {
             if (t.state() == Task.TaskState.FINISHED_CORRECT) output.append("korrekt ");
             else output.append("falsch ");
             output.append("gelöst");
+
+            // function to show the correct answer of the task
+            IVoidFunction showCorrectAnswer =
+                    () ->
+                            OkDialog.showOkDialog(
+                                    t.correctAnswersAsString(), "Korrekte Antwort", () -> {});
+
             OkDialog.showOkDialog(
                     output.toString(),
                     "Ergebnis",
                     () -> {
-                        // if task was finisehd wrong show correct answers
                         if (score < t.points()) {
-                            OkDialog.showOkDialog(
-                                    t.correctAnswersAsString(), "Korrekte Antwort", () -> {});
+                            // show explanation, if there is one and link the showing of correct answer
+                            // as followup OkDialog
+                            String explanation = t.taskExplanation();
+                            if (!explanation.isBlank()) {
+                                OkDialog.showOkDialog(explanation, "Erklärung", showCorrectAnswer);
+                            } else {
+                                // just show the correct answer
+                                showCorrectAnswer.execute();
+                            }
                         }
                     });
         };

--- a/dungeon/src/task/taskdsltypes/AssignTaskDSLType.java
+++ b/dungeon/src/task/taskdsltypes/AssignTaskDSLType.java
@@ -27,12 +27,14 @@ public class AssignTaskDSLType {
             @DSLTypeMember(name = "points") float points,
             @DSLTypeMember(name = "points_to_pass") float pointsToPass,
             @DSLTypeMember(name = "solution") Set<List<Element<String>>> solution,
+            @DSLTypeMember(name = "explanation") String explanation,
             @DSLTypeMember(name = "grading_function")
                     BiFunction<Task, Set<TaskContent>, Float> gradingFunction) {
 
         AssignTask task = new AssignTask();
         task.taskText(description);
         task.taskName(name);
+        task.taskExplanation(explanation);
 
         if (points > 0.0f && pointsToPass > 0.0f) {
             task.points(points, pointsToPass);

--- a/dungeon/src/task/taskdsltypes/MultipleChoiceTask.java
+++ b/dungeon/src/task/taskdsltypes/MultipleChoiceTask.java
@@ -25,12 +25,14 @@ public class MultipleChoiceTask {
             @DSLTypeMember(name = "points") float points,
             @DSLTypeMember(name = "points_to_pass") float pointsToPass,
             @DSLTypeMember(name = "correct_answer_index") List<Integer> correctAnswerIndices,
+            @DSLTypeMember(name = "explanation") String explanation,
             @DSLTypeMember(name = "grading_function")
                     BiFunction<Task, Set<TaskContent>, Float> gradingFunction
             //  scoreFunction
             ) {
         MultipleChoice mc = new MultipleChoice(description);
         mc.taskName(name);
+        mc.taskExplanation(explanation);
 
         if (points > 0.0f && pointsToPass > 0.0f) {
             mc.points(points, pointsToPass);

--- a/dungeon/src/task/taskdsltypes/SingleChoiceTask.java
+++ b/dungeon/src/task/taskdsltypes/SingleChoiceTask.java
@@ -26,10 +26,12 @@ public class SingleChoiceTask {
             @DSLTypeMember(name = "points") float points,
             @DSLTypeMember(name = "points_to_pass") float pointsToPass,
             @DSLTypeMember(name = "correct_answer_index") int correctAnswerIndex,
+            @DSLTypeMember(name = "explanation") String explanation,
             @DSLTypeMember(name = "grading_function")
                     BiFunction<Task, Set<TaskContent>, Float> gradingFunction) {
         SingleChoice sc = new SingleChoice(description);
         sc.taskName(name);
+        sc.taskExplanation(explanation);
 
         if (points > 0.0f && pointsToPass > 0.0f) {
             sc.points(points, pointsToPass);


### PR DESCRIPTION
Fixes #1178 

Aktuell ist das so umgesetzt, das es nur einen Erklärungstext für die gesamte Aufgabe gibt. Es wäre natürlich auch denkbar, für unterschiedliche Fehlerszenarien unterschiedliche Erklärungen vorzusehen, das wäre dann allerdings nochmal deutlich mehr Aufwand.

Die Erklärung (`taskExplanation`) eines Tasks wird in einem `OkDialog` nach einer falsch beantworteten Frage angezeigt, falls er nicht leer ist (überprüft mit `String::isBlank`).