### PR TITLE
[DUNGEON] remove all QuestItems after a Task is solved

### DIFF
--- a/dungeon/src/task/Task.java
+++ b/dungeon/src/task/Task.java
@@ -2,8 +2,6 @@ package task;
 
 import contrib.components.InventoryComponent;
 import contrib.components.ItemComponent;
-import contrib.item.Item;
-
 
 import core.Entity;
 import core.Game;

--- a/dungeon/src/task/Task.java
+++ b/dungeon/src/task/Task.java
@@ -1,11 +1,11 @@
 package task;
 
 import contrib.components.InventoryComponent;
+import contrib.components.ItemComponent;
 import contrib.item.Item;
 
 import core.Entity;
 import core.Game;
-import core.components.PositionComponent;
 import core.utils.MissingHeroException;
 import core.utils.components.MissingComponentException;
 
@@ -418,24 +418,46 @@ public abstract class Task {
         else state(TaskState.FINISHED_WRONG);
         achievedPoints = score;
 
-        dropQuestItems();
+        removeQuestItems();
         return score;
     }
 
-    private void dropQuestItems() {
+    private void removeQuestItems() {
         Entity hero = Game.hero().orElseThrow(MissingHeroException::new);
+        Task t = this;
+        // remove all quest items in invetorys
+        Game.allEntities()
+                .filter(entity -> entity.isPresent(InventoryComponent.class))
+                .forEach(entity -> removeQuestItemFromInventory(entity));
+        Game.allEntities()
+                .filter(entity -> entity.isPresent(ItemComponent.class))
+                .forEach(
+                        entity -> {
+                            ItemComponent ic =
+                                    entity.fetch(ItemComponent.class)
+                                            .orElseThrow(
+                                                    () ->
+                                                            MissingComponentException.build(
+                                                                    entity, ItemComponent.class));
+                            if (ic.item() instanceof QuestItem) {
+                                if (((QuestItem) ic.item())
+                                        .taskContentComponent()
+                                        .content()
+                                        .task()
+                                        .equals(t)) {
+                                    Game.remove(entity);
+                                }
+                            }
+                        });
+    }
+
+    private void removeQuestItemFromInventory(Entity hero) {
         InventoryComponent ic =
                 hero.fetch(InventoryComponent.class)
                         .orElseThrow(
                                 () ->
                                         MissingComponentException.build(
                                                 hero, InventoryComponent.class));
-        PositionComponent pc =
-                hero.fetch(PositionComponent.class)
-                        .orElseThrow(
-                                () ->
-                                        MissingComponentException.build(
-                                                hero, PositionComponent.class));
         Task t = this;
         ic.items(QuestItem.class)
                 .forEach(


### PR DESCRIPTION
Es werden jetzt alle QuestItems im Spiel entfernt (also aus dem Helden Inventar, aus Kisten und die, die in der Welt liegen), wenn eine Task fertig bearbeitet ist. 