### PR TITLE
[GAME] spawn entities on tile center

### DIFF
--- a/game/src/core/systems/PositionSystem.java
+++ b/game/src/core/systems/PositionSystem.java
@@ -6,6 +6,7 @@ import core.System;
 import core.components.PositionComponent;
 import core.level.utils.Coordinate;
 import core.level.utils.LevelElement;
+import core.utils.Point;
 import core.utils.components.MissingComponentException;
 
 /**
@@ -43,8 +44,13 @@ public class PositionSystem extends System {
                     entityStream()
                             .map(this::buildDataObject)
                             .anyMatch(psData -> psData.pc().position().toCoordinate().equals(c));
-            if (!b) data.pc().position(c.toPoint());
-            else randomPosition(data);
+            if (!b) {
+                Point position = c.toPoint();
+                // place on center
+                position.x += 0.5f;
+                position.y += 0.5f;
+                data.pc().position(position);
+            } else randomPosition(data);
         }
     }
 

--- a/game/test/core/systems/PositionSystemTest.java
+++ b/game/test/core/systems/PositionSystemTest.java
@@ -53,8 +53,10 @@ public class PositionSystemTest {
     @Test
     public void test_illegalPosition() {
         pc.position(PositionComponent.ILLEGAL_POSITION);
+        // entities will be placed in the center of a tile, so add the offset for check
+        Point offsetPoint = new Point(point.x + 0.5f, point.y + 0.5f);
         system.execute();
-        assertTrue(pc.position().equals(point));
+        assertTrue(pc.position().equals(offsetPoint));
     }
 
     @Test


### PR DESCRIPTION
Das PositionSystem platziert jetzt die Entitäten in der mitte eines Tiles.



@AHeinisch ich glaube du hattest das schonmal für die Schatzkisten gemacht. Ist jetzt wieder da, nur woanders :) 