### PR TITLE
[GAME] split `Game` into seperat classes, use `Game` as center API

### DIFF
--- a/game/src/core/Entity.java
+++ b/game/src/core/Entity.java
@@ -1,5 +1,7 @@
 package core;
 
+import core.game.ECSManagment;
+
 import dsl.semanticanalysis.types.DSLContextPush;
 import dsl.semanticanalysis.types.DSLType;
 
@@ -65,7 +67,7 @@ public final class Entity implements Comparable<Entity> {
      * Add a new component to this entity.
      *
      * <p>Changes in the component map of the entity will trigger a call to {@link
-     * Game#informAboutChanges}.
+     * ECSManagment#informAboutChanges}.
      *
      * <p>Normally, a component will add itself to its associated entity, so you will not have to do
      * it manually. Remember that an entity can only store one component of each component class.
@@ -74,7 +76,7 @@ public final class Entity implements Comparable<Entity> {
      */
     public void addComponent(final Component component) {
         components.put(component.getClass(), component);
-        Game.informAboutChanges(this);
+        ECSManagment.informAboutChanges(this);
         LOGGER.info(component.getClass().getName() + " Components from " + this + " was added.");
     }
 
@@ -82,13 +84,13 @@ public final class Entity implements Comparable<Entity> {
      * Remove a component from this entity.
      *
      * <p>Changes in the component map of the entity will trigger a call to {@link
-     * Game#informAboutChanges}.
+     * ECSManagment#informAboutChanges}.
      *
      * @param klass the Class of the component
      */
     public void removeComponent(final Class<? extends Component> klass) {
         if (components.remove(klass) != null) {
-            Game.informAboutChanges(this);
+            ECSManagment.informAboutChanges(this);
             LOGGER.info(klass.getName() + " from " + name + " was removed.");
         }
     }

--- a/game/src/core/Game.java
+++ b/game/src/core/Game.java
@@ -30,7 +30,7 @@ import java.util.stream.Stream;
 /**
  * The Center-Point of the framework.
  *
- * <p>This class is basicly a API-Class, it will forward the request to the responsible classes.
+ * <p>This class is basically an API-Class, it will forward the request to the responsible classes.
  */
 public final class Game {
 
@@ -96,66 +96,12 @@ public final class Game {
     }
 
     /**
-     * Retrieves the full-screen mode from the pre-run configuration.
-     *
-     * @return True if full-screen mode is enabled, false otherwise.
-     */
-    public static boolean fullScreen() {
-        return PreRunConfiguration.fullScreen();
-    }
-
-    /**
-     * Sets the full-screen mode in the pre-run configuration.
-     *
-     * @param fullscreen True to enable full-screen mode, false otherwise.
-     */
-    public static void fullScreen(boolean fullscreen) {
-        PreRunConfiguration.fullScreen(fullscreen);
-    }
-
-    /**
-     * Retrieves the window title from the pre-run configuration.
-     *
-     * @return The window title.
-     */
-    public static String windowTitle() {
-        return PreRunConfiguration.windowTitle();
-    }
-
-    /**
      * Sets the window title in the pre-run configuration.
      *
      * @param windowTitle The new window title.
      */
     public static void windowTitle(String windowTitle) {
         PreRunConfiguration.windowTitle(windowTitle);
-    }
-
-    /**
-     * Retrieves the logo path from the pre-run configuration.
-     *
-     * @return The logo path.
-     */
-    public static String logoPath() {
-        return PreRunConfiguration.logoPath();
-    }
-
-    /**
-     * Sets the logo path in the pre-run configuration.
-     *
-     * @param logoPath The new logo path.
-     */
-    public static void logoPath(String logoPath) {
-        PreRunConfiguration.logoPath(logoPath);
-    }
-
-    /**
-     * Retrieves the audio disable setting from the pre-run configuration.
-     *
-     * @return True if audio is disabled, false otherwise.
-     */
-    public static boolean disableAudio() {
-        return PreRunConfiguration.disableAudio();
     }
 
     /**
@@ -168,15 +114,6 @@ public final class Game {
     }
 
     /**
-     * Retrieves the user-defined function for frame updates from the pre-run configuration.
-     *
-     * @return The user-defined function for frame updates.
-     */
-    public static IVoidFunction userOnFrame() {
-        return PreRunConfiguration.userOnFrame();
-    }
-
-    /**
      * Sets the user-defined function for frame updates in the pre-run configuration.
      *
      * @param userOnFrame The new user-defined function for frame updates.
@@ -186,30 +123,12 @@ public final class Game {
     }
 
     /**
-     * Retrieves the user-defined function for setup from the pre-run configuration.
-     *
-     * @return The user-defined function for setup.
-     */
-    public static IVoidFunction userOnSetup() {
-        return PreRunConfiguration.userOnSetup();
-    }
-
-    /**
      * Sets the user-defined function for setup in the pre-run configuration.
      *
      * @param userOnSetup The new user-defined function for setup.
      */
     public static void userOnSetup(IVoidFunction userOnSetup) {
         PreRunConfiguration.userOnSetup(userOnSetup);
-    }
-
-    /**
-     * Retrieves the user-defined function for level load from the pre-run configuration.
-     *
-     * @return The user-defined function for level load.
-     */
-    public static Consumer<Boolean> userOnLevelLoad() {
-        return PreRunConfiguration.userOnLevelLoad();
     }
 
     /**

--- a/game/src/core/Game.java
+++ b/game/src/core/Game.java
@@ -14,18 +14,24 @@ import core.level.elements.ILevel;
 import core.level.utils.Coordinate;
 import core.level.utils.LevelElement;
 import core.level.utils.LevelSize;
-import core.systems.*;
+import core.systems.LevelSystem;
 import core.utils.IVoidFunction;
 import core.utils.Point;
 import core.utils.components.MissingComponentException;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.function.Consumer;
 import java.util.logging.Logger;
 import java.util.stream.Stream;
 
-/** The heart of the framework. From here all strings are pulled. */
+/**
+ * The Center-Point of the framework.
+ *
+ * <p>This class is basicly a API-Class, it will forward the request to the responsible classes.
+ */
 public final class Game {
 
     private static final Logger LOGGER = Logger.getLogger("Game");
@@ -35,105 +41,220 @@ public final class Game {
         GameLoop.run();
     }
 
-    // ====================PreRunConfiguration====================
-
+    /**
+     * Retrieves the window width from the pre-run configuration.
+     *
+     * @return The window width.
+     */
     public static int windowWidth() {
         return PreRunConfiguration.windowWidth();
     }
 
+    /**
+     * Sets the window width in the pre-run configuration.
+     *
+     * @param windowWidth The new window width.
+     */
     public static void windowWidth(int windowWidth) {
         PreRunConfiguration.windowWidth(windowWidth);
     }
 
+    /**
+     * Retrieves the window height from the pre-run configuration.
+     *
+     * @return The window height.
+     */
     public static int windowHeight() {
         return PreRunConfiguration.windowHeight();
     }
 
+    /**
+     * Sets the window height in the pre-run configuration.
+     *
+     * @param windowHeight The new window height.
+     */
     public static void windowHeight(int windowHeight) {
         PreRunConfiguration.windowHeight(windowHeight);
     }
 
+    /**
+     * Retrieves the frame rate from the pre-run configuration.
+     *
+     * @return The frame rate.
+     */
     public static int frameRate() {
         return PreRunConfiguration.frameRate();
     }
 
+    /**
+     * Sets the frame rate in the pre-run configuration.
+     *
+     * @param frameRate The new frame rate.
+     */
     public static void frameRate(int frameRate) {
         PreRunConfiguration.frameRate(frameRate);
     }
 
+    /**
+     * Retrieves the full-screen mode from the pre-run configuration.
+     *
+     * @return True if full-screen mode is enabled, false otherwise.
+     */
     public static boolean fullScreen() {
         return PreRunConfiguration.fullScreen();
     }
 
+    /**
+     * Sets the full-screen mode in the pre-run configuration.
+     *
+     * @param fullscreen True to enable full-screen mode, false otherwise.
+     */
     public static void fullScreen(boolean fullscreen) {
         PreRunConfiguration.fullScreen(fullscreen);
     }
 
+    /**
+     * Retrieves the window title from the pre-run configuration.
+     *
+     * @return The window title.
+     */
     public static String windowTitle() {
         return PreRunConfiguration.windowTitle();
     }
 
+    /**
+     * Sets the window title in the pre-run configuration.
+     *
+     * @param windowTitle The new window title.
+     */
     public static void windowTitle(String windowTitle) {
         PreRunConfiguration.windowTitle(windowTitle);
     }
 
+    /**
+     * Retrieves the logo path from the pre-run configuration.
+     *
+     * @return The logo path.
+     */
     public static String logoPath() {
         return PreRunConfiguration.logoPath();
     }
 
+    /**
+     * Sets the logo path in the pre-run configuration.
+     *
+     * @param logoPath The new logo path.
+     */
     public static void logoPath(String logoPath) {
         PreRunConfiguration.logoPath(logoPath);
     }
 
+    /**
+     * Retrieves the audio disable setting from the pre-run configuration.
+     *
+     * @return True if audio is disabled, false otherwise.
+     */
     public static boolean disableAudio() {
         return PreRunConfiguration.disableAudio();
     }
 
+    /**
+     * Sets the audio disable setting in the pre-run configuration.
+     *
+     * @param disableAudio True to disable audio, false otherwise.
+     */
     public static void disableAudio(boolean disableAudio) {
         PreRunConfiguration.disableAudio(disableAudio);
     }
 
+    /**
+     * Retrieves the user-defined function for frame updates from the pre-run configuration.
+     *
+     * @return The user-defined function for frame updates.
+     */
     public static IVoidFunction userOnFrame() {
         return PreRunConfiguration.userOnFrame();
     }
 
+    /**
+     * Sets the user-defined function for frame updates in the pre-run configuration.
+     *
+     * @param userOnFrame The new user-defined function for frame updates.
+     */
     public static void userOnFrame(IVoidFunction userOnFrame) {
         PreRunConfiguration.userOnFrame(userOnFrame);
     }
 
+    /**
+     * Retrieves the user-defined function for setup from the pre-run configuration.
+     *
+     * @return The user-defined function for setup.
+     */
     public static IVoidFunction userOnSetup() {
         return PreRunConfiguration.userOnSetup();
     }
 
+    /**
+     * Sets the user-defined function for setup in the pre-run configuration.
+     *
+     * @param userOnSetup The new user-defined function for setup.
+     */
     public static void userOnSetup(IVoidFunction userOnSetup) {
         PreRunConfiguration.userOnSetup(userOnSetup);
     }
 
+    /**
+     * Retrieves the user-defined function for level load from the pre-run configuration.
+     *
+     * @return The user-defined function for level load.
+     */
     public static Consumer<Boolean> userOnLevelLoad() {
         return PreRunConfiguration.userOnLevelLoad();
     }
 
+    /**
+     * Sets the user-defined function for level load in the pre-run configuration.
+     *
+     * @param userOnLevelLoad The new user-defined function for level load.
+     */
     public static void userOnLevelLoad(Consumer<Boolean> userOnLevelLoad) {
         PreRunConfiguration.userOnLevelLoad(userOnLevelLoad);
     }
 
+    /**
+     * Initializes the base logger. Removes the console handler and puts all log messages in the log
+     * files.
+     */
     public static void initBaseLogger() {
         PreRunConfiguration.initBaseLogger();
     }
 
+    /**
+     * Loads the configuration from the given path. If the configuration has already been loaded,
+     * the cached version will be used.
+     *
+     * @param pathAsString The path to the config file as a string.
+     * @param keyboardConfigClass The class where the ConfigKey fields are located.
+     * @param keyboardConfigClass1 The class where the ConfigKey fields are located.
+     * @throws IOException If the file could not be read.
+     */
     public static void loadConfig(
-            String s,
+            String pathAsString,
             Class<KeyboardConfig> keyboardConfigClass,
             Class<core.configuration.KeyboardConfig> keyboardConfigClass1)
             throws IOException {
-        PreRunConfiguration.loadConfig(s, keyboardConfigClass, keyboardConfigClass1);
+        PreRunConfiguration.loadConfig(pathAsString, keyboardConfigClass, keyboardConfigClass1);
     }
 
-    // ECS MANAGMENT
-
+    /**
+     * Retrieves the optional stage from the game loop.
+     *
+     * @return The optional stage.
+     */
     public static Optional<Stage> stage() {
         return GameLoop.stage();
     }
+
     /**
      * The given entity will be added to the game.
      *
@@ -158,6 +279,7 @@ public final class Game {
     public static void remove(Entity entity) {
         ECSManagment.remove(entity);
     }
+
     /**
      * Add a {@link System} to the game.
      *
@@ -177,6 +299,7 @@ public final class Game {
     public static Optional<System> add(System system) {
         return ECSManagment.add(system);
     }
+
     /**
      * @return a copy of the map that stores all registered {@link System} in the game.
      */
@@ -282,7 +405,6 @@ public final class Game {
         return ECSManagment.find(component);
     }
 
-    // LEVEL API
     /**
      * @return the currently loaded level
      */

--- a/game/src/core/Game.java
+++ b/game/src/core/Game.java
@@ -13,8 +13,10 @@ import com.badlogic.gdx.scenes.scene2d.Stage;
 import com.badlogic.gdx.utils.Scaling;
 import com.badlogic.gdx.utils.viewport.ScalingViewport;
 
+import contrib.configuration.KeyboardConfig;
+
 import core.components.PositionComponent;
-import core.configuration.Configuration;
+import core.game.PreRunConfiguration;
 import core.level.Tile;
 import core.level.elements.ILevel;
 import core.level.generator.postGeneration.WallGenerator;
@@ -28,7 +30,6 @@ import core.utils.EntitySystemMapper;
 import core.utils.IVoidFunction;
 import core.utils.Point;
 import core.utils.components.MissingComponentException;
-import core.utils.logging.LoggerConfig;
 
 import java.io.IOException;
 import java.util.*;
@@ -40,250 +41,120 @@ import java.util.stream.Stream;
 public final class Game extends ScreenAdapter {
 
     // ====================SETUP====================
-
     private static final Logger LOGGER = Logger.getLogger("Game");
 
-    private static int WINDOW_WIDTH = 1280;
-    /**
-     * Part of the pre-run configuration. The height of the game window in pixels.
-     *
-     * <p>Manipulating this value will only result in changes before {@link Game#run} was executed.
-     */
-    private static int WINDOW_HEIGHT = 720;
-    /**
-     * Part of the pre-run configuration. The fps of the game (frames per second)
-     *
-     * <p>Manipulating this value will only result in changes before {@link Game#run} was executed.
-     */
-    private static int FRAME_RATE = 30;
-    /**
-     * Part of the pre-run configuration. If this value is true, the game will be started in full
-     * screen mode.
-     *
-     * <p>Manipulating this value will only result in changes before {@link Game#run} was executed.
-     */
-    private static boolean FULL_SCREEN = false;
-    /**
-     * Part of the pre-run configuration. The title of the Game-Window.
-     *
-     * <p>Manipulating this value will only result in changes before {@link Game#run} was executed.
-     */
-    private static String WINDOW_TITLE = "PM-Dungeon";
-    /**
-     * Part of the pre-run configuration. The path (as String) to the logo of the Game-Window.
-     *
-     * <p>Manipulating this value will only result in changes before {@link Game#run} was executed.
-     */
-    private static String LOGO_PATH = "logo/cat_logo_35x35.png";
-
-    /**
-     * Part of the pre-run configuration. If this value is true, the audio for the game will be
-     * disabled.
-     *
-     * <p>Manipulating this value will only result in changes before {@link Game#run} was executed.
-     */
-    private static boolean DISABLE_AUDIO = false;
-    /**
-     * Width of the game-window in pixel
-     *
-     * @return the width of the game-window im pixel
-     */
     public static int windowWidth() {
-        return WINDOW_WIDTH;
+        return PreRunConfiguration.windowWidth();
     }
 
-    /**
-     * Height of the game-window in pixel
-     *
-     * @return the height of the game-window im pixel
-     */
-    public static int windowHeight() {
-        return WINDOW_HEIGHT;
-    }
-
-    /**
-     * Get the current frame rate of the game
-     *
-     * @return current frame rate of the game
-     */
-    public static int frameRate() {
-        return FRAME_RATE;
-    }
-
-    /**
-     * Get if the game is currently in full screen mode
-     *
-     * @return true if the game is currently in full screen mode
-     */
-    public static boolean fullScreen() {
-        return FULL_SCREEN;
-    }
-
-    /**
-     * Set the width of the game window in pixels.
-     *
-     * <p>Part of the pre-run configuration: Manipulating this value will only result in changes
-     * before {@link Game#run} was executed.
-     *
-     * @param windowWidth: the new width of the game window in pixels.
-     */
     public static void windowWidth(int windowWidth) {
-        WINDOW_WIDTH = windowWidth;
+        PreRunConfiguration.windowWidth(windowWidth);
     }
 
-    /**
-     * Set the height of the game window in pixels.
-     *
-     * <p>Part of the pre-run configuration: Manipulating this value will only result in changes
-     * before {@link Game#run} was executed.
-     *
-     * @param windowHeight: the new height of the game window in pixels.
-     */
+    public static int windowHeight() {
+        return PreRunConfiguration.windowHeight();
+    }
+
     public static void windowHeight(int windowHeight) {
-        WINDOW_HEIGHT = windowHeight;
+        PreRunConfiguration.windowHeight(windowHeight);
     }
 
-    /**
-     * The frames per second of the game. The FPS determine in which interval the update cycle of
-     * the systems is triggered. Each system is updated once per frame. With an FPS of 30, each
-     * system is updated 30 times per second.
-     *
-     * <p>Part of the pre-run configuration: Manipulating this value will only result in changes
-     * before {@link Game#run} was executed.
-     *
-     * @param frameRate: the new fps of the game
-     */
+    public static int frameRate() {
+        return PreRunConfiguration.frameRate();
+    }
+
     public static void frameRate(int frameRate) {
-        FRAME_RATE = frameRate;
+        PreRunConfiguration.frameRate(frameRate);
     }
 
-    /**
-     * Set the window to fullscreen mode or windowed mode.
-     *
-     * @param fullscreen true for fullscreen, false for windowed
-     */
+    public static boolean fullScreen() {
+        return PreRunConfiguration.fullScreen();
+    }
+
     public static void fullScreen(boolean fullscreen) {
-        FULL_SCREEN = fullscreen;
+        PreRunConfiguration.fullScreen(fullscreen);
     }
 
-    /**
-     * Set the title of the game window.
-     *
-     * <p>Part of the pre-run configuration: Manipulating this value will only result in changes
-     * before {@link Game#run} was executed.
-     *
-     * @param windowTitle: new title
-     */
+    public static String windowTitle() {
+        return PreRunConfiguration.windowTitle();
+    }
+
     public static void windowTitle(String windowTitle) {
-        WINDOW_TITLE = windowTitle;
+        PreRunConfiguration.windowTitle(windowTitle);
     }
 
-    /**
-     * Set the path to the logo of the game window.
-     *
-     * <p>Part of the pre-run configuration: Manipulating this value will only result in changes
-     * before {@link Game#run} was executed.
-     *
-     * @param logoPath: path to the nwe logo as String
-     */
+    public static String logoPath() {
+        return PreRunConfiguration.logoPath();
+    }
+
     public static void logoPath(String logoPath) {
-        LOGO_PATH = logoPath;
+        PreRunConfiguration.logoPath(logoPath);
     }
 
-    /**
-     * Set the function that will be executed at each frame.
-     * <p> Use this, if you want to execute some logic outside of a system.</p>
-     * <p> Will not replace {@link #onFrame )</p>
-     *
-     * @param userFrame function that will be called at each frame.
-     * @see IVoidFunction
-     */
-    public static void userOnFrame(IVoidFunction userFrame) {
-        Game.userOnFrame = userFrame;
+    public static boolean disableAudio() {
+        return PreRunConfiguration.disableAudio();
     }
 
-    /**
-     * Set the function that will be executed once after the libgdx-setup.
-     *
-     * <p>Will not replace {@link #onSetup()}
-     *
-     * @param userOnSetup function that will be once after the libgdx-setup.
-     * @see IVoidFunction
-     */
-    public static void userOnSetup(IVoidFunction userOnSetup) {
-        Game.userOnSetup = userOnSetup;
-    }
-
-    /**
-     * Set the function that will be executed after a new level was loaded.
-     *
-     * <p>The Consumer takes a boolean that is true if the level was never loaded before, and false
-     * if it was loaded before. This can be useful, for example, if you only want to spawn monsters
-     * the first time.
-     *
-     * <p>Use this, if you want to execute some logic after a level was loaded. For example spawning
-     * some Monsters.
-     *
-     * @param userOnLevelLoad the function that will be executed after a new level was loaded
-     *     <p>Will not replace {@link #onLevelLoad}
-     */
-    public static void userOnLevelLoad(Consumer<Boolean> userOnLevelLoad) {
-        Game.userOnLevelLoad = userOnLevelLoad;
-    }
-
-    /**
-     * Set if you want to disable or enable the audi of the game.
-     *
-     * <p>Part of the pre-run configuration: Manipulating this value will only result in changes
-     * before {@link Game#run} was executed.
-     *
-     * @param disableAudio true if you want to disable the audio, false (default) if not.
-     */
     public static void disableAudio(boolean disableAudio) {
-        DISABLE_AUDIO = disableAudio;
+        PreRunConfiguration.disableAudio(disableAudio);
     }
 
-    /**
-     * Initialize the base logger.
-     *
-     * <p>Will remove the console handler and put all log messages in the log files.
-     */
+    public static IVoidFunction userOnFrame() {
+        return PreRunConfiguration.userOnFrame();
+    }
+
+    public static void userOnFrame(IVoidFunction userOnFrame) {
+        PreRunConfiguration.userOnFrame(userOnFrame);
+    }
+
+    public static IVoidFunction userOnSetup() {
+        return PreRunConfiguration.userOnSetup();
+    }
+
+    public static void userOnSetup(IVoidFunction userOnSetup) {
+        PreRunConfiguration.userOnSetup(userOnSetup);
+    }
+
+    public static Consumer<Boolean> userOnLevelLoad() {
+        return PreRunConfiguration.userOnLevelLoad();
+    }
+
+    public static void userOnLevelLoad(Consumer<Boolean> userOnLevelLoad) {
+        PreRunConfiguration.userOnLevelLoad(userOnLevelLoad);
+    }
+
     public static void initBaseLogger() {
-        LoggerConfig.initBaseLogger();
+        PreRunConfiguration.initBaseLogger();
     }
 
-    private static Consumer<Boolean> userOnLevelLoad = (b) -> {};
-
-    /**
-     * Load the configuration from the given path. If the configuration has already been loaded, the
-     * cached version will be used.
-     *
-     * @param pathAsString the path to the config file as a string
-     * @param klass the class where the ConfigKey fields are located
-     * @throws IOException if the file could not be read
-     */
-    public static void loadConfig(String pathAsString, Class<?>... klass) throws IOException {
-        Configuration.loadAndGetConfiguration(pathAsString, klass);
+    public static void loadConfig(
+            String s,
+            Class<KeyboardConfig> keyboardConfigClass,
+            Class<core.configuration.KeyboardConfig> keyboardConfigClass1)
+            throws IOException {
+        PreRunConfiguration.loadConfig(s, keyboardConfigClass, keyboardConfigClass1);
     }
 
     /** Starts the dungeon and requires a {@link Game}. */
     public static void run() {
         Lwjgl3ApplicationConfiguration config = new Lwjgl3ApplicationConfiguration();
-        config.setWindowSizeLimits(WINDOW_WIDTH, WINDOW_HEIGHT, 9999, 9999);
+        config.setWindowSizeLimits(
+                PreRunConfiguration.windowWidth(), PreRunConfiguration.windowHeight(), 9999, 9999);
         // The third and fourth parameters ("maxWidth" and "maxHeight") affect the resizing
         // behavior
         // of the window. If the window is enlarged or maximized, then it can assume these
         // dimensions at maximum. If you have a larger screen resolution than 9999x9999 pixels,
         // increase these parameters.
-        config.setForegroundFPS(FRAME_RATE);
-        config.setTitle(WINDOW_TITLE);
-        config.setWindowIcon(LOGO_PATH);
-        config.disableAudio(DISABLE_AUDIO);
+        config.setForegroundFPS(PreRunConfiguration.frameRate());
+        config.setTitle(PreRunConfiguration.windowTitle());
+        config.setWindowIcon(PreRunConfiguration.logoPath());
+        config.disableAudio(PreRunConfiguration.disableAudio());
 
-        if (FULL_SCREEN) {
+        if (PreRunConfiguration.fullScreen()) {
             config.setFullscreenMode(Lwjgl3ApplicationConfiguration.getDisplayMode());
         } else {
-            config.setWindowedMode(WINDOW_WIDTH, WINDOW_HEIGHT);
+            config.setWindowedMode(
+                    PreRunConfiguration.windowWidth(), PreRunConfiguration.windowHeight());
         }
 
         // uncomment this if you wish no audio
@@ -297,7 +168,7 @@ public final class Game extends ScreenAdapter {
                 config);
     }
 
-    // ====================END-SETUP====================
+    // ====================END SETUP====================
 
     // ====================ECS====================
     /**
@@ -313,11 +184,6 @@ public final class Game extends ScreenAdapter {
      * {@link EntitySystemMapper} with no filter-rules will contain each entity in the game
      */
     private static Set<EntitySystemMapper> activeEntityStorage = new HashSet<>();
-    /**
-     * The width of the game window in pixels.
-     *
-     * <p>Manipulating this value will only result in changes before {@link Game#run} was executed.
-     */
 
     // initial entityStorage has no level
     static {
@@ -428,32 +294,6 @@ public final class Game extends ScreenAdapter {
     private boolean newLevelWasLoadedInThisLoop = false;
 
     /**
-     * Part of the pre-run configuration.
-     * This function will be called at each frame.
-     * <p> Use this, if you want to execute some logic outside of a system.</p>
-     * <p> Will not replace {@link #onFrame )</p>
-     */
-    private static IVoidFunction userOnFrame = () -> {};
-    /**
-     * Part of the pre-run configuration. This function will be called after the libgdx-setup once.
-     *
-     * <p>Will not replace {@link #onSetup()}
-     */
-    private static IVoidFunction userOnSetup = () -> {};
-    /**
-     * Part of the pre-run configuration. This function will be called after a level was loaded.
-     *
-     * <p>Use this, if you want to execute some logic after a level was loaded. For example spawning
-     * some Monsters.
-     *
-     * <p>The Consumer takes a boolean that is true if the level was never loaded before, and false
-     * if it was loaded before. * This can be useful, for example, if you only want to spawn
-     * monsters the first time.
-     *
-     * <p>Will not replace {@link #onLevelLoad}
-     */
-
-    /**
      * Sets {@link #currentLevel} to the new level and changes the currently active entity storage.
      *
      * <p>Will remove all Systems using {@link Game#removeAllSystems()} from the Game. This will
@@ -484,7 +324,7 @@ public final class Game extends ScreenAdapter {
                 }
                 hero().ifPresent(Game::add);
                 currentLevel().onLoad();
-                userOnLevelLoad.accept(firstLoad);
+                PreRunConfiguration.userOnLevelLoad().accept(firstLoad);
             };
 
     /**
@@ -523,7 +363,7 @@ public final class Game extends ScreenAdapter {
         CameraSystem.camera().zoom = Constants.DEFAULT_ZOOM_FACTOR;
         createSystems();
         setupStage();
-        userOnSetup.execute();
+        PreRunConfiguration.userOnSetup().execute();
     }
 
     /**
@@ -535,7 +375,7 @@ public final class Game extends ScreenAdapter {
     private void onFrame() {
         debugKeys();
         fullscreenKey();
-        userOnFrame.execute();
+        PreRunConfiguration.userOnFrame().execute();
     }
 
     // ====================END GAMELOOP====================
@@ -558,7 +398,10 @@ public final class Game extends ScreenAdapter {
     private static void setupStage() {
         stage =
                 new Stage(
-                        new ScalingViewport(Scaling.stretch, WINDOW_WIDTH, WINDOW_HEIGHT),
+                        new ScalingViewport(
+                                Scaling.stretch,
+                                PreRunConfiguration.windowWidth(),
+                                PreRunConfiguration.windowHeight()),
                         new SpriteBatch());
         Gdx.input.setInputProcessor(stage);
     }
@@ -577,7 +420,8 @@ public final class Game extends ScreenAdapter {
             if (!Gdx.graphics.isFullscreen()) {
                 Gdx.graphics.setFullscreenMode(Gdx.graphics.getDisplayMode());
             } else {
-                Gdx.graphics.setWindowedMode(WINDOW_WIDTH, WINDOW_HEIGHT);
+                Gdx.graphics.setWindowedMode(
+                        PreRunConfiguration.windowWidth(), PreRunConfiguration.windowHeight());
             }
         }
     }

--- a/game/src/core/Game.java
+++ b/game/src/core/Game.java
@@ -1,11 +1,13 @@
 package core;
 
 import com.badlogic.gdx.ai.pfa.GraphPath;
+import com.badlogic.gdx.scenes.scene2d.Stage;
 
 import contrib.configuration.KeyboardConfig;
 
 import core.components.PositionComponent;
 import core.game.ECSManagment;
+import core.game.GameLoop;
 import core.game.PreRunConfiguration;
 import core.level.Tile;
 import core.level.elements.ILevel;
@@ -27,6 +29,11 @@ import java.util.stream.Stream;
 public final class Game {
 
     private static final Logger LOGGER = Logger.getLogger("Game");
+
+    /** Starts the dungeon and requires a {@link Game}. */
+    public static void run() {
+        GameLoop.run();
+    }
 
     // ====================PreRunConfiguration====================
 
@@ -122,6 +129,160 @@ public final class Game {
         PreRunConfiguration.loadConfig(s, keyboardConfigClass, keyboardConfigClass1);
     }
 
+    // ECS MANAGMENT
+
+    public static Optional<Stage> stage() {
+        return GameLoop.stage();
+    }
+    /**
+     * The given entity will be added to the game.
+     *
+     * <p>For each {@link System}, it will be checked if the {@link System} will process this
+     * entity.
+     *
+     * <p>If necessary, the {@link System} will trigger {@link System#triggerOnAdd(Entity)} .
+     *
+     * @param entity the entity to add.
+     */
+    public static void add(Entity entity) {
+        ECSManagment.add(entity);
+    }
+
+    /**
+     * The given entity will be removed from the game.
+     *
+     * <p>If necessary, the {@link System}s will trigger {@link System#triggerOnAdd(Entity)} .
+     *
+     * @param entity the entity to remove
+     */
+    public static void remove(Entity entity) {
+        ECSManagment.remove(entity);
+    }
+    /**
+     * Add a {@link System} to the game.
+     *
+     * <p>If a System is added to the game, the {@link System#execute} method will be called every
+     * frame.
+     *
+     * <p>Additionally, the system will be informed about all new, changed, and removed entities.
+     *
+     * <p>The game can only store one system of each system type.
+     *
+     * @param system the System to add
+     * @return an optional that contains the previous existing system of the given system class, if
+     *     one exists
+     * @see System
+     * @see Optional
+     */
+    public static Optional<System> add(System system) {
+        return ECSManagment.add(system);
+    }
+    /**
+     * @return a copy of the map that stores all registered {@link System} in the game.
+     */
+    public static Map<Class<? extends System>, System> systems() {
+        return ECSManagment.systems();
+    }
+
+    /**
+     * Remove all registered systems from the game.
+     *
+     * <p>Will trigger {@link System#onEntityRemove} for each entity in each system.
+     */
+    public static void removeAllSystems() {
+        ECSManagment.removeAllSystems();
+    }
+
+    /**
+     * Use this stream if you want to iterate over all currently active entities.
+     *
+     * @return a stream of all entities currently in the game
+     */
+    public static Stream<Entity> entityStream() {
+        return ECSManagment.entityStream();
+    }
+
+    /**
+     * Use this stream if you want to iterate over all entities that contain the necessary
+     * Components to be processed by the given system.
+     *
+     * @return a stream of all entities currently in the game that should be processed by the given
+     *     system.
+     */
+    public static Stream<Entity> entityStream(System system) {
+        return ECSManagment.entityStream(system);
+    }
+
+    /**
+     * Use this stream if you want to iterate over all entities that contain the given components.
+     *
+     * @return a stream of all entities currently in the game that contains the given components.
+     */
+    public static Stream<Entity> entityStream(Set<Class<? extends Component>> filter) {
+        return ECSManagment.entityStream(filter);
+    }
+
+    /**
+     * @return the player character, can be null if not initialized
+     * @see Optional
+     */
+    public static Optional<Entity> hero() {
+        return ECSManagment.hero();
+    }
+
+    /**
+     * Set the reference of the playable character.
+     *
+     * <p>Be careful: the old hero will not be removed from the game.
+     *
+     * @param hero the new reference of the hero
+     */
+    public static void hero(Entity hero) {
+        ECSManagment.hero(hero);
+    }
+
+    /**
+     * Remove the stored system of the given class from the game. If the System is successfully
+     * removed, the {@link System#triggerOnRemove(Entity)} method of the System will be called for
+     * each existing Entity that was associated with the removed System.
+     *
+     * @param system the class of the system to remove
+     */
+    public static void remove(Class<? extends System> system) {
+        ECSManagment.remove(system);
+    }
+
+    /**
+     * Remove all entities from the game.
+     *
+     * <p>This will also remove all entities from each system.
+     */
+    public static void removeAllEntities() {
+        ECSManagment.removeAllEntities();
+    }
+
+    /**
+     * Use this stream if you want to iterate over all active entities.
+     *
+     * <p>Use {@link #entityStream()} if you want to iterate over all active entities.
+     *
+     * @return a stream of all entities currently in the game
+     */
+    public static Stream<Entity> allEntities() {
+        return ECSManagment.allEntities();
+    }
+
+    /**
+     * Find the entity that contains the given component instance.
+     *
+     * @param component Component instance where the entity is searched for.
+     * @return An Optional containing the found Entity, or an empty Optional if not found.
+     */
+    public static Optional<Entity> find(Component component) {
+        return ECSManagment.find(component);
+    }
+
+    // LEVEL API
     /**
      * @return the currently loaded level
      */

--- a/game/src/core/game/ECSManagment.java
+++ b/game/src/core/game/ECSManagment.java
@@ -4,32 +4,20 @@ import core.Component;
 import core.Entity;
 import core.System;
 import core.level.elements.ILevel;
-import core.systems.*;
 import core.utils.EntitySystemMapper;
 
 import java.util.*;
 import java.util.logging.Logger;
 import java.util.stream.Stream;
 
+/** The class responsible for managing the ECS (Entity-Component-System) in the game. */
 public class ECSManagment {
     private static final Logger LOGGER = Logger.getLogger("ECSManagment");
-    private static Entity hero;
-
-    /**
-     * A Map with each {@link System} in the game.
-     *
-     * <p>The Key-Value is the Class of the system
-     */
     private static final Map<Class<? extends System>, System> systems = new LinkedHashMap<>();
-    /** Maps the level with the different {@link EntitySystemMapper} for that level. */
     private static final Map<ILevel, Set<EntitySystemMapper>> levelStorageMap = new HashMap<>();
-    /**
-     * Collection of {@link EntitySystemMapper} that maps the existing entities to the systems. The
-     * {@link EntitySystemMapper} with no filter-rules will contain each entity in the game
-     */
+    private static Entity hero;
     private static Set<EntitySystemMapper> activeEntityStorage = new HashSet<>();
 
-    // initial entityStorage has no level
     static {
         levelStorageMap.put(null, activeEntityStorage);
         activeEntityStorage.add(new EntitySystemMapper());
@@ -138,8 +126,6 @@ public class ECSManagment {
     protected static void activeEntityStorage(Set<EntitySystemMapper> computeIfAbsent) {
         activeEntityStorage = computeIfAbsent;
     }
-
-    // ====================ESC END====================
 
     /**
      * @return a copy of the map that stores all registered {@link System} in the game.

--- a/game/src/core/game/ECSManagment.java
+++ b/game/src/core/game/ECSManagment.java
@@ -1,0 +1,283 @@
+package core.game;
+
+import core.Component;
+import core.Entity;
+import core.Game;
+import core.System;
+import core.level.elements.ILevel;
+import core.level.generator.postGeneration.WallGenerator;
+import core.level.generator.randomwalk.RandomWalkGenerator;
+import core.systems.*;
+import core.utils.EntitySystemMapper;
+
+import java.util.*;
+import java.util.stream.Stream;
+
+public class ECSManagment {
+    // ====================ECS====================
+
+    private static Entity hero;
+
+    /**
+     * A Map with each {@link System} in the game.
+     *
+     * <p>The Key-Value is the Class of the system
+     */
+    private static final Map<Class<? extends System>, System> systems = new LinkedHashMap<>();
+    /** Maps the level with the different {@link EntitySystemMapper} for that level. */
+    private static final Map<ILevel, Set<EntitySystemMapper>> levelStorageMap = new HashMap<>();
+    /**
+     * Collection of {@link EntitySystemMapper} that maps the existing entities to the systems. The
+     * {@link EntitySystemMapper} with no filter-rules will contain each entity in the game
+     */
+    private static Set<EntitySystemMapper> activeEntityStorage = new HashSet<>();
+
+    // initial entityStorage has no level
+    static {
+        levelStorageMap.put(null, activeEntityStorage);
+        activeEntityStorage.add(new EntitySystemMapper());
+    }
+
+    /**
+     * Inform each {@link System} that the given Entity has changes on component bases.
+     *
+     * <p>If necessary, the {@link System}s will trigger {@link System#triggerOnAdd(Entity)} or
+     * {@link System#triggerOnRemove(Entity)}.
+     *
+     * @param entity the entity that has changes in its Component Collection.
+     */
+    public static void informAboutChanges(Entity entity) {
+        if (entityStream().anyMatch(entity1 -> entity1.equals(entity))) {
+            activeEntityStorage.forEach(f -> f.update(entity));
+            LOGGER.info("Entity: " + entity + " informed the Game about component changes.");
+        }
+    }
+
+    /**
+     * The given entity will be added to the game.
+     *
+     * <p>For each {@link System}, it will be checked if the {@link System} will process this
+     * entity.
+     *
+     * <p>If necessary, the {@link System} will trigger {@link System#triggerOnAdd(Entity)} .
+     *
+     * @param entity the entity to add.
+     */
+    public static void add(Entity entity) {
+        activeEntityStorage.forEach(f -> f.add(entity));
+        LOGGER.info("Entity: " + entity + " will be added to the Game.");
+    }
+
+    /**
+     * The given entity will be removed from the game.
+     *
+     * <p>If necessary, the {@link System}s will trigger {@link System#triggerOnAdd(Entity)} .
+     *
+     * @param entity the entity to remove
+     */
+    public static void remove(Entity entity) {
+        activeEntityStorage.forEach(f -> f.remove(entity));
+        LOGGER.info("Entity: " + entity + " will be removed from the Game.");
+    }
+
+    /**
+     * Create a new {@link EntitySystemMapper} with the given filter rules.
+     *
+     * <p>The {@link EntitySystemMapper} will be added to {@link #activeEntityStorage}.
+     *
+     * <p>All entities in the empty filter (basically every entity in the game) will be tried to add
+     * with {@link EntitySystemMapper#add(Entity)}.
+     *
+     * <p>This function will not check if an {@link EntitySystemMapper} with the same rules already
+     * exists. If an {@link EntitySystemMapper} exists, it will not be replaced, and the {@link
+     * EntitySystemMapper} created in this function will be lost.
+     *
+     * @param filter Set of Component classes that define the filter rules.
+     * @return the created {@link EntitySystemMapper}.
+     */
+    private static EntitySystemMapper createNewEntitySystemMapper(
+            Set<Class<? extends Component>> filter) {
+        EntitySystemMapper mapper = new EntitySystemMapper(filter);
+        activeEntityStorage.add(mapper);
+        entityStream().forEach(mapper::add);
+        return mapper;
+    }
+
+    /**
+     * Add a {@link System} to the game.
+     *
+     * <p>If a System is added to the game, the {@link System#execute} method will be called every
+     * frame.
+     *
+     * <p>Additionally, the system will be informed about all new, changed, and removed entities.
+     *
+     * <p>The game can only store one system of each system type.
+     *
+     * @param system the System to add
+     * @return an optional that contains the previous existing system of the given system class, if
+     *     one exists
+     * @see System
+     * @see Optional
+     */
+    public static Optional<System> add(System system) {
+        System currentSystem = systems.get(system.getClass());
+        systems.put(system.getClass(), system);
+        // add to existing filter or create new filter if no matching exists
+        Optional<EntitySystemMapper> filter =
+                activeEntityStorage.stream()
+                        .filter(f -> f.equals(system.filterRules()))
+                        .findFirst();
+        filter.ifPresentOrElse(
+                f -> f.add(system),
+                () -> createNewEntitySystemMapper(system.filterRules()).add(system));
+        LOGGER.info("A new " + system.getClass().getName() + " was added to the game");
+        return Optional.ofNullable(currentSystem);
+    }
+
+    // ====================ESC END====================
+
+    /** Create the systems. */
+    private void createSystems() {
+        add(new PositionSystem());
+        add(new CameraSystem());
+        add(
+                new LevelSystem(
+                        DrawSystem.painter(),
+                        new WallGenerator(new RandomWalkGenerator()),
+                        onLevelLoad));
+        add(new DrawSystem());
+        add(new VelocitySystem());
+        add(new PlayerSystem());
+    }
+
+    /**
+     * @return a copy of the map that stores all registered {@link System} in the game.
+     */
+    public static Map<Class<? extends System>, System> systems() {
+        return new LinkedHashMap<>(systems);
+    }
+
+    /**
+     * Remove all registered systems from the game.
+     *
+     * <p>Will trigger {@link System#onEntityRemove} for each entity in each system.
+     */
+    public static void removeAllSystems() {
+        new HashSet<>(systems.keySet()).forEach(Game::remove);
+    }
+
+    /**
+     * Use this stream if you want to iterate over all currently active entities.
+     *
+     * @return a stream of all entities currently in the game
+     */
+    public static Stream<Entity> entityStream() {
+        return entityStream(new HashSet<>());
+    }
+
+    /**
+     * Use this stream if you want to iterate over all entities that contain the necessary
+     * Components to be processed by the given system.
+     *
+     * @return a stream of all entities currently in the game that should be processed by the given
+     *     system.
+     */
+    public static Stream<Entity> entityStream(System system) {
+        return entityStream(system.filterRules());
+    }
+
+    /**
+     * Use this stream if you want to iterate over all entities that contain the given components.
+     *
+     * @return a stream of all entities currently in the game that contains the given components.
+     */
+    public static Stream<Entity> entityStream(Set<Class<? extends Component>> filter) {
+        Stream<Entity> returnStream;
+        Optional<EntitySystemMapper> rf =
+                activeEntityStorage.stream().filter(f -> f.equals(filter)).findFirst();
+
+        if (rf.isEmpty()) {
+            EntitySystemMapper newMapper = createNewEntitySystemMapper(filter);
+            returnStream = newMapper.stream();
+        } else returnStream = rf.get().stream();
+        return returnStream;
+    }
+
+    /**
+     * @return the player character, can be null if not initialized
+     * @see Optional
+     */
+    public static Optional<Entity> hero() {
+        return Optional.ofNullable(hero);
+    }
+
+    /**
+     * Set the reference of the playable character.
+     *
+     * <p>Be careful: the old hero will not be removed from the game.
+     *
+     * @param hero the new reference of the hero
+     */
+    public static void hero(Entity hero) {
+        Game.hero = hero;
+    }
+
+    /**
+     * Remove the stored system of the given class from the game. If the System is successfully
+     * removed, the {@link System#triggerOnRemove(Entity)} method of the System will be called for
+     * each existing Entity that was associated with the removed System.
+     *
+     * @param system the class of the system to remove
+     */
+    public static void remove(Class<? extends System> system) {
+        System systemInstance = systems.remove(system);
+        if (systemInstance != null) activeEntityStorage.forEach(f -> f.remove(systemInstance));
+    }
+
+    /**
+     * Remove all entities from the game.
+     *
+     * <p>This will also remove all entities from each system.
+     */
+    public static void removeAllEntities() {
+        allEntities().forEach(Game::remove);
+        LOGGER.info("All entities will be removed from the game.");
+    }
+
+    /**
+     * Use this stream if you want to iterate over all active entities.
+     *
+     * <p>Use {@link #entityStream()} if you want to iterate over all active entities.
+     *
+     * @return a stream of all entities currently in the game
+     */
+    public static Stream<Entity> allEntities() {
+        Set<Entity> allEntities = new HashSet<>();
+        levelStorageMap
+                .values()
+                .forEach(
+                        entitySystemMappers ->
+                                entitySystemMappers.forEach(
+                                        entitySystemMapper ->
+                                                entitySystemMapper.stream()
+                                                        .forEach(allEntities::add)));
+
+        return allEntities.stream();
+    }
+
+    /**
+     * Find the entity that contains the given component instance.
+     *
+     * @param component Component instance where the entity is searched for.
+     * @return An Optional containing the found Entity, or an empty Optional if not found.
+     */
+    public static Optional<Entity> find(Component component) {
+        return allEntities()
+                .filter(
+                        entity ->
+                                entity.fetch(component.getClass())
+                                        .map(component::equals)
+                                        .orElse(false))
+                .findFirst();
+    }
+}

--- a/game/src/core/game/ECSManagment.java
+++ b/game/src/core/game/ECSManagment.java
@@ -2,20 +2,17 @@ package core.game;
 
 import core.Component;
 import core.Entity;
-import core.Game;
 import core.System;
 import core.level.elements.ILevel;
-import core.level.generator.postGeneration.WallGenerator;
-import core.level.generator.randomwalk.RandomWalkGenerator;
 import core.systems.*;
 import core.utils.EntitySystemMapper;
 
 import java.util.*;
+import java.util.logging.Logger;
 import java.util.stream.Stream;
 
 public class ECSManagment {
-    // ====================ECS====================
-
+    private static final Logger LOGGER = Logger.getLogger("ECSManagment");
     private static Entity hero;
 
     /**
@@ -134,21 +131,15 @@ public class ECSManagment {
         return Optional.ofNullable(currentSystem);
     }
 
-    // ====================ESC END====================
-
-    /** Create the systems. */
-    private void createSystems() {
-        add(new PositionSystem());
-        add(new CameraSystem());
-        add(
-                new LevelSystem(
-                        DrawSystem.painter(),
-                        new WallGenerator(new RandomWalkGenerator()),
-                        onLevelLoad));
-        add(new DrawSystem());
-        add(new VelocitySystem());
-        add(new PlayerSystem());
+    protected static Map<ILevel, Set<EntitySystemMapper>> levelStorageMap() {
+        return levelStorageMap;
     }
+
+    protected static void activeEntityStorage(Set<EntitySystemMapper> computeIfAbsent) {
+        activeEntityStorage = computeIfAbsent;
+    }
+
+    // ====================ESC END====================
 
     /**
      * @return a copy of the map that stores all registered {@link System} in the game.
@@ -163,7 +154,7 @@ public class ECSManagment {
      * <p>Will trigger {@link System#onEntityRemove} for each entity in each system.
      */
     public static void removeAllSystems() {
-        new HashSet<>(systems.keySet()).forEach(Game::remove);
+        new HashSet<>(systems.keySet()).forEach(ECSManagment::remove);
     }
 
     /**
@@ -219,7 +210,7 @@ public class ECSManagment {
      * @param hero the new reference of the hero
      */
     public static void hero(Entity hero) {
-        Game.hero = hero;
+        ECSManagment.hero = hero;
     }
 
     /**
@@ -240,7 +231,7 @@ public class ECSManagment {
      * <p>This will also remove all entities from each system.
      */
     public static void removeAllEntities() {
-        allEntities().forEach(Game::remove);
+        allEntities().forEach(ECSManagment::remove);
         LOGGER.info("All entities will be removed from the game.");
     }
 

--- a/game/src/core/game/GameLoop.java
+++ b/game/src/core/game/GameLoop.java
@@ -31,40 +31,9 @@ import java.util.logging.Logger;
 /** The heart of the framework. From here, all settings are pulled. */
 public class GameLoop extends ScreenAdapter {
     private static final Logger LOGGER = Logger.getLogger("GameLoop");
+    private static Stage stage;
     private boolean doSetup = true;
     private boolean newLevelWasLoadedInThisLoop = false;
-    private boolean uiDebugFlag = false;
-
-    // for singleton
-    private GameLoop() {}
-
-    /** Starts the dungeon and requires a {@link Game}. */
-    public static void run() {
-        Lwjgl3ApplicationConfiguration config = new Lwjgl3ApplicationConfiguration();
-        config.setWindowSizeLimits(
-                PreRunConfiguration.windowWidth(), PreRunConfiguration.windowHeight(), 9999, 9999);
-        config.setForegroundFPS(PreRunConfiguration.frameRate());
-        config.setTitle(PreRunConfiguration.windowTitle());
-        config.setWindowIcon(PreRunConfiguration.logoPath());
-        config.disableAudio(PreRunConfiguration.disableAudio());
-
-        if (PreRunConfiguration.fullScreen()) {
-            config.setFullscreenMode(Lwjgl3ApplicationConfiguration.getDisplayMode());
-        } else {
-            config.setWindowedMode(
-                    PreRunConfiguration.windowWidth(), PreRunConfiguration.windowHeight());
-        }
-
-        new Lwjgl3Application(
-                new com.badlogic.gdx.Game() {
-                    @Override
-                    public void create() {
-                        setScreen(new GameLoop());
-                    }
-                },
-                config);
-    }
-
     /**
      * Sets {@link Game#currentLevel} to the new level and changes the currently active entity
      * storage.
@@ -102,6 +71,58 @@ public class GameLoop extends ScreenAdapter {
                 Game.currentLevel().onLoad();
                 PreRunConfiguration.userOnLevelLoad().accept(firstLoad);
             };
+
+    private boolean uiDebugFlag = false;
+
+    // for singleton
+    private GameLoop() {}
+
+    /** Starts the dungeon and requires a {@link Game}. */
+    public static void run() {
+        Lwjgl3ApplicationConfiguration config = new Lwjgl3ApplicationConfiguration();
+        config.setWindowSizeLimits(
+                PreRunConfiguration.windowWidth(), PreRunConfiguration.windowHeight(), 9999, 9999);
+        config.setForegroundFPS(PreRunConfiguration.frameRate());
+        config.setTitle(PreRunConfiguration.windowTitle());
+        config.setWindowIcon(PreRunConfiguration.logoPath());
+        config.disableAudio(PreRunConfiguration.disableAudio());
+
+        if (PreRunConfiguration.fullScreen()) {
+            config.setFullscreenMode(Lwjgl3ApplicationConfiguration.getDisplayMode());
+        } else {
+            config.setWindowedMode(
+                    PreRunConfiguration.windowWidth(), PreRunConfiguration.windowHeight());
+        }
+
+        new Lwjgl3Application(
+                new com.badlogic.gdx.Game() {
+                    @Override
+                    public void create() {
+                        setScreen(new GameLoop());
+                    }
+                },
+                config);
+    }
+
+    public static Optional<Stage> stage() {
+        return Optional.ofNullable(stage);
+    }
+
+    private static void updateStage(Stage x) {
+        x.act(Gdx.graphics.getDeltaTime());
+        x.draw();
+    }
+
+    private static void setupStage() {
+        stage =
+                new Stage(
+                        new ScalingViewport(
+                                Scaling.stretch,
+                                PreRunConfiguration.windowWidth(),
+                                PreRunConfiguration.windowHeight()),
+                        new SpriteBatch());
+        Gdx.input.setInputProcessor(stage);
+    }
 
     /**
      * Main game loop.
@@ -152,28 +173,6 @@ public class GameLoop extends ScreenAdapter {
         debugKeys();
         fullscreenKey();
         PreRunConfiguration.userOnFrame().execute();
-    }
-
-    private static Stage stage;
-
-    public static Optional<Stage> stage() {
-        return Optional.ofNullable(stage);
-    }
-
-    private static void updateStage(Stage x) {
-        x.act(Gdx.graphics.getDeltaTime());
-        x.draw();
-    }
-
-    private static void setupStage() {
-        stage =
-                new Stage(
-                        new ScalingViewport(
-                                Scaling.stretch,
-                                PreRunConfiguration.windowWidth(),
-                                PreRunConfiguration.windowHeight()),
-                        new SpriteBatch());
-        Gdx.input.setInputProcessor(stage);
     }
 
     /** Just for debugging, remove later. */

--- a/game/src/core/game/GameLoop.java
+++ b/game/src/core/game/GameLoop.java
@@ -1,0 +1,231 @@
+package core.game;
+
+import static com.badlogic.gdx.graphics.GL20.GL_COLOR_BUFFER_BIT;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Input;
+import com.badlogic.gdx.ScreenAdapter;
+import com.badlogic.gdx.backends.lwjgl3.Lwjgl3Application;
+import com.badlogic.gdx.backends.lwjgl3.Lwjgl3ApplicationConfiguration;
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.badlogic.gdx.scenes.scene2d.Stage;
+import com.badlogic.gdx.utils.Scaling;
+import com.badlogic.gdx.utils.viewport.ScalingViewport;
+
+import core.Entity;
+import core.Game;
+import core.System;
+import core.components.PositionComponent;
+import core.systems.CameraSystem;
+import core.systems.DrawSystem;
+import core.utils.Constants;
+import core.utils.IVoidFunction;
+import core.utils.components.MissingComponentException;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+
+public class GameLoop extends ScreenAdapter {
+    private boolean doSetup = true;
+    private boolean newLevelWasLoadedInThisLoop = false;
+    private boolean uiDebugFlag = false;
+
+    /** Starts the dungeon and requires a {@link Game}. */
+    public static void run() {
+        Lwjgl3ApplicationConfiguration config = new Lwjgl3ApplicationConfiguration();
+        config.setWindowSizeLimits(
+                PreRunConfiguration.windowWidth(), PreRunConfiguration.windowHeight(), 9999, 9999);
+        // The third and fourth parameters ("maxWidth" and "maxHeight") affect the resizing
+        // behavior
+        // of the window. If the window is enlarged or maximized, then it can assume these
+        // dimensions at maximum. If you have a larger screen resolution than 9999x9999 pixels,
+        // increase these parameters.
+        config.setForegroundFPS(PreRunConfiguration.frameRate());
+        config.setTitle(PreRunConfiguration.windowTitle());
+        config.setWindowIcon(PreRunConfiguration.logoPath());
+        config.disableAudio(PreRunConfiguration.disableAudio());
+
+        if (PreRunConfiguration.fullScreen()) {
+            config.setFullscreenMode(Lwjgl3ApplicationConfiguration.getDisplayMode());
+        } else {
+            config.setWindowedMode(
+                    PreRunConfiguration.windowWidth(), PreRunConfiguration.windowHeight());
+        }
+
+        // uncomment this if you wish no audio
+        new Lwjgl3Application(
+                new com.badlogic.gdx.Game() {
+                    @Override
+                    public void create() {
+                        setScreen(new Game());
+                    }
+                },
+                config);
+    }
+
+    /**
+     * Sets {@link #currentLevel} to the new level and changes the currently active entity storage.
+     *
+     * <p>Will remove all Systems using {@link Game#removeAllSystems()} from the Game. This will
+     * trigger {@link System#onEntityRemove} for the old level. Then, it will readd all Systems
+     * using {@link Game#add(System)}, triggering {@link System#onEntityAdd} for the new level.
+     *
+     * <p>Will re-add the hero if they exist.
+     */
+    private final IVoidFunction onLevelLoad =
+            () -> {
+                newLevelWasLoadedInThisLoop = true;
+                boolean firstLoad = !levelStorageMap.containsKey(currentLevel());
+                hero().ifPresent(Game::remove);
+                // Remove the systems so that each triggerOnRemove(entity) will be called (basically
+                // cleanup).
+                Map<Class<? extends System>, System> s = Game.systems();
+                removeAllSystems();
+                activeEntityStorage =
+                        levelStorageMap.computeIfAbsent(currentLevel(), k -> new HashSet<>());
+                // readd the systems so that each triggerOnAdd(entity) will be called (basically
+                // setup). This will also create new EntitySystemMapper if needed.
+                s.values().forEach(Game::add);
+
+                try {
+                    hero().ifPresent(this::placeOnLevelStart);
+                } catch (MissingComponentException e) {
+                    LOGGER.warning(e.getMessage());
+                }
+                hero().ifPresent(Game::add);
+                currentLevel().onLoad();
+                PreRunConfiguration.userOnLevelLoad().accept(firstLoad);
+            };
+
+    /**
+     * Main game loop.
+     *
+     * <p>Redraws the dungeon, updates the entity sets, and triggers the execution of the systems.
+     * Will call {@link #onFrame}.
+     *
+     * @param delta the time since the last loop
+     */
+    @Override
+    public void render(float delta) {
+        if (doSetup) onSetup();
+        DrawSystem.batch().setProjectionMatrix(CameraSystem.camera().combined);
+        onFrame();
+        clearScreen();
+
+        for (System system : systems().values()) {
+            // if a new level was loaded, stop this loop-run
+            if (newLevelWasLoadedInThisLoop) break;
+            if (system.isRunning()) system.execute();
+        }
+        newLevelWasLoadedInThisLoop = false;
+        CameraSystem.camera().update();
+        // stage logic
+        Game.stage().ifPresent(Game::updateStage);
+    }
+
+    /**
+     * Called once at the beginning of the game.
+     *
+     * <p>Will perform some setup.
+     */
+    private void onSetup() {
+        doSetup = false;
+        CameraSystem.camera().zoom = Constants.DEFAULT_ZOOM_FACTOR;
+        createSystems();
+        setupStage();
+        PreRunConfiguration.userOnSetup().execute();
+    }
+
+    /**
+     * Called at the beginning of each frame, before the entities are updated and the systems are
+     * executed.
+     *
+     * <p>This is the place to add basic logic that isn't part of any system.
+     */
+    private void onFrame() {
+        debugKeys();
+        fullscreenKey();
+        PreRunConfiguration.userOnFrame().execute();
+    }
+
+    private static Stage stage;
+
+    public static Optional<Stage> stage() {
+        return Optional.ofNullable(stage);
+    }
+
+    private static void updateStage(Stage x) {
+        x.act(Gdx.graphics.getDeltaTime());
+        x.draw();
+    }
+
+    private static void setupStage() {
+        stage =
+                new Stage(
+                        new ScalingViewport(
+                                Scaling.stretch,
+                                PreRunConfiguration.windowWidth(),
+                                PreRunConfiguration.windowHeight()),
+                        new SpriteBatch());
+        Gdx.input.setInputProcessor(stage);
+    }
+
+    /** Just for debugging, remove later. */
+    private void debugKeys() {
+        if (Gdx.input.isKeyJustPressed(Input.Keys.UP)) {
+            // toggle UI "debug rendering"
+            stage().ifPresent(x -> x.setDebugAll(uiDebugFlag = !uiDebugFlag));
+        }
+    }
+
+    private void fullscreenKey() {
+        if (Gdx.input.isKeyJustPressed(
+                core.configuration.KeyboardConfig.TOGGLE_FULLSCREEN.value())) {
+            if (!Gdx.graphics.isFullscreen()) {
+                Gdx.graphics.setFullscreenMode(Gdx.graphics.getDisplayMode());
+            } else {
+                Gdx.graphics.setWindowedMode(
+                        PreRunConfiguration.windowWidth(), PreRunConfiguration.windowHeight());
+            }
+        }
+    }
+
+    /**
+     * Set the position of the given entity to the position of the level-start.
+     *
+     * <p>A {@link PositionComponent} is needed.
+     *
+     * @param entity entity to set on the start of the level, normally this is the hero.
+     */
+    private void placeOnLevelStart(Entity entity) {
+        add(entity);
+        PositionComponent pc =
+                entity.fetch(PositionComponent.class)
+                        .orElseThrow(
+                                () ->
+                                        MissingComponentException.build(
+                                                entity, PositionComponent.class));
+        pc.position(startTile());
+    }
+
+    /**
+     * Clear the screen. Removes all.
+     *
+     * <p>Needs to be called before redraw something.
+     */
+    private void clearScreen() {
+        Gdx.gl.glClearColor(0, 0, 0, 1);
+        Gdx.gl.glClear(GL_COLOR_BUFFER_BIT);
+    }
+
+    @Override
+    public void resize(int width, int height) {
+        super.resize(width, height);
+        stage().ifPresent(
+                        x -> {
+                            x.getViewport().setWorldSize(width, height);
+                            x.getViewport().update(width, height, true);
+                        });
+    }
+}

--- a/game/src/core/game/PreRunConfiguration.java
+++ b/game/src/core/game/PreRunConfiguration.java
@@ -1,0 +1,147 @@
+package core.game;
+
+import core.configuration.Configuration;
+import core.utils.IVoidFunction;
+import core.utils.logging.LoggerConfig;
+
+import java.io.IOException;
+import java.util.function.Consumer;
+
+/**
+ * PreRunConfiguration class represents the pre-run configuration for the game. It includes various
+ * settings such as window dimensions, frame rate, full-screen mode, and more. This class contains
+ * all the necessary configurations that need to be set before the game starts.
+ */
+public class PreRunConfiguration {
+
+    // Window Dimensions
+    private static int WINDOW_WIDTH = 1280;
+    private static int WINDOW_HEIGHT = 720;
+
+    // Frame Rate
+    private static int FRAME_RATE = 30;
+
+    // Full-Screen Mode
+    private static boolean FULL_SCREEN = false;
+
+    // Window Title
+    private static String WINDOW_TITLE = "PM-Dungeon";
+
+    // Logo Path
+    private static String LOGO_PATH = "logo/cat_logo_35x35.png";
+
+    // Audio Settings
+    private static boolean DISABLE_AUDIO = false;
+
+    // User-Defined Functions
+    private static IVoidFunction userOnFrame = () -> {};
+    private static IVoidFunction userOnSetup = () -> {};
+    private static Consumer<Boolean> userOnLevelLoad = (b) -> {};
+
+    /** Getters and Setters for window dimensions. */
+    public static int windowWidth() {
+        return WINDOW_WIDTH;
+    }
+
+    public static void windowWidth(int windowWidth) {
+        WINDOW_WIDTH = windowWidth;
+    }
+
+    public static int windowHeight() {
+        return WINDOW_HEIGHT;
+    }
+
+    public static void windowHeight(int windowHeight) {
+        WINDOW_HEIGHT = windowHeight;
+    }
+
+    /** Getters and Setters for frame rate. */
+    public static int frameRate() {
+        return FRAME_RATE;
+    }
+
+    public static void frameRate(int frameRate) {
+        FRAME_RATE = frameRate;
+    }
+
+    /** Getters and Setters for full-screen mode. */
+    public static boolean fullScreen() {
+        return FULL_SCREEN;
+    }
+
+    public static void fullScreen(boolean fullscreen) {
+        FULL_SCREEN = fullscreen;
+    }
+
+    /** Getters and Setters for window title. */
+    public static String windowTitle() {
+        return WINDOW_TITLE;
+    }
+
+    public static void windowTitle(String windowTitle) {
+        WINDOW_TITLE = windowTitle;
+    }
+
+    /** Getters and Setters for logo path. */
+    public static String logoPath() {
+        return LOGO_PATH;
+    }
+
+    public static void logoPath(String logoPath) {
+        LOGO_PATH = logoPath;
+    }
+
+    /** Getters and Setters for audio settings. */
+    public static boolean disableAudio() {
+        return DISABLE_AUDIO;
+    }
+
+    public static void disableAudio(boolean disableAudio) {
+        DISABLE_AUDIO = disableAudio;
+    }
+
+    /** Getters and Setters for user-defined functions. */
+    public static IVoidFunction userOnFrame() {
+        return userOnFrame;
+    }
+
+    public static void userOnFrame(IVoidFunction userOnFrame) {
+        PreRunConfiguration.userOnFrame = userOnFrame;
+    }
+
+    public static IVoidFunction userOnSetup() {
+        return userOnSetup;
+    }
+
+    public static void userOnSetup(IVoidFunction userOnSetup) {
+        PreRunConfiguration.userOnSetup = userOnSetup;
+    }
+
+    public static Consumer<Boolean> userOnLevelLoad() {
+        return userOnLevelLoad;
+    }
+
+    public static void userOnLevelLoad(Consumer<Boolean> userOnLevelLoad) {
+        PreRunConfiguration.userOnLevelLoad = userOnLevelLoad;
+    }
+
+    /**
+     * Initialize the base logger. Will remove the console handler and put all log messages in the
+     * log files.
+     */
+    public static void initBaseLogger() {
+        LoggerConfig.initBaseLogger();
+    }
+
+    /**
+     * Load the configuration from the given path. If the configuration has already been loaded, the
+     * cached version will be used.
+     *
+     * @param pathAsString the path to the config file as a string
+     * @param klass the class where the ConfigKey fields are located
+     * @throws IOException if the file could not be read
+     */
+    public static void loadConfig(String pathAsString, Class<?>... klass) throws IOException {
+        Configuration.loadAndGetConfiguration(pathAsString, klass);
+    }
+}

--- a/game/src/core/game/PreRunConfiguration.java
+++ b/game/src/core/game/PreRunConfiguration.java
@@ -8,9 +8,9 @@ import java.io.IOException;
 import java.util.function.Consumer;
 
 /**
- * PreRunConfiguration class represents the pre-run configuration for the game. It includes various
- * settings such as window dimensions, frame rate, full-screen mode, and more. This class contains
- * all the necessary configurations that need to be set before the game starts.
+ * The `PreRunConfiguration` class represents the pre-run configuration for the game. It includes
+ * various settings such as window dimensions, frame rate, full-screen mode, and more. This class
+ * contains all the necessary configurations that need to be set before the game starts.
  */
 public class PreRunConfiguration {
 
@@ -38,108 +38,201 @@ public class PreRunConfiguration {
     private static IVoidFunction userOnSetup = () -> {};
     private static Consumer<Boolean> userOnLevelLoad = (b) -> {};
 
-    /** Getters and Setters for window dimensions. */
+    /**
+     * Gets the width of the game window.
+     *
+     * @return The width of the game window.
+     */
     public static int windowWidth() {
         return WINDOW_WIDTH;
     }
 
+    /**
+     * Sets the width of the game window.
+     *
+     * @param windowWidth The width of the game window.
+     */
     public static void windowWidth(int windowWidth) {
         WINDOW_WIDTH = windowWidth;
     }
 
+    /**
+     * Gets the height of the game window.
+     *
+     * @return The height of the game window.
+     */
     public static int windowHeight() {
         return WINDOW_HEIGHT;
     }
 
+    /**
+     * Sets the height of the game window.
+     *
+     * @param windowHeight The height of the game window.
+     */
     public static void windowHeight(int windowHeight) {
         WINDOW_HEIGHT = windowHeight;
     }
 
-    /** Getters and Setters for frame rate. */
+    /**
+     * Gets the frame rate of the game.
+     *
+     * @return The frame rate of the game.
+     */
     public static int frameRate() {
         return FRAME_RATE;
     }
 
+    /**
+     * Sets the frame rate of the game.
+     *
+     * @param frameRate The frame rate of the game.
+     */
     public static void frameRate(int frameRate) {
         FRAME_RATE = frameRate;
     }
 
-    /** Getters and Setters for full-screen mode. */
+    /**
+     * Checks if the game is in full-screen mode.
+     *
+     * @return True if the game is in full-screen mode, false otherwise.
+     */
     public static boolean fullScreen() {
         return FULL_SCREEN;
     }
 
+    /**
+     * Sets whether the game should be in full-screen mode.
+     *
+     * @param fullscreen True to enable full-screen mode, false otherwise.
+     */
     public static void fullScreen(boolean fullscreen) {
         FULL_SCREEN = fullscreen;
     }
 
-    /** Getters and Setters for window title. */
+    /**
+     * Gets the title of the game window.
+     *
+     * @return The title of the game window.
+     */
     public static String windowTitle() {
         return WINDOW_TITLE;
     }
 
+    /**
+     * Sets the title of the game window.
+     *
+     * @param windowTitle The title of the game window.
+     */
     public static void windowTitle(String windowTitle) {
         WINDOW_TITLE = windowTitle;
     }
 
-    /** Getters and Setters for logo path. */
+    /**
+     * Gets the path to the game logo.
+     *
+     * @return The path to the game logo.
+     */
     public static String logoPath() {
         return LOGO_PATH;
     }
 
+    /**
+     * Sets the path to the game logo.
+     *
+     * @param logoPath The path to the game logo.
+     */
     public static void logoPath(String logoPath) {
         LOGO_PATH = logoPath;
     }
 
-    /** Getters and Setters for audio settings. */
+    /**
+     * Checks if audio is disabled.
+     *
+     * @return True if audio is disabled, false otherwise.
+     */
     public static boolean disableAudio() {
         return DISABLE_AUDIO;
     }
 
+    /**
+     * Sets whether audio should be disabled.
+     *
+     * @param disableAudio True to disable audio, false otherwise.
+     */
     public static void disableAudio(boolean disableAudio) {
         DISABLE_AUDIO = disableAudio;
     }
 
-    /** Getters and Setters for user-defined functions. */
+    /**
+     * Gets the user-defined function for frame logic.
+     *
+     * @return The user-defined function for frame logic.
+     */
     public static IVoidFunction userOnFrame() {
         return userOnFrame;
     }
 
+    /**
+     * Sets the user-defined function for frame logic.
+     *
+     * @param userOnFrame The user-defined function for frame logic.
+     */
     public static void userOnFrame(IVoidFunction userOnFrame) {
         PreRunConfiguration.userOnFrame = userOnFrame;
     }
 
+    /**
+     * Gets the user-defined function for setup logic.
+     *
+     * @return The user-defined function for setup logic.
+     */
     public static IVoidFunction userOnSetup() {
         return userOnSetup;
     }
 
+    /**
+     * Sets the user-defined function for setup logic.
+     *
+     * @param userOnSetup The user-defined function for setup logic.
+     */
     public static void userOnSetup(IVoidFunction userOnSetup) {
         PreRunConfiguration.userOnSetup = userOnSetup;
     }
 
+    /**
+     * Gets the user-defined function for level load logic.
+     *
+     * @return The user-defined function for level load logic.
+     */
     public static Consumer<Boolean> userOnLevelLoad() {
         return userOnLevelLoad;
     }
 
+    /**
+     * Sets the user-defined function for level load logic.
+     *
+     * @param userOnLevelLoad The user-defined function for level load logic.
+     */
     public static void userOnLevelLoad(Consumer<Boolean> userOnLevelLoad) {
         PreRunConfiguration.userOnLevelLoad = userOnLevelLoad;
     }
 
     /**
-     * Initialize the base logger. Will remove the console handler and put all log messages in the
-     * log files.
+     * Initializes the base logger. Removes the console handler and puts all log messages in the log
+     * files.
      */
     public static void initBaseLogger() {
         LoggerConfig.initBaseLogger();
     }
 
     /**
-     * Load the configuration from the given path. If the configuration has already been loaded, the
-     * cached version will be used.
+     * Loads the configuration from the given path. If the configuration has already been loaded,
+     * the cached version will be used.
      *
-     * @param pathAsString the path to the config file as a string
-     * @param klass the class where the ConfigKey fields are located
-     * @throws IOException if the file could not be read
+     * @param pathAsString The path to the config file as a string.
+     * @param klass The class where the ConfigKey fields are located.
+     * @throws IOException If the file could not be read.
      */
     public static void loadConfig(String pathAsString, Class<?>... klass) throws IOException {
         Configuration.loadAndGetConfiguration(pathAsString, klass);

--- a/game/test/contrib/utils/components/item/ItemTest.java
+++ b/game/test/contrib/utils/components/item/ItemTest.java
@@ -202,7 +202,6 @@ public class ItemTest {
     /** Tests if item is present in inventory and removed from Game world after collect */
     @Test
     public void testCollect() {
-
         assertEquals("There should be no entity in the game", 0, Game.entityStream().count());
 
         Item item = new Item("Test item", "Test description", defaultAnimation);

--- a/game/test/contrib/utils/components/item/ItemTest.java
+++ b/game/test/contrib/utils/components/item/ItemTest.java
@@ -202,6 +202,7 @@ public class ItemTest {
     /** Tests if item is present in inventory and removed from Game world after collect */
     @Test
     public void testCollect() {
+
         assertEquals("There should be no entity in the game", 0, Game.entityStream().count());
 
         Item item = new Item("Test item", "Test description", defaultAnimation);


### PR DESCRIPTION
fixes #970 

Ich habe die Inhalte der Klasse `Game` aufgesplittet.

- In `PreRunConfiguration` liegt jetzt alles, was vor dem Start des eigentlichen Spiels gesetzt/konfiguriert werden muss/kann. 
- In `ECSManagement` liegt alles, was irgendwas mit dem Verwalten der Entitäten oder Systeme zu tun hat. 
- In `GameLoop` liegt alles, was mit dem Schleifendurchlauf zu tun hat (inklusive Starter-Methode).

Ich habe keine neuen Logiken geschrieben, lediglich extrahiert.

Durch diese Auslagerung sollte es einfacher sein, den Code zu navigieren. 

Die Klasse `Game` kann (und sollte) weiterhin als zentrale API verwendet werden. Das bedeutet, dass ich für alle Methoden eine Weiterleitung/Delegation(?) (gibt es dafür eigentlich einen richtigen Namen?) eingebaut habe. Wir hatten das schon einmal für die Level-Geschichte gemacht (war damals ein Wunsch von @cagix).
