### PR TITLE
[DSL] Native Scenario Builder in DSL integrieren; Forcen von Scenario Builder für einzelne Tasks ermöglichen

### DIFF
--- a/dungeon/assets/scripts/internal_scenario_builder_usage.dng
+++ b/dungeon/assets/scripts/internal_scenario_builder_usage.dng
@@ -7,9 +7,25 @@ single_choice_task meine_aufgabe {
     grading_function: grade_single_choice_task
 }
 
+assign_task meine_assign_aufgabe {
+  description: "Bitte ordne Elemente einander zu! Die Fragen beziehen sich auf Programmierung.",
+  solution: <
+      ["Elementaroperation", "anzahl = 0"],
+      ["Elementaroperation", "sinus(30)"],
+      ["Kontrollstruktur", "if"],
+      ["Kontrollstruktur", "if - else"],
+      ["Kontrollstruktur", "while"],
+      ["Kontrollstruktur", "do - while"],
+      ["Kontrollstruktur", "repeat - until"],
+      ["Basisanweisung", _],
+      [_, "Öffne die Tür."]
+  >
+}
+
 // Definition von Aufgabenabhängigkeiten
 graph task_graph {
     meine_aufgabe;
+    meine_assign_aufgabe;
 }
 
 // Übergabe der Aufgabenabhängigkeit an das Dungeon-System

--- a/dungeon/assets/scripts/internal_scenario_builder_usage.dng
+++ b/dungeon/assets/scripts/internal_scenario_builder_usage.dng
@@ -1,0 +1,18 @@
+// Aufgabendefinition
+single_choice_task meine_aufgabe {
+    description: "Das ist der Aufgabentext",
+    answers: [ "1", "2", "3" ],
+    correct_answer_index: 2,
+    explanation: "Dieser Text wird angezeigt, falls die Aufgabe falsch beantwortet wird",
+    grading_function: grade_single_choice_task
+}
+
+// Definition von Aufgabenabhängigkeiten
+graph task_graph {
+    meine_aufgabe;
+}
+
+// Übergabe der Aufgabenabhängigkeit an das Dungeon-System
+dungeon_config meine_config {
+    dependency_graph: task_graph
+}

--- a/dungeon/src/dsl/interpreter/DSLInterpreter.java
+++ b/dungeon/src/dsl/interpreter/DSLInterpreter.java
@@ -479,7 +479,7 @@ public class DSLInterpreter implements AstVisitor<Object> {
         } else if (type.getTypeKind().equals(IType.Kind.EnumType)) {
             return new EnumValue((EnumType) type, null);
         } else if (type.getTypeKind().equals(IType.Kind.FunctionType)) {
-            return FunctionValue.NONE;
+            return (Value) FunctionValue.NONE.clone();
         }
         return Value.NONE;
     }

--- a/dungeon/src/dsl/interpreter/DSLInterpreter.java
+++ b/dungeon/src/dsl/interpreter/DSLInterpreter.java
@@ -346,16 +346,11 @@ public class DSLInterpreter implements AstVisitor<Object> {
                 this.scenarioBuilderStorage.retrieveRandomScenarioBuilderForType(
                         (IType) potentialTaskType);
         if (scenarioBuilder.isEmpty()) {
-            // TODO: this should fall back on a hard coded Java builder method
             return Optional.empty();
         }
 
         Value retValue =
                 (Value) this.callCallableRawParameters(scenarioBuilder.get(), List.of(task));
-        /*Value retValue =
-        (Value)
-                this.executeUserDefinedFunctionRawParameters(
-                        scenarioBuilder.get(), List.of(task));*/
         var typeInstantiator = this.environment.getTypeInstantiator();
 
         // create the java representation of the return Value

--- a/dungeon/src/dsl/interpreter/DSLInterpreter.java
+++ b/dungeon/src/dsl/interpreter/DSLInterpreter.java
@@ -292,9 +292,11 @@ public class DSLInterpreter implements AstVisitor<Object> {
         symbols.stream()
                 .filter(
                         symbol -> {
-                            if (symbol instanceof FunctionSymbol functionSymbol) {
-                                FunctionType functionType = functionSymbol.getFunctionType();
-                                if (!functionType.getReturnType().equals(returnType)) {
+                            if (symbol instanceof ICallable callable) {
+                                FunctionType functionType = callable.getFunctionType();
+                                if (!functionType
+                                        .getReturnType()
+                                        .equals(returnType)) {
                                     return false;
                                 }
                                 if (functionType.getParameterTypes().size() != 1) {
@@ -308,7 +310,7 @@ public class DSLInterpreter implements AstVisitor<Object> {
                             }
                             return false;
                         })
-                .map(symbol -> (FunctionSymbol) symbol)
+                .map(symbol -> (ICallable) symbol)
                 .forEach(this.scenarioBuilderStorage::storeScenarioBuilder);
     }
 
@@ -340,7 +342,7 @@ public class DSLInterpreter implements AstVisitor<Object> {
             throw new RuntimeException("Not a supported task type!");
         }
 
-        Optional<FunctionSymbol> scenarioBuilder =
+        Optional<ICallable> scenarioBuilder =
                 this.scenarioBuilderStorage.retrieveRandomScenarioBuilderForType(
                         (IType) potentialTaskType);
         if (scenarioBuilder.isEmpty()) {
@@ -349,9 +351,11 @@ public class DSLInterpreter implements AstVisitor<Object> {
         }
 
         Value retValue =
-                (Value)
-                        this.executeUserDefinedFunctionRawParameters(
-                                scenarioBuilder.get(), List.of(task));
+                (Value) this.callCallableRawParameters(scenarioBuilder.get(), List.of(task));
+        /*Value retValue =
+        (Value)
+                this.executeUserDefinedFunctionRawParameters(
+                        scenarioBuilder.get(), List.of(task));*/
         var typeInstantiator = this.environment.getTypeInstantiator();
 
         // create the java representation of the return Value

--- a/dungeon/src/dsl/interpreter/DSLInterpreter.java
+++ b/dungeon/src/dsl/interpreter/DSLInterpreter.java
@@ -294,9 +294,7 @@ public class DSLInterpreter implements AstVisitor<Object> {
                         symbol -> {
                             if (symbol instanceof ICallable callable) {
                                 FunctionType functionType = callable.getFunctionType();
-                                if (!functionType
-                                        .getReturnType()
-                                        .equals(returnType)) {
+                                if (!functionType.getReturnType().equals(returnType)) {
                                     return false;
                                 }
                                 if (functionType.getParameterTypes().size() != 1) {

--- a/dungeon/src/dsl/interpreter/ScenarioBuilderStorage.java
+++ b/dungeon/src/dsl/interpreter/ScenarioBuilderStorage.java
@@ -3,6 +3,7 @@ package dsl.interpreter;
 import dsl.runtime.IEvironment;
 import dsl.runtime.Value;
 import dsl.semanticanalysis.FunctionSymbol;
+import dsl.semanticanalysis.ICallable;
 import dsl.semanticanalysis.types.AggregateType;
 import dsl.semanticanalysis.types.FunctionType;
 import dsl.semanticanalysis.types.IType;
@@ -17,7 +18,7 @@ import java.util.*;
  * type is the key (as {@link IType}).
  */
 public class ScenarioBuilderStorage {
-    HashMap<IType, List<FunctionSymbol>> storedScenarioBuilders;
+    HashMap<IType, List<ICallable>> storedScenarioBuilders;
     HashMap<IType, ArrayDeque<Integer>> lastRetrievedBuilderIdxs;
 
     /** Constructor. */
@@ -78,16 +79,16 @@ public class ScenarioBuilderStorage {
      * maps to {@link Task} and return an `entity<><>` {@link Value}. The client code is responsible
      * to ensure this!
      *
-     * @param functionSymbol the {@link FunctionSymbol} to store as a scenario builder method.
+     * @param callable the {@link FunctionSymbol} to store as a scenario builder method.
      */
-    public void storeScenarioBuilder(FunctionSymbol functionSymbol) {
+    public void storeScenarioBuilder(ICallable callable) {
         // retrieve list for task type
         // the first parametertype denotes the task type
-        IType taskType = functionSymbol.getFunctionType().getParameterTypes().get(0);
+        IType taskType = callable.getFunctionType().getParameterTypes().get(0);
 
         if (storedScenarioBuilders.containsKey(taskType)) {
             var list = storedScenarioBuilders.get(taskType);
-            list.add(functionSymbol);
+            list.add(callable);
         }
 
         // clear last retrieved builders for this type
@@ -104,13 +105,13 @@ public class ScenarioBuilderStorage {
      *     for the given {@link IType}. If this {@link ScenarioBuilderStorage} does not store such a
      *     scenario builder, an empty {@link Optional} is returned.
      */
-    public Optional<FunctionSymbol> retrieveRandomScenarioBuilderForType(IType type) {
-        Optional<FunctionSymbol> returnSymbol = Optional.empty();
+    public Optional<ICallable> retrieveRandomScenarioBuilderForType(IType type) {
+        Optional<ICallable> returnSymbol = Optional.empty();
         if (!storedScenarioBuilders.containsKey(type)) {
             return returnSymbol;
         }
 
-        List<FunctionSymbol> list = storedScenarioBuilders.get(type);
+        List<ICallable> list = storedScenarioBuilders.get(type);
         if (list.size() == 0) {
             return returnSymbol;
         }
@@ -166,8 +167,8 @@ public class ScenarioBuilderStorage {
         int idx = idxsWithLowestCount.get(randomInt);
 
         // retrieve the function symbol by idx
-        FunctionSymbol symbol = list.get(idx);
+        ICallable callable = list.get(idx);
         lastRetrievedIdxs.add(idx);
-        return Optional.of(symbol);
+        return Optional.of(callable);
     }
 }

--- a/dungeon/src/dsl/runtime/FunctionValue.java
+++ b/dungeon/src/dsl/runtime/FunctionValue.java
@@ -30,4 +30,8 @@ public class FunctionValue extends Value {
     public Object clone() {
         return new FunctionValue(this.dataType, this.getCallable());
     }
+
+    public boolean isEmpty() {
+        return this.getInternalValue() == null;
+    }
 }

--- a/dungeon/src/dsl/runtime/GameEnvironment.java
+++ b/dungeon/src/dsl/runtime/GameEnvironment.java
@@ -347,7 +347,7 @@ public class GameEnvironment implements IEvironment {
         // native scenario builder functions
         var entitySetSetSymbol = this.globalScope.resolve("entity<><>");
         SetType entitySetSetType;
-        if (entitySetSetSymbol.equals(Symbol.NULL) ) {
+        if (entitySetSetSymbol.equals(Symbol.NULL)) {
             entitySetSetType = new SetType(entitySetType, this.globalScope);
             this.globalScope.bind(entitySetSetType);
         } else {
@@ -366,8 +366,8 @@ public class GameEnvironment implements IEvironment {
         if (!multipleChoiceSymbol.equals(Symbol.NULL)) {
             IType multipleChoiceTaskType = (IType) multipleChoiceSymbol;
             NativeFunction multipleChoiceScenarioBuilderFunc =
-                new MultipleChoiceNativeScenarioBuilder(
-                    this.globalScope, multipleChoiceTaskType, entitySetSetType);
+                    new MultipleChoiceNativeScenarioBuilder(
+                            this.globalScope, multipleChoiceTaskType, entitySetSetType);
             nativeFunctions.add(multipleChoiceScenarioBuilderFunc);
         }
 
@@ -375,8 +375,8 @@ public class GameEnvironment implements IEvironment {
         if (!assignSymbol.equals(Symbol.NULL)) {
             IType assignTaskType = (IType) assignSymbol;
             NativeFunction assignTaskNativeScenarioBuilder =
-                new AssignTaskNativeScenarioBuilder(
-                    this.globalScope, assignTaskType, entitySetSetType);
+                    new AssignTaskNativeScenarioBuilder(
+                            this.globalScope, assignTaskType, entitySetSetType);
             nativeFunctions.add(assignTaskNativeScenarioBuilder);
         }
 
@@ -1017,11 +1017,11 @@ public class GameEnvironment implements IEvironment {
          * @param parentScope parent scope of this function
          */
         public MultipleChoiceNativeScenarioBuilder(
-            IScope parentScope, IType multipleChoiceType, IType entitySetSetType) {
+                IScope parentScope, IType multipleChoiceType, IType entitySetSetType) {
             super(
-                "$default_multiple_choice_scenario$",
-                parentScope,
-                new FunctionType(entitySetSetType, multipleChoiceType));
+                    "$default_multiple_choice_scenario$",
+                    parentScope,
+                    new FunctionType(entitySetSetType, multipleChoiceType));
         }
 
         @Override
@@ -1050,11 +1050,11 @@ public class GameEnvironment implements IEvironment {
          * @param parentScope parent scope of this function
          */
         public AssignTaskNativeScenarioBuilder(
-            IScope parentScope, IType assignTaskType, IType entitySetSetType) {
+                IScope parentScope, IType assignTaskType, IType entitySetSetType) {
             super(
-                "$default_assign_task_scenario$",
-                parentScope,
-                new FunctionType(entitySetSetType, assignTaskType));
+                    "$default_assign_task_scenario$",
+                    parentScope,
+                    new FunctionType(entitySetSetType, assignTaskType));
         }
 
         @Override

--- a/dungeon/src/dsl/runtime/GameEnvironment.java
+++ b/dungeon/src/dsl/runtime/GameEnvironment.java
@@ -371,6 +371,15 @@ public class GameEnvironment implements IEvironment {
             nativeFunctions.add(multipleChoiceScenarioBuilderFunc);
         }
 
+        var assignSymbol = this.globalScope.resolve("assign_task");
+        if (!assignSymbol.equals(Symbol.NULL)) {
+            IType assignTaskType = (IType) assignSymbol;
+            NativeFunction assignTaskNativeScenarioBuilder =
+                new AssignTaskNativeScenarioBuilder(
+                    this.globalScope, assignTaskType, entitySetSetType);
+            nativeFunctions.add(assignTaskNativeScenarioBuilder);
+        }
+
         return nativeFunctions;
     }
 
@@ -1025,6 +1034,39 @@ public class GameEnvironment implements IEvironment {
 
             // call func
             return NativeScenarioBuilder.quizOnHud(task);
+        }
+
+        @Override
+        public ICallable.Type getCallableType() {
+            return ICallable.Type.Native;
+        }
+    }
+
+    private static class AssignTaskNativeScenarioBuilder extends NativeFunction {
+
+        /**
+         * Constructor
+         *
+         * @param parentScope parent scope of this function
+         */
+        public AssignTaskNativeScenarioBuilder(
+            IScope parentScope, IType assignTaskType, IType entitySetSetType) {
+            super(
+                "$default_assign_task_scenario$",
+                parentScope,
+                new FunctionType(entitySetSetType, assignTaskType));
+        }
+
+        @Override
+        public Object call(DSLInterpreter interpreter, List<Node> parameters) {
+            assert parameters != null && parameters.size() > 0;
+
+            var parameterValues = interpreter.evaluateNodes(parameters);
+            var parameterObjects = interpreter.translateValuesToObjects(parameterValues);
+            AssignTask task = (AssignTask) parameterObjects.get(0);
+
+            // call func
+            return NativeScenarioBuilder.assignTaskA(task);
         }
 
         @Override

--- a/dungeon/src/dsl/runtime/GameEnvironment.java
+++ b/dungeon/src/dsl/runtime/GameEnvironment.java
@@ -28,8 +28,8 @@ import dslinterop.dsltypeadapters.DrawComponentAdapter;
 import dslinterop.dsltypeadapters.QuestItemAdapter;
 import dslinterop.dsltypeproperties.EntityExtension;
 import dslinterop.dsltypeproperties.QuestItemExtension;
-
 import dslinterop.nativescenariobuilder.NativeScenarioBuilder;
+
 import task.*;
 import task.components.TaskComponent;
 import task.components.TaskContentComponent;
@@ -291,7 +291,8 @@ public class GameEnvironment implements IEvironment {
         // build functions with dependency on specific non-builtin types
         IType questItemType = (IType) this.globalScope.resolve("quest_item");
         IType entityType = (IType) this.globalScope.resolve("entity");
-        IType entitySetType = new SetType(entityType, this.globalScope);
+        SetType entitySetType = new SetType(entityType, this.globalScope);
+        this.globalScope.bind(entitySetType);
 
         NativeFunction placeQuestItem =
                 new NativePlaceQuestItem(Scope.NULL, questItemType, entitySetType);
@@ -344,12 +345,30 @@ public class GameEnvironment implements IEvironment {
         }
 
         // native scenario builder functions
-        IType entitySetSetType = new SetType(entitySetType, this.globalScope);
+        var entitySetSetSymbol = this.globalScope.resolve("entity<><>");
+        SetType entitySetSetType;
+        if (entitySetSetSymbol.equals(Symbol.NULL) ) {
+            entitySetSetType = new SetType(entitySetType, this.globalScope);
+            this.globalScope.bind(entitySetSetType);
+        } else {
+            entitySetSetType = (SetType) entitySetSetSymbol;
+        }
         var singleChoiceSymbol = this.globalScope.resolve("single_choice_task");
         if (!singleChoiceSymbol.equals(Symbol.NULL)) {
-            IType singleChoiceTaskType = (IType) taskSymbol;
-            NativeFunction singleChoiceScenarioBuilderFunc = new SingleChoiceNativeScenarioBuilder(this.globalScope, singleChoiceTaskType, entitySetSetType);
+            IType singleChoiceTaskType = (IType) singleChoiceSymbol;
+            NativeFunction singleChoiceScenarioBuilderFunc =
+                    new SingleChoiceNativeScenarioBuilder(
+                            this.globalScope, singleChoiceTaskType, entitySetSetType);
             nativeFunctions.add(singleChoiceScenarioBuilderFunc);
+        }
+
+        var multipleChoiceSymbol = this.globalScope.resolve("multiple_choice_task");
+        if (!multipleChoiceSymbol.equals(Symbol.NULL)) {
+            IType multipleChoiceTaskType = (IType) multipleChoiceSymbol;
+            NativeFunction multipleChoiceScenarioBuilderFunc =
+                new MultipleChoiceNativeScenarioBuilder(
+                    this.globalScope, multipleChoiceTaskType, entitySetSetType);
+            nativeFunctions.add(multipleChoiceScenarioBuilderFunc);
         }
 
         return nativeFunctions;
@@ -955,12 +974,45 @@ public class GameEnvironment implements IEvironment {
          *
          * @param parentScope parent scope of this function
          */
-        public SingleChoiceNativeScenarioBuilder(IScope parentScope, IType singleChoiceType, IType entitySetSetType) {
+        public SingleChoiceNativeScenarioBuilder(
+                IScope parentScope, IType singleChoiceType, IType entitySetSetType) {
             super(
-                "$default_single_choice_scenario$",
+                    "$default_single_choice_scenario$",
+                    parentScope,
+                    new FunctionType(entitySetSetType, singleChoiceType));
+        }
+
+        @Override
+        public Object call(DSLInterpreter interpreter, List<Node> parameters) {
+            assert parameters != null && parameters.size() > 0;
+
+            var parameterValues = interpreter.evaluateNodes(parameters);
+            var parameterObjects = interpreter.translateValuesToObjects(parameterValues);
+            Quiz task = (Quiz) parameterObjects.get(0);
+
+            // call func
+            return NativeScenarioBuilder.quizOnHud(task);
+        }
+
+        @Override
+        public ICallable.Type getCallableType() {
+            return ICallable.Type.Native;
+        }
+    }
+
+    private static class MultipleChoiceNativeScenarioBuilder extends NativeFunction {
+
+        /**
+         * Constructor
+         *
+         * @param parentScope parent scope of this function
+         */
+        public MultipleChoiceNativeScenarioBuilder(
+            IScope parentScope, IType multipleChoiceType, IType entitySetSetType) {
+            super(
+                "$default_multiple_choice_scenario$",
                 parentScope,
-                new FunctionType(entitySetSetType, singleChoiceType));
-            this.func = GradingFunctions.assignGradingEasy();
+                new FunctionType(entitySetSetType, multipleChoiceType));
         }
 
         @Override

--- a/dungeon/src/dsl/runtime/Value.java
+++ b/dungeon/src/dsl/runtime/Value.java
@@ -80,14 +80,14 @@ public class Value implements IClonable {
      */
     public boolean setInternalValue(Object internalValue) {
         // TODO: should this check for datatype compatibility?
-        if (isMutable) {
+        if (!isMutable) {
+            throw new RuntimeException("Tried to write to non-mutable value!");
+        } else {
             this.object = internalValue;
 
             this.dirty = true;
             return true;
         }
-        System.out.println("Tried to set internal value of immutable value");
-        return false;
     }
 
     /**

--- a/dungeon/src/dsl/semanticanalysis/FunctionDefinitionBinder.java
+++ b/dungeon/src/dsl/semanticanalysis/FunctionDefinitionBinder.java
@@ -179,8 +179,11 @@ public class FunctionDefinitionBinder implements AstVisitor<Void> {
                 innerTypeNode.accept(this);
             }
             var innerType = globalScope.resolveType(innerTypeNode.getName());
-            ListType listType = new ListType(innerType, globalScope);
-            globalScope.bind(listType);
+            Symbol listTypeSymbol = globalScope.resolve(ListType.getListTypeName(innerType));
+            if (listTypeSymbol.equals(Symbol.NULL)) {
+                ListType listType = new ListType(innerType, globalScope);
+                globalScope.bind(listType);
+            }
         }
         return null;
     }
@@ -201,8 +204,11 @@ public class FunctionDefinitionBinder implements AstVisitor<Void> {
                 innerTypeNode.accept(this);
             }
             var innerType = globalScope.resolveType(innerTypeNode.getName());
-            SetType setType = new SetType(innerType, globalScope);
-            globalScope.bind(setType);
+            Symbol setTypeSymbol = globalScope.resolve(SetType.getSetTypeName(innerType));
+            if (setTypeSymbol.equals(Symbol.NULL)) {
+                SetType setType = new SetType(innerType, globalScope);
+                globalScope.bind(setType);
+            }
         }
         return null;
     }

--- a/dungeon/src/dsl/semanticanalysis/SemanticAnalyzer.java
+++ b/dungeon/src/dsl/semanticanalysis/SemanticAnalyzer.java
@@ -620,8 +620,11 @@ public class SemanticAnalyzer implements AstVisitor<Void> {
                 innerTypeNode.accept(this);
             }
             var innerType = (IType) this.environment.resolveInGlobalScope(innerTypeNode.getName());
-            ListType listType = new ListType(innerType, this.globalScope());
-            this.globalScope().bind(listType);
+            Symbol listTypeSymbol = this.globalScope().resolve(ListType.getListTypeName(innerType));
+            if (listTypeSymbol.equals(Symbol.NULL)) {
+                ListType listType = new ListType(innerType, this.globalScope());
+                this.globalScope().bind(listType);
+            }
         }
         return null;
     }
@@ -639,8 +642,11 @@ public class SemanticAnalyzer implements AstVisitor<Void> {
                 innerTypeNode.accept(this);
             }
             var innerType = (IType) this.environment.resolveInGlobalScope(innerTypeNode.getName());
-            SetType setType = new SetType(innerType, this.globalScope());
-            this.globalScope().bind(setType);
+            Symbol setTypeSymbol = this.globalScope().resolve(SetType.getSetTypeName(innerType));
+            if (setTypeSymbol.equals(Symbol.NULL)) {
+                SetType setType = new SetType(innerType, this.globalScope());
+                this.globalScope().bind(setType);
+            }
         }
         return null;
     }

--- a/dungeon/src/dsl/semanticanalysis/types/TypeBuilder.java
+++ b/dungeon/src/dsl/semanticanalysis/types/TypeBuilder.java
@@ -224,11 +224,8 @@ public class TypeBuilder {
                                 ? convertToDSLName(forType.getSimpleName())
                                 : annotation.name();
 
-                // create adapterType
-                var adapterType = createAdapterType(forType, dslTypeName, method, parentScope);
+                createAdapterType(forType, dslTypeName, method, parentScope);
 
-                this.javaTypeToDSLType.put(forType, adapterType);
-                parentScope.bind((Symbol) adapterType);
                 return;
             }
         }
@@ -244,6 +241,8 @@ public class TypeBuilder {
 
         var typeAdapter =
                 new AggregateTypeAdapter(dslTypeName, parentScope, forType, adapterMethod);
+        this.javaTypeToDSLType.put(forType, typeAdapter);
+        parentScope.bind(typeAdapter);
 
         // bind symbol for each parameter in the adapterMethod
         for (var parameter : adapterMethod.getParameters()) {

--- a/dungeon/src/dsl/semanticanalysis/types/TypeInstantiator.java
+++ b/dungeon/src/dsl/semanticanalysis/types/TypeInstantiator.java
@@ -390,11 +390,12 @@ public class TypeInstantiator {
                     }
                 }
                 if (field.isAnnotationPresent(DSLCallback.class)) {
-                    if (fieldValue != Value.NONE && fieldValue != FunctionValue.NONE) {
+                    if (fieldValue != Value.NONE
+                            && fieldValue != FunctionValue.NONE
+                            && fieldValue instanceof FunctionValue funcValue
+                            && !funcValue.isEmpty()) {
                         assert fieldValue.getDataType().getTypeKind() == IType.Kind.FunctionType;
-                        FunctionValue functionValue = (FunctionValue) fieldValue;
-                        if (!(functionValue.getCallable()
-                                instanceof FunctionSymbol functionSymbol)) {
+                        if (!(funcValue.getCallable() instanceof FunctionSymbol functionSymbol)) {
                             throw new RuntimeException(
                                     "Usage of non-FunctionSymbol callables as DSLCallback currently not supported");
                         } else {

--- a/dungeon/src/dsl/semanticanalysis/types/callbackadapter/CallbackAdapter.java
+++ b/dungeon/src/dsl/semanticanalysis/types/callbackadapter/CallbackAdapter.java
@@ -40,6 +40,10 @@ public class CallbackAdapter implements Consumer, TriConsumer, BiConsumer {
         return convertValueToObject(returnValue);
     }
 
+    public ICallable callable() {
+        return this.callable;
+    }
+
     protected Object convertValueToObject(Value value) {
         return this.rtEnv.getTypeInstantiator().instantiate(value);
     }

--- a/dungeon/src/dslinterop/nativescenariobuilder/NativeScenarioBuilder.java
+++ b/dungeon/src/dslinterop/nativescenariobuilder/NativeScenarioBuilder.java
@@ -8,17 +8,15 @@ import contrib.entities.WorldItemBuilder;
 import contrib.hud.GUICombination;
 import contrib.hud.OkDialog;
 import contrib.hud.UITools;
-
 import contrib.hud.inventory.InventoryGUI;
 import contrib.utils.components.draw.ChestAnimations;
+
 import core.Entity;
-import core.Game;
 import core.components.DrawComponent;
 import core.components.PositionComponent;
-
 import core.utils.components.draw.Animation;
 import core.utils.components.draw.CoreAnimationPriorities;
-import core.utils.components.draw.CoreAnimations;
+
 import task.Task;
 import task.TaskContent;
 import task.components.TaskComponent;
@@ -64,8 +62,9 @@ public class NativeScenarioBuilder {
         Set<Entity> roomSet = new HashSet<>();
 
         // set scenario text
-        task.scenarioText("Die Schriftrollen enthalten die Antworten. Ordne die Schriftrollen " +
-            "den passenden Quest-Truhen zu!");
+        task.scenarioText(
+                "Die Schriftrollen enthalten die Antworten. Ordne die Schriftrollen "
+                        + "den passenden Quest-Truhen zu!");
         // set answer picker function
         task.answerPickingFunction(AnswerPickingFunctions.multipleChestPicker());
 
@@ -88,7 +87,9 @@ public class NativeScenarioBuilder {
             for (var element : entry.getValue()) {
                 if (!element.equals(AssignTask.EMPTY_ELEMENT)) {
                     Animation animation =
-                        new Animation("items/book/wisdom_scroll.png", CoreAnimationPriorities.DEFAULT.priority());
+                            new Animation(
+                                    "items/book/wisdom_scroll.png",
+                                    CoreAnimationPriorities.DEFAULT.priority());
                     TaskContentComponent tcc = new TaskContentComponent(element);
                     QuestItem questItem = new QuestItem(animation, tcc);
                     Entity worldItem = WorldItemBuilder.buildWorldItem(questItem);
@@ -107,7 +108,8 @@ public class NativeScenarioBuilder {
                     chest.addComponent(new InventoryComponent());
 
                     chest.removeComponent(InteractionComponent.class);
-                    chest.addComponent(new InteractionComponent(1.5f, true, QuestChestInventoryInteraction()));
+                    chest.addComponent(
+                            new InteractionComponent(1.5f, true, QuestChestInventoryInteraction()));
 
                     // mark as task container
                     var tcc = new TaskContentComponent();
@@ -117,7 +119,7 @@ public class NativeScenarioBuilder {
                     task.addContent(key);
                     task.addContainer(key);
                     roomSet.add(chest);
-                } catch(Exception ex) {
+                } catch (Exception ex) {
                     throw new RuntimeException(ex);
                 }
             }
@@ -129,17 +131,17 @@ public class NativeScenarioBuilder {
 
     private static InteractionComponent askOnInteractionQuiz(Quiz quiz) {
         return new InteractionComponent(
-            1,
-            true,
-            (thisEntity, otherEntity) -> {
-                if (quiz.state().equals(Task.TaskState.ACTIVE)
-                    || quiz.state().equals(Task.TaskState.PROCESSING_ACTIVE)) {
-                    QuizUI.askQuizOnHud(quiz);
-                } else {
-                    OkDialog.showOkDialog(
-                        "Du hast die Aufgabe schon bearbeitet.", "Info", () -> {});
-                }
-            });
+                1,
+                true,
+                (thisEntity, otherEntity) -> {
+                    if (quiz.state().equals(Task.TaskState.ACTIVE)
+                            || quiz.state().equals(Task.TaskState.PROCESSING_ACTIVE)) {
+                        QuizUI.askQuizOnHud(quiz);
+                    } else {
+                        OkDialog.showOkDialog(
+                                "Du hast die Aufgabe schon bearbeitet.", "Info", () -> {});
+                    }
+                });
     }
 
     private static BiConsumer<Entity, Entity> QuestChestInventoryInteraction() {
@@ -155,51 +157,51 @@ public class NativeScenarioBuilder {
                 TaskContent content = optionalTcc.get().content();
                 Task task = content.task();
                 inventory =
-                    new InventoryGUI(content + " (Quest: '" + task.taskName() + "')", chestIc);
+                        new InventoryGUI(content + " (Quest: '" + task.taskName() + "')", chestIc);
             }
 
             UIComponent uiComponent =
-                new UIComponent(new GUICombination(new InventoryGUI(otherIc), inventory), true);
+                    new UIComponent(new GUICombination(new InventoryGUI(otherIc), inventory), true);
             uiComponent.onClose(
-                () ->
-                    chest.fetch(DrawComponent.class)
-                        .ifPresent(
-                            interactedDC -> {
-                                // remove all prior
-                                // opened animations
-                                interactedDC.deQueueByPriority(
-                                    ChestAnimations.OPEN_FULL.priority());
-                                if (chestIc.count() > 0) {
-                                    // aslong as
-                                    // there is an
-                                    // item inside
-                                    // the chest
-                                    // show a full
-                                    // chest
-                                    interactedDC.queueAnimation(
-                                        ChestAnimations.OPEN_FULL);
-                                } else {
-                                    // empty chest
-                                    // show the
-                                    // empty
-                                    // animation
-                                    interactedDC.queueAnimation(
-                                        ChestAnimations.OPEN_EMPTY);
-                                }
-                            }));
+                    () ->
+                            chest.fetch(DrawComponent.class)
+                                    .ifPresent(
+                                            interactedDC -> {
+                                                // remove all prior
+                                                // opened animations
+                                                interactedDC.deQueueByPriority(
+                                                        ChestAnimations.OPEN_FULL.priority());
+                                                if (chestIc.count() > 0) {
+                                                    // aslong as
+                                                    // there is an
+                                                    // item inside
+                                                    // the chest
+                                                    // show a full
+                                                    // chest
+                                                    interactedDC.queueAnimation(
+                                                            ChestAnimations.OPEN_FULL);
+                                                } else {
+                                                    // empty chest
+                                                    // show the
+                                                    // empty
+                                                    // animation
+                                                    interactedDC.queueAnimation(
+                                                            ChestAnimations.OPEN_EMPTY);
+                                                }
+                                            }));
             other.addComponent(uiComponent);
             chest.fetch(DrawComponent.class)
-                .ifPresent(
-                    interactedDC -> {
-                        // only add opening animation when it is not
-                        // finished
-                        if (interactedDC
-                            .getAnimation(ChestAnimations.OPENING)
-                            .map(animation -> !animation.isFinished())
-                            .orElse(true)) {
-                            interactedDC.queueAnimation(ChestAnimations.OPENING);
-                        }
-                    });
+                    .ifPresent(
+                            interactedDC -> {
+                                // only add opening animation when it is not
+                                // finished
+                                if (interactedDC
+                                        .getAnimation(ChestAnimations.OPENING)
+                                        .map(animation -> !animation.isFinished())
+                                        .orElse(true)) {
+                                    interactedDC.queueAnimation(ChestAnimations.OPENING);
+                                }
+                            });
         };
     }
 

--- a/dungeon/src/dslinterop/nativescenariobuilder/NativeScenarioBuilder.java
+++ b/dungeon/src/dslinterop/nativescenariobuilder/NativeScenarioBuilder.java
@@ -1,20 +1,35 @@
 package dslinterop.nativescenariobuilder;
 
 import contrib.components.InteractionComponent;
+import contrib.components.InventoryComponent;
+import contrib.components.UIComponent;
 import contrib.entities.EntityFactory;
+import contrib.entities.WorldItemBuilder;
+import contrib.hud.GUICombination;
 import contrib.hud.OkDialog;
 import contrib.hud.UITools;
 
+import contrib.hud.inventory.InventoryGUI;
+import contrib.utils.components.draw.ChestAnimations;
 import core.Entity;
+import core.Game;
 import core.components.DrawComponent;
 import core.components.PositionComponent;
 
+import core.utils.components.draw.Animation;
+import core.utils.components.draw.CoreAnimationPriorities;
+import core.utils.components.draw.CoreAnimations;
 import task.Task;
 import task.TaskContent;
 import task.components.TaskComponent;
+import task.components.TaskContentComponent;
+import task.reporting.AnswerPickingFunctions;
 import task.tasktype.AssignTask;
+import task.tasktype.Element;
 import task.tasktype.Quiz;
+import task.utils.gamecontent.QuestItem;
 import task.utils.hud.QuizUI;
+import task.utils.hud.YesNoDialog;
 
 import java.io.IOException;
 import java.util.HashSet;
@@ -32,7 +47,7 @@ public class NativeScenarioBuilder {
         }
         new TaskComponent(quiz, questowner);
 
-        questowner.addComponent(askOnInteraction(quiz));
+        questowner.addComponent(askOnInteractionQuiz(quiz));
 
         Set<Set<Entity>> returnSet = new HashSet<>();
         Set<Entity> roomSet = new HashSet<>();
@@ -44,18 +59,158 @@ public class NativeScenarioBuilder {
         return returnSet;
     }
 
-    private HashSet<HashSet<Entity>> assignTaskA(AssignTask task) {
-        return null;
+    public static Set<Set<Entity>> assignTaskA(AssignTask task) {
+        Set<Set<Entity>> returnSet = new HashSet<>();
+        Set<Entity> roomSet = new HashSet<>();
+
+        // set scenario text
+        task.scenarioText("Die Schriftrollen enthalten die Antworten. Ordne die Schriftrollen " +
+            "den passenden Quest-Truhen zu!");
+        // set answer picker function
+        task.answerPickingFunction(AnswerPickingFunctions.multipleChestPicker());
+
+        // setup quest owner
+        Entity questowner = new Entity("Questgeber");
+        questowner.addComponent(new PositionComponent());
+        try {
+            questowner.addComponent(new DrawComponent("character/knight"));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        new TaskComponent(task, questowner);
+        questowner.addComponent(askOnInteractionYesNo(task));
+        roomSet.add(questowner);
+
+        // setup items and chests
+        var entrySet = task.solution().entrySet();
+        for (var entry : entrySet) {
+            // setup quest items
+            for (var element : entry.getValue()) {
+                if (!element.equals(AssignTask.EMPTY_ELEMENT)) {
+                    Animation animation =
+                        new Animation("items/book/wisdom_scroll.png", CoreAnimationPriorities.DEFAULT.priority());
+                    TaskContentComponent tcc = new TaskContentComponent(element);
+                    QuestItem questItem = new QuestItem(animation, tcc);
+                    Entity worldItem = WorldItemBuilder.buildWorldItem(questItem);
+                    roomSet.add(worldItem);
+                }
+            }
+
+            // setup chests
+            Element key = entry.getKey();
+            if (!key.equals(AssignTask.EMPTY_ELEMENT)) {
+                try {
+                    Entity chest = EntityFactory.newChest();
+
+                    // empty generated chest
+                    chest.removeComponent(InventoryComponent.class);
+                    chest.addComponent(new InventoryComponent());
+
+                    chest.removeComponent(InteractionComponent.class);
+                    chest.addComponent(new InteractionComponent(1.5f, true, QuestChestInventoryInteraction()));
+
+                    // mark as task container
+                    var tcc = new TaskContentComponent();
+                    tcc.content(key);
+                    chest.addComponent(tcc);
+
+                    task.addContent(key);
+                    task.addContainer(key);
+                    roomSet.add(chest);
+                } catch(Exception ex) {
+                    throw new RuntimeException(ex);
+                }
+            }
+        }
+
+        returnSet.add(roomSet);
+        return returnSet;
     }
 
-    private static InteractionComponent askOnInteraction(Quiz quiz) {
+    private static InteractionComponent askOnInteractionQuiz(Quiz quiz) {
+        return new InteractionComponent(
+            1,
+            true,
+            (thisEntity, otherEntity) -> {
+                if (quiz.state().equals(Task.TaskState.ACTIVE)
+                    || quiz.state().equals(Task.TaskState.PROCESSING_ACTIVE)) {
+                    QuizUI.askQuizOnHud(quiz);
+                } else {
+                    OkDialog.showOkDialog(
+                        "Du hast die Aufgabe schon bearbeitet.", "Info", () -> {});
+                }
+            });
+    }
+
+    private static BiConsumer<Entity, Entity> QuestChestInventoryInteraction() {
+        return (chest, other) -> {
+            InventoryComponent chestIc = chest.fetch(InventoryComponent.class).get();
+            InventoryComponent otherIc = other.fetch(InventoryComponent.class).get();
+
+            var optionalTcc = chest.fetch(TaskContentComponent.class);
+            InventoryGUI inventory;
+            if (optionalTcc.isEmpty()) {
+                inventory = new InventoryGUI(chestIc);
+            } else {
+                TaskContent content = optionalTcc.get().content();
+                Task task = content.task();
+                inventory =
+                    new InventoryGUI(content + " (Quest: '" + task.taskName() + "')", chestIc);
+            }
+
+            UIComponent uiComponent =
+                new UIComponent(new GUICombination(new InventoryGUI(otherIc), inventory), true);
+            uiComponent.onClose(
+                () ->
+                    chest.fetch(DrawComponent.class)
+                        .ifPresent(
+                            interactedDC -> {
+                                // remove all prior
+                                // opened animations
+                                interactedDC.deQueueByPriority(
+                                    ChestAnimations.OPEN_FULL.priority());
+                                if (chestIc.count() > 0) {
+                                    // aslong as
+                                    // there is an
+                                    // item inside
+                                    // the chest
+                                    // show a full
+                                    // chest
+                                    interactedDC.queueAnimation(
+                                        ChestAnimations.OPEN_FULL);
+                                } else {
+                                    // empty chest
+                                    // show the
+                                    // empty
+                                    // animation
+                                    interactedDC.queueAnimation(
+                                        ChestAnimations.OPEN_EMPTY);
+                                }
+                            }));
+            other.addComponent(uiComponent);
+            chest.fetch(DrawComponent.class)
+                .ifPresent(
+                    interactedDC -> {
+                        // only add opening animation when it is not
+                        // finished
+                        if (interactedDC
+                            .getAnimation(ChestAnimations.OPENING)
+                            .map(animation -> !animation.isFinished())
+                            .orElse(true)) {
+                            interactedDC.queueAnimation(ChestAnimations.OPENING);
+                        }
+                    });
+        };
+    }
+
+    private static InteractionComponent askOnInteractionYesNo(Task task) {
         return new InteractionComponent(
                 1,
                 true,
                 (thisEntity, otherEntity) -> {
-                    if (quiz.state().equals(Task.TaskState.ACTIVE)
-                            || quiz.state().equals(Task.TaskState.PROCESSING_ACTIVE)) {
-                        QuizUI.askQuizOnHud(quiz);
+                    if (task.state().equals(Task.TaskState.ACTIVE)
+                            || task.state().equals(Task.TaskState.PROCESSING_ACTIVE)) {
+                        YesNoDialog.showYesNoDialog(task);
                     } else {
                         OkDialog.showOkDialog(
                                 "Du hast die Aufgabe schon bearbeitet.", "Info", () -> {});

--- a/dungeon/src/dslinterop/nativescenariobuilder/NativeScenarioBuilder.java
+++ b/dungeon/src/dslinterop/nativescenariobuilder/NativeScenarioBuilder.java
@@ -1,0 +1,77 @@
+package dslinterop.nativescenariobuilder;
+
+import contrib.components.InteractionComponent;
+import contrib.entities.EntityFactory;
+import contrib.hud.UITools;
+
+import core.Entity;
+import core.components.DrawComponent;
+import core.components.PositionComponent;
+
+import task.Task;
+import task.TaskContent;
+import task.components.TaskComponent;
+import task.tasktype.AssignTask;
+import task.tasktype.Quiz;
+import task.utils.hud.UIAnswerCallback;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.BiConsumer;
+
+public class NativeScenarioBuilder {
+    public static Set<Set<Entity>> quizOnHud(Quiz quiz) {
+        Entity questowner = new Entity("Questowner");
+        questowner.addComponent(new PositionComponent());
+        try {
+            questowner.addComponent(new DrawComponent("character/knight"));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        questowner.addComponent(askOnInteraction(quiz));
+        new TaskComponent(quiz, questowner);
+
+        Set<Set<Entity>> returnSet = new HashSet<>();
+        Set<Entity> roomSet = new HashSet<>();
+
+        roomSet.add(questowner);
+
+        returnSet.add(roomSet);
+        returnSet.add(fillerSet());
+        returnSet.add(fillerSet());
+        returnSet.add(fillerSet());
+        return returnSet;
+    }
+
+    private HashSet<HashSet<Entity>> assignTaskA(AssignTask task) {
+        return null;
+    }
+
+    private static InteractionComponent askOnInteraction(Quiz quiz) {
+        return new InteractionComponent(
+            1, true, UIAnswerCallback.askOnInteraction(quiz, showAnswersOnHud()));
+    }
+
+    private static BiConsumer<Task, Set<TaskContent>> showAnswersOnHud() {
+        return (task, taskContents) -> {
+            float score = task.gradeTask(taskContents);
+            task.managerEntity().get().removeComponent(InteractionComponent.class);
+            UITools.generateNewTextDialog("Your score: " + score, "Ok", "Given answer");
+        };
+    }
+
+    private static Set<Entity> fillerSet() {
+        try {
+            return Set.of(
+                EntityFactory.newChest(),
+                EntityFactory.randomMonster(),
+                EntityFactory.randomMonster(),
+                EntityFactory.randomMonster());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+
+}

--- a/dungeon/src/task/Task.java
+++ b/dungeon/src/task/Task.java
@@ -64,6 +64,7 @@ public abstract class Task {
     protected List<TaskContent> content;
     protected BiFunction<Task, Set<TaskContent>, Float> scoringFunction;
     protected Function<Task, Set<TaskContent>> answerPickingFunction;
+    protected Function<? extends Task, Set<Set<Entity>>> scenarioBuilderFunction;
     protected float points;
     protected Set<TaskContent> container;
     private TaskState state;
@@ -221,6 +222,24 @@ public abstract class Task {
      */
     public String scenarioText() {
         return scenarioText;
+    }
+
+    /**
+     * Get the forced scenario builder.
+     *
+     * @return the scenario builder
+     */
+    public Function<? extends Task, Set<Set<Entity>>> scenarioBuilderFunction() {
+        return this.scenarioBuilderFunction;
+    }
+
+    /**
+     * Set the forced scenario builder.
+     *
+     * @param func new scenario builder
+     */
+    public void scenarioBuilderFunction(Function<? extends Task, Set<Set<Entity>>> func) {
+        this.scenarioBuilderFunction = func;
     }
 
     /**

--- a/dungeon/src/task/dslinterop/AssignTaskDSLType.java
+++ b/dungeon/src/task/dslinterop/AssignTaskDSLType.java
@@ -2,6 +2,8 @@ package task.dslinterop;
 
 import static task.tasktype.AssignTask.EMPTY_ELEMENT;
 
+import core.Entity;
+
 import dsl.semanticanalysis.types.*;
 
 import task.Task;
@@ -28,12 +30,17 @@ public class AssignTaskDSLType {
             @DSLTypeMember(name = "solution") Set<List<Element<String>>> solution,
             @DSLTypeMember(name = "explanation") String explanation,
             @DSLTypeMember(name = "grading_function")
-                    BiFunction<Task, Set<TaskContent>, Float> gradingFunction) {
-
+                    BiFunction<Task, Set<TaskContent>, Float> gradingFunction,
+            @DSLTypeMember(name = "scenario_builder")
+                    Function<AssignTask, Set<Set<Entity>>> scenarioBuilder) {
         AssignTask task = new AssignTask();
         task.taskText(description);
         task.taskName(name);
         task.explanation(explanation);
+
+        if (scenarioBuilder != null) {
+            task.scenarioBuilderFunction(scenarioBuilder);
+        }
 
         if (points > 0.0f && pointsToPass > 0.0f) {
             task.points(points, pointsToPass);

--- a/dungeon/src/task/dslinterop/MultipleChoiceTask.java
+++ b/dungeon/src/task/dslinterop/MultipleChoiceTask.java
@@ -1,5 +1,7 @@
 package task.dslinterop;
 
+import core.Entity;
+
 import dsl.semanticanalysis.types.*;
 
 import task.Task;
@@ -26,12 +28,18 @@ public class MultipleChoiceTask {
             @DSLTypeMember(name = "correct_answer_index") List<Integer> correctAnswerIndices,
             @DSLTypeMember(name = "explanation") String explanation,
             @DSLTypeMember(name = "grading_function")
-                    BiFunction<Task, Set<TaskContent>, Float> gradingFunction
+                    BiFunction<Task, Set<TaskContent>, Float> gradingFunction,
+            @DSLTypeMember(name = "scenario_builder")
+                    Function<MultipleChoice, Set<Set<Entity>>> scenarioBuilder
             //  scoreFunction
             ) {
         MultipleChoice mc = new MultipleChoice(description);
         mc.taskName(name);
         mc.explanation(explanation);
+
+        if (scenarioBuilder != null) {
+            mc.scenarioBuilderFunction(scenarioBuilder);
+        }
 
         if (points > 0.0f && pointsToPass > 0.0f) {
             mc.points(points, pointsToPass);

--- a/dungeon/src/task/dslinterop/SingleChoiceTask.java
+++ b/dungeon/src/task/dslinterop/SingleChoiceTask.java
@@ -1,5 +1,7 @@
 package task.dslinterop;
 
+import core.Entity;
+
 import dsl.semanticanalysis.types.*;
 
 import task.Task;
@@ -27,10 +29,16 @@ public class SingleChoiceTask {
             @DSLTypeMember(name = "correct_answer_index") int correctAnswerIndex,
             @DSLTypeMember(name = "explanation") String explanation,
             @DSLTypeMember(name = "grading_function")
-                    BiFunction<Task, Set<TaskContent>, Float> gradingFunction) {
+                    BiFunction<Task, Set<TaskContent>, Float> gradingFunction,
+            @DSLTypeMember(name = "scenario_builder")
+                    Function<SingleChoice, Set<Set<Entity>>> scenarioBuilder) {
         SingleChoice sc = new SingleChoice(description);
         sc.taskName(name);
         sc.explanation(explanation);
+
+        if (scenarioBuilder != null) {
+            sc.scenarioBuilderFunction(scenarioBuilder);
+        }
 
         if (points > 0.0f && pointsToPass > 0.0f) {
             sc.points(points, pointsToPass);

--- a/dungeon/src/task/utils/hud/QuizUI.java
+++ b/dungeon/src/task/utils/hud/QuizUI.java
@@ -62,9 +62,7 @@ public class QuizUI {
                                     IVoidFunction showCorrectAnswer =
                                             () ->
                                                     OkDialog.showOkDialog(
-                                                            "'"
-                                                                    + task.correctAnswersAsString()
-                                                                    + "'",
+                                                            task.correctAnswersAsString(),
                                                             "Korrekte Antwort",
                                                             () -> {});
 

--- a/dungeon/src/task/utils/hud/YesNoDialog.java
+++ b/dungeon/src/task/utils/hud/YesNoDialog.java
@@ -163,9 +163,7 @@ public class YesNoDialog {
             IVoidFunction showCorrectAnswer =
                     () ->
                             OkDialog.showOkDialog(
-                                    "'" + t.correctAnswersAsString() + "'",
-                                    "Korrekte Antwort",
-                                    () -> {});
+                                    t.correctAnswersAsString(), "Korrekte Antwort", () -> {});
 
             OkDialog.showOkDialog(
                     output.toString(),

--- a/dungeon/test/dsl/interpreter/TestDSLInterpreter.java
+++ b/dungeon/test/dsl/interpreter/TestDSLInterpreter.java
@@ -28,6 +28,7 @@ import graph.taskdependencygraph.TaskEdge;
 import graph.taskdependencygraph.TaskNode;
 
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import task.*;
@@ -2908,7 +2909,8 @@ public class TestDSLInterpreter {
         single_choice_task t1 {
             description: "Task1",
             answers: ["1", "2", "3"],
-            correct_answer_index: 2
+            correct_answer_index: 2,
+            scenario_builder: build_scenario1
         }
 
         graph g {
@@ -2992,6 +2994,8 @@ public class TestDSLInterpreter {
     }
 
     @Test
+    // native scenario builders will make this test case obsolete
+    @Ignore
     public void testScenarioBuilderTypeCreation() {
         String program =
                 """
@@ -3134,7 +3138,8 @@ public class TestDSLInterpreter {
                 single_choice_task t {
                     description: "hello",
                     answers: [1,2,3],
-                    correct_answer_index: 1
+                    correct_answer_index: 1,
+                    scenario_builder: build_scenario
                 }
 
                 graph g {
@@ -3487,7 +3492,8 @@ public class TestDSLInterpreter {
         single_choice_task t1 {
             description: "Task1",
                 answers: ["1", "2", "3"],
-            correct_answer_index: 2
+            correct_answer_index: 2,
+            scenario_builder: build_scenario1
         }
 
         graph g {
@@ -3543,7 +3549,8 @@ public class TestDSLInterpreter {
             multiple_choice_task t1 {
                 description: "Task1",
                 answers: ["1", "2", "3"],
-                correct_answer_index: [1,2]
+                correct_answer_index: [1,2],
+                scenario_builder: build_scenario1
             }
 
             graph g {
@@ -3659,7 +3666,8 @@ public class TestDSLInterpreter {
         single_choice_task t1 {
             description: "Task1",
             answers: ["1", "2", "3"],
-            correct_answer_index: 2
+            correct_answer_index: 2,
+            scenario_builder: build_scenario1
         }
 
         graph g {
@@ -3943,7 +3951,8 @@ public class TestDSLInterpreter {
         single_choice_task t1 {
             description: "Task1",
             answers: ["1", "HELLO", "3"],
-            correct_answer_index: 2
+            correct_answer_index: 2,
+            scenario_builder: build_task
         }
 
         graph g {


### PR DESCRIPTION
Implementiert native Scenario Builder, also native Funktionen, die eine Aufgabe als Argument erhalten und ein Set von Entitäts-Sets zurück geben. Nutzt den gleichen Mechanismus wie die bisherigen ScenarioBuilder.

Durch die Änderungen sind einige Tests kaputt gegangen, die davon abhängig sind, dass ein bestimmter Scenario-Builder verwendet wird. Daher implementiert dieser PR auch das forcen eines Scenario builders für einen bestimmten Task.

Enthält kleinere Fixes (z.B. Überprüfung auf "empty" `FunctionValue` in TypeInstantiator).

Wird #1136 obsolet machen, da wir hier in diesem PR die bereits vorhandenen Mittel des `DSLInterpreter`s nutzen und keine neuen Strukturen bauen.