### PR TITLE
[GAME] fix `SkillTest #executeWhenCoolDownExpired ` and `ItemTest#testCollectNoInventory`

### DIFF
--- a/game/test/contrib/utils/components/item/ItemTest.java
+++ b/game/test/contrib/utils/components/item/ItemTest.java
@@ -35,8 +35,7 @@ public class ItemTest {
 
     @Before
     public void before() {
-        Game.removeAllEntities();
-
+        cleanup();
         Game.add(
                 new LevelSystem(
                         Mockito.mock(Painter.class),
@@ -87,8 +86,10 @@ public class ItemTest {
 
     @After
     public void cleanup() {
-        Game.removeAllSystems();
         Game.removeAllEntities();
+        Game.removeAllSystems();
+        Game.hero(null);
+        Game.currentLevel(null);
     }
 
     @Test

--- a/game/test/contrib/utils/components/skill/SkillTest.java
+++ b/game/test/contrib/utils/components/skill/SkillTest.java
@@ -9,7 +9,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
 public class SkillTest {
@@ -49,12 +48,13 @@ public class SkillTest {
     }
 
     @Test
-    public void executeWhenCoolDownExpired() {
-        final long baseCoolDown = TimeUnit.MILLISECONDS.toSeconds(1);
+    public void executeWhenCoolDownExpired() throws InterruptedException {
+        final long baseCoolDown = 100;
         skill = new Skill(skillFunction, baseCoolDown);
 
         skill.execute(entity);
         assertEquals("Skill should have been executed once", 1, value);
+        Thread.sleep(baseCoolDown);
         assertTrue("Skill should be usable again", skill.canBeUsedAgain());
 
         skill.execute(entity);


### PR DESCRIPTION
fixes #1220, fixes #1219


zu #1220 
- Der Test hatte eine Zeitabhängigkeit und scheinbar war 1ms cooldown teilweise zu viel, daher hab ich jetzt einen Thread-Sleep eingebaut

zu #1219 
Ich konnte den Fehler nicht ganz reproduzieren, aber es sieht stark danach aus, als ob die Testenv. vorher nicht korrekt aufgeräumt wurde.