### PR TITLE
[GAME] fix  `ItemTest#testCollectNoInventory`

### DIFF
--- a/game/src/contrib/utils/components/skill/Skill.java
+++ b/game/src/contrib/utils/components/skill/Skill.java
@@ -2,6 +2,7 @@ package contrib.utils.components.skill;
 
 import core.Entity;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.util.function.Consumer;
 
@@ -57,7 +58,7 @@ public class Skill {
      * @return true if the specified time (coolDownInSeconds) has passed
      */
     public boolean canBeUsedAgain() {
-        return Instant.now().isAfter(nextUsableAt) || Instant.now().equals(nextUsableAt);
+        return Duration.between(Instant.now(), nextUsableAt).toMillis() <= 0;
     }
 
     /**

--- a/game/src/contrib/utils/components/skill/Skill.java
+++ b/game/src/contrib/utils/components/skill/Skill.java
@@ -58,7 +58,9 @@ public class Skill {
      * @return true if the specified time (coolDownInSeconds) has passed
      */
     public boolean canBeUsedAgain() {
-        return Duration.between(Instant.now(), nextUsableAt).toMillis() <= 0;
+        // check if the cooldown is active, return the negated result (this avoids some problems in
+        // nano-sec range)
+        return !(Duration.between(Instant.now(), nextUsableAt).toMillis() > 0);
     }
 
     /**

--- a/game/test/contrib/utils/components/item/ItemTest.java
+++ b/game/test/contrib/utils/components/item/ItemTest.java
@@ -10,6 +10,7 @@ import core.Entity;
 import core.Game;
 import core.components.DrawComponent;
 import core.components.PositionComponent;
+import core.level.Tile;
 import core.level.TileLevel;
 import core.level.generator.IGenerator;
 import core.level.utils.DesignLabel;
@@ -22,10 +23,10 @@ import core.utils.components.draw.Painter;
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 
 public class ItemTest {
@@ -36,14 +37,13 @@ public class ItemTest {
 
     @Before
     public void before() {
-        cleanup();
         Game.add(
                 new LevelSystem(
                         Mockito.mock(Painter.class),
                         Mockito.mock(IGenerator.class),
                         Mockito.mock(IVoidFunction.class)));
 
-        Game.currentLevel(
+        TileLevel level =
                 new TileLevel(
                         new LevelElement[][] {
                             new LevelElement[] {
@@ -82,7 +82,12 @@ public class ItemTest {
                                 LevelElement.FLOOR
                             }
                         },
-                        DesignLabel.DEFAULT));
+                        DesignLabel.DEFAULT);
+
+        for (Tile t : new ArrayList<>(level.exitTiles())) {
+            level.changeTileElementType(t, LevelElement.FLOOR);
+        }
+        Game.currentLevel(level);
     }
 
     @After
@@ -203,7 +208,6 @@ public class ItemTest {
 
     /** Tests if item is present in inventory and removed from Game world after collect */
     @Test
-    @Ignore
     public void testCollect() {
         assertEquals("There should be no entity in the game", 0, Game.entityStream().count());
 
@@ -227,7 +231,6 @@ public class ItemTest {
 
     /** Tests if item can be collected from entity with no InventoryComponent. */
     @Test
-    @Ignore
     public void testCollectNoInventory() {
         assertEquals("There should be no entity in the game", 0, Game.entityStream().count());
 

--- a/game/test/contrib/utils/components/skill/SkillTest.java
+++ b/game/test/contrib/utils/components/skill/SkillTest.java
@@ -7,7 +7,6 @@ import core.Game;
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.function.Consumer;

--- a/game/test/contrib/utils/components/skill/SkillTest.java
+++ b/game/test/contrib/utils/components/skill/SkillTest.java
@@ -7,6 +7,7 @@ import core.Game;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.function.Consumer;
@@ -48,6 +49,7 @@ public class SkillTest {
     }
 
     @Test
+    @Ignore
     public void executeWhenCoolDownExpired() throws InterruptedException {
         final long baseCoolDown = 1;
         skill = new Skill(skillFunction, baseCoolDown);

--- a/game/test/contrib/utils/components/skill/SkillTest.java
+++ b/game/test/contrib/utils/components/skill/SkillTest.java
@@ -49,12 +49,12 @@ public class SkillTest {
     }
 
     @Test
-    @Ignore
     public void executeWhenCoolDownExpired() throws InterruptedException {
         final long baseCoolDown = 1;
         skill = new Skill(skillFunction, baseCoolDown);
         skill.execute(entity);
         assertEquals("Skill should have been executed once", 1, value);
+        Thread.sleep(5);
         assertTrue("Skill should be usable again", skill.canBeUsedAgain());
         skill.execute(entity);
         assertEquals("Skill should have been executed twice", 2, value);

--- a/game/test/contrib/utils/components/skill/SkillTest.java
+++ b/game/test/contrib/utils/components/skill/SkillTest.java
@@ -7,7 +7,6 @@ import core.Game;
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.function.Consumer;
@@ -49,15 +48,12 @@ public class SkillTest {
     }
 
     @Test
-    @Ignore
     public void executeWhenCoolDownExpired() throws InterruptedException {
-        final long baseCoolDown = 100;
+        final long baseCoolDown = 1;
         skill = new Skill(skillFunction, baseCoolDown);
         skill.execute(entity);
         assertEquals("Skill should have been executed once", 1, value);
-        Thread.sleep(baseCoolDown);
         assertTrue("Skill should be usable again", skill.canBeUsedAgain());
-
         skill.execute(entity);
         assertEquals("Skill should have been executed twice", 2, value);
     }


### PR DESCRIPTION
fixes https://github.com/Programmiermethoden/Dungeon/issues/1219,
fixes #1220


Zu #1219
Wenn ein Level erzeugt wird, welches keinen Ausgang hat, wird automatisch einer platziert. Im Test konnte es daher zufällig passieren, dass der Punkt 0,0 der Ausgang ist und damit ein Item nicht darauf gedroppt wurde.
