### PR TITLE
[GAME] cleanup `PositionComponent` 

### DIFF
--- a/game/src/core/components/PositionComponent.java
+++ b/game/src/core/components/PositionComponent.java
@@ -22,8 +22,7 @@ import java.util.logging.Logger;
 @DSLType(name = "position_component")
 public final class PositionComponent implements Component {
 
-    public static final Point ILLEGAL_POSITION = new Point(-100, -100);
-    private final Logger LOGGER = Logger.getLogger(this.getClass().getName());
+    public static final Point ILLEGAL_POSITION = new Point(Integer.MIN_VALUE, Integer.MIN_VALUE);
     private Point position;
 
     /**

--- a/game/src/core/components/PositionComponent.java
+++ b/game/src/core/components/PositionComponent.java
@@ -6,17 +6,24 @@ import core.utils.Point;
 
 import dsl.semanticanalysis.typesystem.typebuilding.annotation.DSLType;
 
-import java.util.logging.Logger;
-
 /**
  * Store the position of the associated entity in the level.
  *
- * <p>Various systems access the position of an entity through this component, e.g. the {@link
- * core.systems.DrawSystem} uses the position to draw an entity in the right place and the {@link
+ * <p>Various systems access the position of an entity through this component, e.g., the {@link
+ * core.systems.DrawSystem} uses the position to draw an entity in the right place, and the {@link
  * core.systems.VelocitySystem} updates the position values based on the velocity and the previous
- * position of an entity. See <a
- * href="https://github.com/Programmiermethoden/Dungeon/tree/master/doc/ecs/systems">System-Overview</a>.
+ * position of an entity.
  *
+ * <p>If the position is the {@link #ILLEGAL_POSITION}, the {@link core.systems.PositionSystem} will
+ * change the position to a random position of an accessible tile in the current level.
+ *
+ * <p>Use {@link #position(Tile)} to set the position to the position of the given tile.
+ *
+ * <p>Use {@link #position(Point)} to set the position to the given position.
+ *
+ * <p>Use {@link #position()} to get a copy of the position.
+ *
+ * @see core.systems.PositionSystem
  * @see Point
  */
 @DSLType(name = "position_component")
@@ -28,9 +35,9 @@ public final class PositionComponent implements Component {
     /**
      * Create a new PositionComponent with given position.
      *
-     * <p>Sets the position of this entity to the given point.
+     * <p>Sets the position to the given point.
      *
-     * @param position The position of the entity in the level.
+     * @param position The position in the level.
      */
     public PositionComponent(final Point position) {
         this.position = position;
@@ -39,10 +46,10 @@ public final class PositionComponent implements Component {
     /**
      * Create a new PositionComponent.
      *
-     * <p>Sets the position of this entity to a point with the given x and y positions.
+     * <p>Sets the position to a point with the given x and y positions.
      *
-     * @param x x-position of the entity
-     * @param y y-position of the entity
+     * @param x x-position
+     * @param y y-position
      */
     public PositionComponent(float x, float y) {
         this(new Point(x, y));
@@ -60,27 +67,27 @@ public final class PositionComponent implements Component {
     }
 
     /**
-     * Get the position of the associated entity.
+     * Get the position.
      *
-     * @return The position of the associated entity.
+     * @return The position.
      */
     public Point position() {
         return new Point(position);
     }
 
     /**
-     * Set the position of the associated entity
+     * Set the position.
      *
-     * @param position new Position of the associated entity
+     * @param position new Position
      */
     public void position(final Point position) {
         this.position = new Point(position);
     }
 
     /**
-     * Set the position of the associated entity.
+     * Set the position
      *
-     * @param tile The tile where the new position of the associated entity is located.
+     * @param tile The tile where the new position is located.
      * @see Tile
      */
     public void position(final Tile tile) {

--- a/game/src/core/components/PositionComponent.java
+++ b/game/src/core/components/PositionComponent.java
@@ -66,7 +66,7 @@ public final class PositionComponent implements Component {
      * @return The position of the associated entity.
      */
     public Point position() {
-        return position;
+        return new Point(position);
     }
 
     /**
@@ -75,7 +75,7 @@ public final class PositionComponent implements Component {
      * @param position new Position of the associated entity
      */
     public void position(final Point position) {
-        this.position = position;
+        this.position = new Point(position);
     }
 
     /**

--- a/game/test/contrib/entities/ChestTest.java
+++ b/game/test/contrib/entities/ChestTest.java
@@ -53,10 +53,10 @@ public class ChestTest {
         assertTrue(
                 "Needs the PositionComponent to be somewhere in the Level",
                 positionComponent.isPresent());
-        assertEquals(
+        assertTrue(
                 "Position should be equal to the given Position",
-                position,
-                positionComponent.map(PositionComponent.class::cast).get().position());
+                position.equals(
+                        positionComponent.map(PositionComponent.class::cast).get().position()));
     }
 
     /**

--- a/game/test/core/components/PositionComponentTest.java
+++ b/game/test/core/components/PositionComponentTest.java
@@ -1,6 +1,6 @@
 package core.components;
 
-import static org.junit.Assert.assertEquals;
+import static junit.framework.TestCase.assertTrue;
 
 import core.utils.Point;
 
@@ -19,9 +19,9 @@ public class PositionComponentTest {
 
     @Test
     public void setPosition() {
-        assertEquals(position, positionComponent.position());
+        assertTrue(position.equals(positionComponent.position()));
         Point newPoint = new Point(3, 4);
         positionComponent.position(newPoint);
-        assertEquals(newPoint, positionComponent.position());
+        assertTrue(newPoint.equals(positionComponent.position()));
     }
 }

--- a/game/test/core/level/TileLevelAPITest.java
+++ b/game/test/core/level/TileLevelAPITest.java
@@ -207,7 +207,7 @@ public class TileLevelAPITest {
         Tile end = Mockito.mock(Tile.class);
         Point p = new Point(3, 3);
         when(end.position()).thenReturn(p);
-        when(level.tileAt(p)).thenReturn(end);
+        when(level.tileAt((Point) any())).thenReturn(end);
         Mockito.when(level.endTile()).thenReturn(end);
 
         hero.fetch(PositionComponent.class).get().position(end);


### PR DESCRIPTION
setzt #1025 für die Klasse `PositionComponent` um.


Nennenswerte Änderung: 
`position()` gibt nun eine Kopie des Punktes. zurück, wodurch eine direkte veränderung der Werte nicht mehr mögliich ist, man muss jetzt immer den setter verwenden. 