### PR TITLE
[Game] refactor animationclass only using factory methods instead of mix

### DIFF
--- a/dungeon/src/dslinterop/dsltypeadapters/QuestItemAdapter.java
+++ b/dungeon/src/dslinterop/dsltypeadapters/QuestItemAdapter.java
@@ -2,6 +2,7 @@ package dslinterop.dsltypeadapters;
 
 import core.utils.components.draw.Animation;
 import core.utils.components.draw.CoreAnimationPriorities;
+import core.utils.components.draw.SimpleIPath;
 
 import dsl.semanticanalysis.typesystem.typebuilding.annotation.DSLTypeAdapter;
 import dsl.semanticanalysis.typesystem.typebuilding.annotation.DSLTypeMember;
@@ -26,7 +27,8 @@ public class QuestItemAdapter {
             @DSLTypeMember(name = "description") String description,
             @DSLTypeMember(name = "texture_path") String texturePath) {
         Animation animation =
-                new Animation(texturePath, CoreAnimationPriorities.DEFAULT.priority());
+                Animation.fromSingleImage(
+                        new SimpleIPath(texturePath), CoreAnimationPriorities.DEFAULT.priority());
         TaskContentComponent tcc = new TaskContentComponent();
         return new QuestItem(animation, tcc);
     }

--- a/dungeon/src/dslinterop/nativescenariobuilder/NativeScenarioBuilder.java
+++ b/dungeon/src/dslinterop/nativescenariobuilder/NativeScenarioBuilder.java
@@ -16,6 +16,7 @@ import core.components.DrawComponent;
 import core.components.PositionComponent;
 import core.utils.components.draw.Animation;
 import core.utils.components.draw.CoreAnimationPriorities;
+import core.utils.components.draw.SimpleIPath;
 
 import task.Task;
 import task.TaskContent;
@@ -87,8 +88,8 @@ public class NativeScenarioBuilder {
             for (var element : entry.getValue()) {
                 if (!element.equals(AssignTask.EMPTY_ELEMENT)) {
                     Animation animation =
-                            new Animation(
-                                    "items/book/wisdom_scroll.png",
+                            Animation.fromSingleImage(
+                                    new SimpleIPath("items/book/wisdom_scroll.png"),
                                     CoreAnimationPriorities.DEFAULT.priority());
                     TaskContentComponent tcc = new TaskContentComponent(element);
                     QuestItem questItem = new QuestItem(animation, tcc);

--- a/dungeon/test/dsl/interpreter/TestDSLInterpreter.java
+++ b/dungeon/test/dsl/interpreter/TestDSLInterpreter.java
@@ -2985,10 +2985,10 @@ public class TestDSLInterpreter {
         var entityInSecondRoom = secondRoomSet.iterator().next();
 
         DrawComponent drawComp1 = entityInFirstRoom.fetch(DrawComponent.class).get();
-        var frameDrawComp1 = drawComp1.currentAnimation().getAnimationFrames().get(0);
+        var frameDrawComp1 = drawComp1.currentAnimation().getAnimationFrames().get(0).pathString();
 
         DrawComponent drawComp2 = entityInSecondRoom.fetch(DrawComponent.class).get();
-        var frameDrawComp2 = drawComp2.currentAnimation().getAnimationFrames().get(0);
+        var frameDrawComp2 = drawComp2.currentAnimation().getAnimationFrames().get(0).pathString();
 
         int firstEntitiesId = entityInFirstRoom.id();
         int secondEntitiesId = entityInSecondRoom.id();

--- a/game/src/contrib/hud/crafting/CraftingGUI.java
+++ b/game/src/contrib/hud/crafting/CraftingGUI.java
@@ -21,6 +21,7 @@ import contrib.item.Item;
 
 import core.Game;
 import core.utils.components.draw.Animation;
+import core.utils.components.draw.SimpleIPath;
 import core.utils.components.draw.TextureMap;
 
 import java.util.ArrayList;
@@ -103,7 +104,7 @@ public class CraftingGUI extends CombinableGUI {
     private static final BitmapFont bitmapFont;
 
     static {
-        backgroundAnimation = Animation.fromSingleImage(BACKGROUND_TEXTURE_PATH);
+        backgroundAnimation = Animation.fromSingleImage(new SimpleIPath(BACKGROUND_TEXTURE_PATH));
 
         Pixmap pixmap = new Pixmap(1, 1, Pixmap.Format.RGBA8888);
         pixmap.drawPixel(0, 0, NUMBER_BACKGROUND_COLOR);
@@ -131,10 +132,20 @@ public class CraftingGUI extends CombinableGUI {
         this.targetInventory = targetInventory;
         this.buttonOk =
                 new ImageButton(
-                        this, Animation.fromSingleImage(BUTTON_OK_TEXTURE_PATH), 0, 0, 1, 1);
+                        this,
+                        Animation.fromSingleImage(new SimpleIPath(BUTTON_OK_TEXTURE_PATH)),
+                        0,
+                        0,
+                        1,
+                        1);
         this.buttonCancel =
                 new ImageButton(
-                        this, Animation.fromSingleImage(BUTTON_CANCEL_TEXTURE_PATH), 0, 0, 1, 1);
+                        this,
+                        Animation.fromSingleImage(new SimpleIPath(BUTTON_CANCEL_TEXTURE_PATH)),
+                        0,
+                        0,
+                        1,
+                        1);
         this.buttonOk.onClick((button) -> this.craft());
         this.buttonCancel.onClick((button) -> this.cancel());
     }

--- a/game/src/contrib/hud/crafting/CraftingGUI.java
+++ b/game/src/contrib/hud/crafting/CraftingGUI.java
@@ -103,7 +103,7 @@ public class CraftingGUI extends CombinableGUI {
     private static final BitmapFont bitmapFont;
 
     static {
-        backgroundAnimation = Animation.of(BACKGROUND_TEXTURE_PATH);
+        backgroundAnimation = Animation.fromSingleImage(BACKGROUND_TEXTURE_PATH);
 
         Pixmap pixmap = new Pixmap(1, 1, Pixmap.Format.RGBA8888);
         pixmap.drawPixel(0, 0, NUMBER_BACKGROUND_COLOR);
@@ -129,9 +129,12 @@ public class CraftingGUI extends CombinableGUI {
      */
     public CraftingGUI(InventoryComponent targetInventory) {
         this.targetInventory = targetInventory;
-        this.buttonOk = new ImageButton(this, Animation.of(BUTTON_OK_TEXTURE_PATH), 0, 0, 1, 1);
+        this.buttonOk =
+                new ImageButton(
+                        this, Animation.fromSingleImage(BUTTON_OK_TEXTURE_PATH), 0, 0, 1, 1);
         this.buttonCancel =
-                new ImageButton(this, Animation.of(BUTTON_CANCEL_TEXTURE_PATH), 0, 0, 1, 1);
+                new ImageButton(
+                        this, Animation.fromSingleImage(BUTTON_CANCEL_TEXTURE_PATH), 0, 0, 1, 1);
         this.buttonOk.onClick((button) -> this.craft());
         this.buttonCancel.onClick((button) -> this.cancel());
     }

--- a/game/src/contrib/item/Item.java
+++ b/game/src/contrib/item/Item.java
@@ -35,9 +35,6 @@ import java.util.logging.Logger;
  * #stackSize()} and {@link #maxStackSize()} methods.
  */
 public class Item implements CraftingIngredient, CraftingResult {
-
-    protected static final Animation DEFAULT_ANIMATION =
-            Animation.of("animation/missing_texture.png");
     private static final Logger LOGGER = Logger.getLogger(Item.class.getName());
 
     /**

--- a/game/src/contrib/item/Item.java
+++ b/game/src/contrib/item/Item.java
@@ -38,10 +38,10 @@ public class Item implements CraftingIngredient, CraftingResult {
     private static final Logger LOGGER = Logger.getLogger(Item.class.getName());
 
     /**
-     * Maps identifiers in crafting recipes (e.g. {@link ItemResourceBerry}) to their corresponding class
-     * objects (e.g. ItemResourceBerry.java). This map is used to associate identifiers in crafting
-     * recipes with the actual classes and create an instance of the respective item when the recipe
-     * is crafted.
+     * Maps identifiers in crafting recipes (e.g. {@link ItemResourceBerry}) to their corresponding
+     * class objects (e.g. ItemResourceBerry.java). This map is used to associate identifiers in
+     * crafting recipes with the actual classes and create an instance of the respective item when
+     * the recipe is crafted.
      *
      * <p>The keys in the map are the simple names of the classes (e.g. "ItemBookRed"), and the
      * values are the corresponding class objects.

--- a/game/src/contrib/item/Item.java
+++ b/game/src/contrib/item/Item.java
@@ -38,8 +38,8 @@ public class Item implements CraftingIngredient, CraftingResult {
     private static final Logger LOGGER = Logger.getLogger(Item.class.getName());
 
     /**
-     * Maps identifiers in crafting recipes (e.g. {@link ItemBookRed}) to their corresponding class
-     * objects (e.g. ItemBookRed.java). This map is used to associate identifiers in crafting
+     * Maps identifiers in crafting recipes (e.g. {@link ItemResourceBerry}) to their corresponding class
+     * objects (e.g. ItemResourceBerry.java). This map is used to associate identifiers in crafting
      * recipes with the actual classes and create an instance of the respective item when the recipe
      * is crafted.
      *

--- a/game/src/contrib/item/concreteItem/ItemPotionHealth.java
+++ b/game/src/contrib/item/concreteItem/ItemPotionHealth.java
@@ -8,6 +8,7 @@ import contrib.utils.components.health.DamageType;
 
 import core.Entity;
 import core.utils.components.draw.Animation;
+import core.utils.components.draw.SimpleIPath;
 
 public class ItemPotionHealth extends Item {
 
@@ -17,7 +18,7 @@ public class ItemPotionHealth extends Item {
         super(
                 "Health Potion",
                 "A health potion. It heals you for " + HEAL_AMOUNT + " health points.",
-                Animation.fromSingleImage("items/potion/health_potion.png"));
+                Animation.fromSingleImage(new SimpleIPath("items/potion/health_potion.png")));
     }
 
     @Override

--- a/game/src/contrib/item/concreteItem/ItemPotionHealth.java
+++ b/game/src/contrib/item/concreteItem/ItemPotionHealth.java
@@ -17,7 +17,7 @@ public class ItemPotionHealth extends Item {
         super(
                 "Health Potion",
                 "A health potion. It heals you for " + HEAL_AMOUNT + " health points.",
-                Animation.of("items/potion/health_potion.png"));
+                Animation.fromSingleImage("items/potion/health_potion.png"));
     }
 
     @Override

--- a/game/src/contrib/item/concreteItem/ItemPotionWater.java
+++ b/game/src/contrib/item/concreteItem/ItemPotionWater.java
@@ -8,6 +8,7 @@ import contrib.utils.components.health.DamageType;
 
 import core.Entity;
 import core.utils.components.draw.Animation;
+import core.utils.components.draw.SimpleIPath;
 
 public class ItemPotionWater extends Item {
 
@@ -19,7 +20,7 @@ public class ItemPotionWater extends Item {
                 "A bottle of water. It's not very useful except for hydration. It heals you for "
                         + HEAL_AMOUNT
                         + " health points.",
-                Animation.fromSingleImage("items/potion/water_bottle.png"));
+                Animation.fromSingleImage(new SimpleIPath("items/potion/water_bottle.png")));
     }
 
     @Override

--- a/game/src/contrib/item/concreteItem/ItemPotionWater.java
+++ b/game/src/contrib/item/concreteItem/ItemPotionWater.java
@@ -19,7 +19,7 @@ public class ItemPotionWater extends Item {
                 "A bottle of water. It's not very useful except for hydration. It heals you for "
                         + HEAL_AMOUNT
                         + " health points.",
-                Animation.of("items/potion/water_bottle.png"));
+                Animation.fromSingleImage("items/potion/water_bottle.png"));
     }
 
     @Override

--- a/game/src/contrib/item/concreteItem/ItemResourceBerry.java
+++ b/game/src/contrib/item/concreteItem/ItemResourceBerry.java
@@ -8,13 +8,17 @@ import contrib.utils.components.health.DamageType;
 
 import core.Entity;
 import core.utils.components.draw.Animation;
+import core.utils.components.draw.SimpleIPath;
 
 public class ItemResourceBerry extends Item {
 
     private static final int HEAL_AMOUNT = 5;
 
     public ItemResourceBerry() {
-        super("Berry", "A berry.", Animation.fromSingleImage("items/resource/berry.png"));
+        super(
+                "Berry",
+                "A berry.",
+                Animation.fromSingleImage(new SimpleIPath("items/resource/berry.png")));
     }
 
     @Override

--- a/game/src/contrib/item/concreteItem/ItemResourceBerry.java
+++ b/game/src/contrib/item/concreteItem/ItemResourceBerry.java
@@ -14,7 +14,7 @@ public class ItemResourceBerry extends Item {
     private static final int HEAL_AMOUNT = 5;
 
     public ItemResourceBerry() {
-        super("Berry", "A berry.", Animation.of("items/resource/berry.png"));
+        super("Berry", "A berry.", Animation.fromSingleImage("items/resource/berry.png"));
     }
 
     @Override

--- a/game/src/contrib/item/concreteItem/ItemResourceEgg.java
+++ b/game/src/contrib/item/concreteItem/ItemResourceEgg.java
@@ -17,7 +17,7 @@ public class ItemResourceEgg extends Item {
         super(
                 "Egg",
                 "An egg. What was there before? The chicken or the egg?",
-                Animation.of("items/resource/egg.png"));
+                Animation.fromSingleImage("items/resource/egg.png"));
     }
 
     @Override

--- a/game/src/contrib/item/concreteItem/ItemResourceEgg.java
+++ b/game/src/contrib/item/concreteItem/ItemResourceEgg.java
@@ -8,6 +8,7 @@ import core.Entity;
 import core.Game;
 import core.components.PositionComponent;
 import core.utils.components.draw.Animation;
+import core.utils.components.draw.SimpleIPath;
 
 import java.io.IOException;
 
@@ -17,7 +18,7 @@ public class ItemResourceEgg extends Item {
         super(
                 "Egg",
                 "An egg. What was there before? The chicken or the egg?",
-                Animation.fromSingleImage("items/resource/egg.png"));
+                Animation.fromSingleImage(new SimpleIPath("items/resource/egg.png")));
     }
 
     @Override

--- a/game/src/contrib/item/concreteItem/ItemResourceMushroomRed.java
+++ b/game/src/contrib/item/concreteItem/ItemResourceMushroomRed.java
@@ -8,6 +8,7 @@ import contrib.utils.components.health.DamageType;
 
 import core.Entity;
 import core.utils.components.draw.Animation;
+import core.utils.components.draw.SimpleIPath;
 
 public class ItemResourceMushroomRed extends Item {
 
@@ -17,7 +18,7 @@ public class ItemResourceMushroomRed extends Item {
         super(
                 "Red Mushroom",
                 "A red mushroom.",
-                Animation.fromSingleImage("items/resource/mushroom_red.png"));
+                Animation.fromSingleImage(new SimpleIPath("items/resource/mushroom_red.png")));
     }
 
     @Override

--- a/game/src/contrib/item/concreteItem/ItemResourceMushroomRed.java
+++ b/game/src/contrib/item/concreteItem/ItemResourceMushroomRed.java
@@ -14,7 +14,10 @@ public class ItemResourceMushroomRed extends Item {
     private static final int DAMAGE_AMOUNT = 20;
 
     public ItemResourceMushroomRed() {
-        super("Red Mushroom", "A red mushroom.", Animation.of("items/resource/mushroom_red.png"));
+        super(
+                "Red Mushroom",
+                "A red mushroom.",
+                Animation.fromSingleImage("items/resource/mushroom_red.png"));
     }
 
     @Override

--- a/game/src/core/components/DrawComponent.java
+++ b/game/src/core/components/DrawComponent.java
@@ -6,6 +6,7 @@ import core.systems.VelocitySystem;
 import core.utils.components.draw.Animation;
 import core.utils.components.draw.CoreAnimations;
 import core.utils.components.draw.IPath;
+import core.utils.components.draw.SimpleIPath;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -316,7 +317,7 @@ public final class DrawComponent implements Component {
         // Ultimately, we will create animations out of this by using the
         // Animation(LinkedList<String>) constructor.
 
-        HashMap<String, List<String>> storage = new HashMap<>();
+        HashMap<String, List<IPath>> storage = new HashMap<>();
         animationMap = new HashMap<>();
 
         // Iterate over each file and directory in the JAR.
@@ -356,10 +357,11 @@ public final class DrawComponent implements Component {
                     String lastDir = fileName.substring(secondLastSlashIndex + 1, lastSlashIndex);
 
                     // add animation-files to new or existing storage map
-                    if (storage.containsKey(lastDir)) storage.get(lastDir).add(fileName);
+                    if (storage.containsKey(lastDir))
+                        storage.get(lastDir).add(new SimpleIPath(fileName));
                     else {
-                        LinkedList<String> list = new LinkedList<>();
-                        list.add(fileName);
+                        LinkedList<IPath> list = new LinkedList<>();
+                        list.add(new SimpleIPath(fileName));
                         storage.put(lastDir, list);
                     }
                 }
@@ -368,9 +370,10 @@ public final class DrawComponent implements Component {
 
         // sort the files in lexicographic order (like the most os)
         // animations will be played in order
-        storage.values().forEach(Collections::sort);
+        storage.values().forEach(x -> x.sort(Comparator.comparing(IPath::pathString)));
         // create animations
-        storage.forEach((name, textureSet) -> animationMap.put(name, new Animation(textureSet)));
+        storage.forEach(
+                (name, textureSet) -> animationMap.put(name, Animation.fromCollection(textureSet)));
         jar.close();
     }
 

--- a/game/src/core/components/DrawComponent.java
+++ b/game/src/core/components/DrawComponent.java
@@ -382,7 +382,9 @@ public final class DrawComponent implements Component {
                 animationMap =
                         Arrays.stream(Objects.requireNonNull(apps.listFiles()))
                                 .filter(File::isDirectory)
-                                .collect(Collectors.toMap(File::getName, Animation::of));
+                                .collect(
+                                        Collectors.toMap(
+                                                File::getName, Animation::fromSubDir));
             } catch (URISyntaxException ignored) {
             }
         }

--- a/game/src/core/components/DrawComponent.java
+++ b/game/src/core/components/DrawComponent.java
@@ -382,9 +382,7 @@ public final class DrawComponent implements Component {
                 animationMap =
                         Arrays.stream(Objects.requireNonNull(apps.listFiles()))
                                 .filter(File::isDirectory)
-                                .collect(
-                                        Collectors.toMap(
-                                                File::getName, Animation::fromSubDir));
+                                .collect(Collectors.toMap(File::getName, Animation::fromSubDir));
             } catch (URISyntaxException ignored) {
             }
         }

--- a/game/src/core/utils/components/draw/Animation.java
+++ b/game/src/core/utils/components/draw/Animation.java
@@ -26,13 +26,13 @@ import java.util.stream.Collectors;
  */
 public final class Animation {
 
-    private static final String MISSING_TEXTURE = "animation/missing_texture.png";
+    private static final IPath MISSING_TEXTURE = new SimpleIPath("animation/missing_texture.png");
     private static final int DEFAULT_FRAME_TIME = 5;
     private static final boolean DEFAULT_IS_LOOP = true;
     private static final int DEFAULT_PRIO = 200;
 
     /** The set of textures that build the animation. */
-    private final List<String> animationFrames;
+    private final List<IPath> animationFrames;
 
     /** The count of textures for the animation. */
     private final int frames;
@@ -58,9 +58,8 @@ public final class Animation {
      * @param looping should the Animation continue to repeat ?
      * @param prio priority for playing this animation
      */
-    public Animation(Collection<String> animationFrames, int frameTime, boolean looping, int prio) {
+    private Animation(Collection<IPath> animationFrames, int frameTime, boolean looping, int prio) {
         assert (animationFrames != null && !animationFrames.isEmpty());
-        assert (frameTime > 0);
         this.animationFrames = new ArrayList<>(animationFrames);
         frames = animationFrames.size();
         this.timeBetweenFrames = frameTime;
@@ -75,8 +74,9 @@ public final class Animation {
      * @param frameTime How many frames to wait, before switching to the next texture?
      * @param prio priority for playing this animation
      */
-    public Animation(Collection<String> animationFrames, int frameTime, int prio) {
-        this(animationFrames, frameTime, DEFAULT_IS_LOOP, prio);
+    public static Animation fromCollection(
+            Collection<IPath> animationFrames, int frameTime, int prio) {
+        return new Animation(animationFrames, frameTime, DEFAULT_IS_LOOP, prio);
     }
 
     /**
@@ -84,8 +84,8 @@ public final class Animation {
      *
      * @param animationFrames The list of textures that builds the animation. Must be in order.
      */
-    public Animation(Collection<String> animationFrames) {
-        this(
+    public static Animation fromCollection(Collection<IPath> animationFrames) {
+        return new Animation(
                 animationFrames,
                 DEFAULT_FRAME_TIME,
                 DEFAULT_IS_LOOP,
@@ -93,13 +93,16 @@ public final class Animation {
     }
 
     /**
-     * Creates an animation containing only one frame. repeats forever
+     * Creates an animation.
      *
-     * @param animationFrame The texture that builds the animation.
+     * @param animationFrames The list of textures that builds the animation. Must be in order.
+     * @param frameTime How many frames to wait, before switching to the next texture?
+     * @param looping should the Animation continue to repeat ?
      * @param prio priority for playing this animation
      */
-    public Animation(String animationFrame, int prio) {
-        this(Set.of(animationFrame), Animation.DEFAULT_FRAME_TIME, DEFAULT_IS_LOOP, prio);
+    public static Animation fromCollection(
+            Collection<IPath> animationFrames, int frameTime, boolean looping, int prio) {
+        return new Animation(animationFrames, frameTime, looping, prio);
     }
 
     /**
@@ -115,17 +118,15 @@ public final class Animation {
      * @return The created Animation instance
      */
     public static Animation fromSubDir(File subDir, int frameTime, boolean loop, int prio) {
-        List<String> fileNames =
+        List<IPath> fileNames =
                 Arrays.stream(Objects.requireNonNull(subDir.listFiles()))
                         .filter(File::isFile)
-                        .map(File::getPath)
+                        .map(file -> new SimpleIPath(file.getPath()))
                         // sort the files in lexicographic order (like the most os) so animations
                         // will be played in order
-                        .sorted()
+                        .sorted(Comparator.comparing(SimpleIPath::pathString))
                         .collect(Collectors.toList());
-        Animation animation = new Animation(fileNames, frameTime, prio);
-        animation.setLoop(loop);
-        return animation;
+        return new Animation(fileNames, frameTime, loop, prio);
     }
 
     /**
@@ -148,8 +149,7 @@ public final class Animation {
      * @return The created Animation instance
      */
     public static Animation fromSingleImage(IPath fileName) {
-        return new Animation(
-                List.of(fileName.pathString()), DEFAULT_FRAME_TIME, DEFAULT_IS_LOOP, DEFAULT_PRIO);
+        return new Animation(List.of(fileName), DEFAULT_FRAME_TIME, DEFAULT_IS_LOOP, DEFAULT_PRIO);
     }
 
     /**
@@ -160,8 +160,7 @@ public final class Animation {
      * @return The created Animation instance
      */
     public static Animation fromSingleImage(IPath fileName, int frameTime) {
-        return new Animation(
-                List.of(fileName.pathString()), frameTime, DEFAULT_IS_LOOP, DEFAULT_PRIO);
+        return new Animation(List.of(fileName), frameTime, DEFAULT_IS_LOOP, DEFAULT_PRIO);
     }
 
     /**
@@ -181,9 +180,9 @@ public final class Animation {
      */
     public String nextAnimationTexturePath() {
         if (isFinished()) {
-            return animationFrames.get(currentFrameIndex);
+            return animationFrames.get(currentFrameIndex).pathString();
         }
-        String stringToReturn = animationFrames.get(currentFrameIndex);
+        String stringToReturn = animationFrames.get(currentFrameIndex).pathString();
         frameTimeCounter = (frameTimeCounter + 1) % timeBetweenFrames;
         if (frameTimeCounter == 0) {
             currentFrameIndex = (currentFrameIndex + 1) % frames;
@@ -210,7 +209,7 @@ public final class Animation {
      *
      * @return List containing the paths of the single frames of the animation.
      */
-    public List<String> getAnimationFrames() {
+    public List<IPath> getAnimationFrames() {
         return animationFrames;
     }
 

--- a/game/src/core/utils/components/draw/Animation.java
+++ b/game/src/core/utils/components/draw/Animation.java
@@ -147,8 +147,9 @@ public final class Animation {
      * @param fileName path to the frame
      * @return The created Animation instance
      */
-    public static Animation fromSingleImage(String fileName) {
-        return new Animation(List.of(fileName), DEFAULT_FRAME_TIME, DEFAULT_IS_LOOP, DEFAULT_PRIO);
+    public static Animation fromSingleImage(IPath fileName) {
+        return new Animation(
+                List.of(fileName.pathString()), DEFAULT_FRAME_TIME, DEFAULT_IS_LOOP, DEFAULT_PRIO);
     }
 
     /**

--- a/game/src/core/utils/components/draw/Animation.java
+++ b/game/src/core/utils/components/draw/Animation.java
@@ -159,8 +159,9 @@ public final class Animation {
      * @param frameTime How many frames to wait, before switching to the next texture?
      * @return The created Animation instance
      */
-    public static Animation fromSingleImage(String fileName, int frameTime) {
-        return new Animation(List.of(fileName), frameTime, DEFAULT_IS_LOOP, DEFAULT_PRIO);
+    public static Animation fromSingleImage(IPath fileName, int frameTime) {
+        return new Animation(
+                List.of(fileName.pathString()), frameTime, DEFAULT_IS_LOOP, DEFAULT_PRIO);
     }
 
     /**

--- a/game/src/core/utils/components/draw/Animation.java
+++ b/game/src/core/utils/components/draw/Animation.java
@@ -114,7 +114,7 @@ public final class Animation {
      * @param prio priority for playing this animation
      * @return The created Animation instance
      */
-    public static Animation of(File subDir, int frameTime, boolean loop, int prio) {
+    public static Animation fromSubDir(File subDir, int frameTime, boolean loop, int prio) {
         List<String> fileNames =
                 Arrays.stream(Objects.requireNonNull(subDir.listFiles()))
                         .filter(File::isFile)
@@ -137,8 +137,8 @@ public final class Animation {
      * @param subDir Path to the subdirectory where the animation frames are stored
      * @return The created Animation instance
      */
-    public static Animation of(File subDir) {
-        return Animation.of(subDir, DEFAULT_FRAME_TIME, DEFAULT_IS_LOOP, DEFAULT_PRIO);
+    public static Animation fromSubDir(File subDir) {
+        return Animation.fromSubDir(subDir, DEFAULT_FRAME_TIME, DEFAULT_IS_LOOP, DEFAULT_PRIO);
     }
 
     /**
@@ -147,7 +147,7 @@ public final class Animation {
      * @param fileName path to the frame
      * @return The created Animation instance
      */
-    public static Animation of(String fileName) {
+    public static Animation fromSingleImage(String fileName) {
         return new Animation(List.of(fileName), DEFAULT_FRAME_TIME, DEFAULT_IS_LOOP, DEFAULT_PRIO);
     }
 
@@ -158,7 +158,7 @@ public final class Animation {
      * @param frameTime How many frames to wait, before switching to the next texture?
      * @return The created Animation instance
      */
-    public static Animation of(String fileName, int frameTime) {
+    public static Animation fromSingleImage(String fileName, int frameTime) {
         return new Animation(List.of(fileName), frameTime, DEFAULT_IS_LOOP, DEFAULT_PRIO);
     }
 

--- a/game/src/core/utils/components/draw/SimpleIPath.java
+++ b/game/src/core/utils/components/draw/SimpleIPath.java
@@ -1,0 +1,18 @@
+package core.utils.components.draw;
+
+public class SimpleIPath implements IPath {
+    private final String path;
+    public SimpleIPath(String path) {
+        this.path = path;
+    }
+
+    @Override
+    public String pathString() {
+        return path;
+    }
+
+    @Override
+    public int priority() {
+        return 0;
+    }
+}

--- a/game/src/core/utils/components/draw/SimpleIPath.java
+++ b/game/src/core/utils/components/draw/SimpleIPath.java
@@ -2,6 +2,7 @@ package core.utils.components.draw;
 
 public class SimpleIPath implements IPath {
     private final String path;
+
     public SimpleIPath(String path) {
         this.path = path;
     }

--- a/game/test/contrib/components/InventoryComponentTest.java
+++ b/game/test/contrib/components/InventoryComponentTest.java
@@ -9,8 +9,8 @@ import contrib.item.Item;
 import core.Entity;
 import core.Game;
 import core.utils.components.draw.Animation;
-
 import core.utils.components.draw.SimpleIPath;
+
 import org.junit.After;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -18,6 +18,9 @@ import org.mockito.Mockito;
 import java.util.Arrays;
 
 public class InventoryComponentTest {
+
+    public static final SimpleIPath MISSING_TEXTURE =
+            new SimpleIPath("animation/missing_texture.png");
 
     @After
     public void cleanup() {
@@ -44,7 +47,7 @@ public class InventoryComponentTest {
                 new Item(
                         "Test item",
                         "Test description",
-                        Animation.fromSingleImage(new SimpleIPath("animation/missing_texture.png")));
+                        Animation.fromSingleImage(MISSING_TEXTURE));
         assertTrue(ic.add(itemData));
         assertEquals(1, ic.count());
     }
@@ -61,13 +64,13 @@ public class InventoryComponentTest {
                 new Item(
                         "Test item",
                         "Test description",
-                        Animation.fromSingleImage(new SimpleIPath("animation/missing_texture.png"))));
+                        Animation.fromSingleImage(MISSING_TEXTURE)));
         assertTrue(
                 ic.add(
                         new Item(
                                 "Test item",
                                 "Test description",
-                                Animation.fromSingleImage(new SimpleIPath("animation/missing_texture.png")))));
+                                Animation.fromSingleImage(MISSING_TEXTURE))));
 
         assertEquals(2, ic.count());
     }
@@ -82,13 +85,13 @@ public class InventoryComponentTest {
                 new Item(
                         "Test item",
                         "Test description",
-                        Animation.fromSingleImage(new SimpleIPath("animation/missing_texture.png"))));
+                        Animation.fromSingleImage(MISSING_TEXTURE)));
         assertFalse(
                 ic.add(
                         new Item(
                                 "Test item",
                                 "Test description",
-                                Animation.fromSingleImage(new SimpleIPath("animation/missing_texture.png")))));
+                                Animation.fromSingleImage(MISSING_TEXTURE))));
         assertEquals(1, ic.count());
     }
 
@@ -102,7 +105,7 @@ public class InventoryComponentTest {
                 new Item(
                         "Test item",
                         "Test description",
-                        Animation.fromSingleImage(new SimpleIPath("animation/missing_texture.png")));
+                        Animation.fromSingleImage(MISSING_TEXTURE));
         ic.add(itemData);
         assertTrue(ic.remove(itemData));
 
@@ -119,7 +122,7 @@ public class InventoryComponentTest {
                 new Item(
                         "Test item",
                         "Test description",
-                        Animation.fromSingleImage(new SimpleIPath("animation/missing_texture.png")));
+                        Animation.fromSingleImage(MISSING_TEXTURE));
         ic.add(itemData);
         ic.remove(itemData);
         assertFalse(ic.remove(itemData));
@@ -137,7 +140,7 @@ public class InventoryComponentTest {
                 new Item(
                         "Test item",
                         "Test description",
-                        Animation.fromSingleImage(new SimpleIPath("animation/missing_texture.png")));
+                        Animation.fromSingleImage(MISSING_TEXTURE));
         ic.add(itemData);
         assertFalse(ic.remove(null));
 
@@ -163,7 +166,7 @@ public class InventoryComponentTest {
                 new Item(
                         "Test item",
                         "Test description",
-                        Animation.fromSingleImage(new SimpleIPath("animation/missing_texture.png")));
+                        Animation.fromSingleImage(MISSING_TEXTURE));
         ic.add(itemData);
         Item[] list = ic.items();
         assertEquals("should have one Item", 1, list.length);
@@ -180,13 +183,13 @@ public class InventoryComponentTest {
                 new Item(
                         "Test item",
                         "Test description",
-                        Animation.fromSingleImage(new SimpleIPath("animation/missing_texture.png")));
+                        Animation.fromSingleImage(MISSING_TEXTURE));
         ic.add(itemData1);
         Item itemData2 =
                 new Item(
                         "Test item",
                         "Test description",
-                        Animation.fromSingleImage(new SimpleIPath("animation/missing_texture.png")));
+                        Animation.fromSingleImage(MISSING_TEXTURE));
         ic.add(itemData2);
         Item[] list = ic.items();
         assertEquals("should have two Items", 2, list.length);
@@ -204,7 +207,7 @@ public class InventoryComponentTest {
                 new Item(
                         "Test item",
                         "Test description",
-                        Animation.fromSingleImage(new SimpleIPath("animation/missing_texture.png")));
+                        Animation.fromSingleImage(MISSING_TEXTURE));
         Item[] list = ic.items();
         assertEquals("should have no Items", 0, ic.count());
         assertFalse("Item should not be in returned List", Arrays.asList(list).contains(itemData));

--- a/game/test/contrib/components/InventoryComponentTest.java
+++ b/game/test/contrib/components/InventoryComponentTest.java
@@ -43,7 +43,7 @@ public class InventoryComponentTest {
                 new Item(
                         "Test item",
                         "Test description",
-                        Animation.of("animation/missing_texture.png"));
+                        Animation.fromSingleImage("animation/missing_texture.png"));
         assertTrue(ic.add(itemData));
         assertEquals(1, ic.count());
     }
@@ -60,13 +60,13 @@ public class InventoryComponentTest {
                 new Item(
                         "Test item",
                         "Test description",
-                        Animation.of("animation/missing_texture.png")));
+                        Animation.fromSingleImage("animation/missing_texture.png")));
         assertTrue(
                 ic.add(
                         new Item(
                                 "Test item",
                                 "Test description",
-                                Animation.of("animation/missing_texture.png"))));
+                                Animation.fromSingleImage("animation/missing_texture.png"))));
 
         assertEquals(2, ic.count());
     }
@@ -81,13 +81,13 @@ public class InventoryComponentTest {
                 new Item(
                         "Test item",
                         "Test description",
-                        Animation.of("animation/missing_texture.png")));
+                        Animation.fromSingleImage("animation/missing_texture.png")));
         assertFalse(
                 ic.add(
                         new Item(
                                 "Test item",
                                 "Test description",
-                                Animation.of("animation/missing_texture.png"))));
+                                Animation.fromSingleImage("animation/missing_texture.png"))));
         assertEquals(1, ic.count());
     }
 
@@ -101,7 +101,7 @@ public class InventoryComponentTest {
                 new Item(
                         "Test item",
                         "Test description",
-                        Animation.of("animation/missing_texture.png"));
+                        Animation.fromSingleImage("animation/missing_texture.png"));
         ic.add(itemData);
         assertTrue(ic.remove(itemData));
 
@@ -118,7 +118,7 @@ public class InventoryComponentTest {
                 new Item(
                         "Test item",
                         "Test description",
-                        Animation.of("animation/missing_texture.png"));
+                        Animation.fromSingleImage("animation/missing_texture.png"));
         ic.add(itemData);
         ic.remove(itemData);
         assertFalse(ic.remove(itemData));
@@ -136,7 +136,7 @@ public class InventoryComponentTest {
                 new Item(
                         "Test item",
                         "Test description",
-                        Animation.of("animation/missing_texture.png"));
+                        Animation.fromSingleImage("animation/missing_texture.png"));
         ic.add(itemData);
         assertFalse(ic.remove(null));
 
@@ -162,7 +162,7 @@ public class InventoryComponentTest {
                 new Item(
                         "Test item",
                         "Test description",
-                        Animation.of("animation/missing_texture.png"));
+                        Animation.fromSingleImage("animation/missing_texture.png"));
         ic.add(itemData);
         Item[] list = ic.items();
         assertEquals("should have one Item", 1, list.length);
@@ -179,13 +179,13 @@ public class InventoryComponentTest {
                 new Item(
                         "Test item",
                         "Test description",
-                        Animation.of("animation/missing_texture.png"));
+                        Animation.fromSingleImage("animation/missing_texture.png"));
         ic.add(itemData1);
         Item itemData2 =
                 new Item(
                         "Test item",
                         "Test description",
-                        Animation.of("animation/missing_texture.png"));
+                        Animation.fromSingleImage("animation/missing_texture.png"));
         ic.add(itemData2);
         Item[] list = ic.items();
         assertEquals("should have two Items", 2, list.length);
@@ -203,7 +203,7 @@ public class InventoryComponentTest {
                 new Item(
                         "Test item",
                         "Test description",
-                        Animation.of("animation/missing_texture.png"));
+                        Animation.fromSingleImage("animation/missing_texture.png"));
         Item[] list = ic.items();
         assertEquals("should have no Items", 0, ic.count());
         assertFalse("Item should not be in returned List", Arrays.asList(list).contains(itemData));

--- a/game/test/contrib/components/InventoryComponentTest.java
+++ b/game/test/contrib/components/InventoryComponentTest.java
@@ -10,6 +10,7 @@ import core.Entity;
 import core.Game;
 import core.utils.components.draw.Animation;
 
+import core.utils.components.draw.SimpleIPath;
 import org.junit.After;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -43,7 +44,7 @@ public class InventoryComponentTest {
                 new Item(
                         "Test item",
                         "Test description",
-                        Animation.fromSingleImage("animation/missing_texture.png"));
+                        Animation.fromSingleImage(new SimpleIPath("animation/missing_texture.png")));
         assertTrue(ic.add(itemData));
         assertEquals(1, ic.count());
     }
@@ -60,13 +61,13 @@ public class InventoryComponentTest {
                 new Item(
                         "Test item",
                         "Test description",
-                        Animation.fromSingleImage("animation/missing_texture.png")));
+                        Animation.fromSingleImage(new SimpleIPath("animation/missing_texture.png"))));
         assertTrue(
                 ic.add(
                         new Item(
                                 "Test item",
                                 "Test description",
-                                Animation.fromSingleImage("animation/missing_texture.png"))));
+                                Animation.fromSingleImage(new SimpleIPath("animation/missing_texture.png")))));
 
         assertEquals(2, ic.count());
     }
@@ -81,13 +82,13 @@ public class InventoryComponentTest {
                 new Item(
                         "Test item",
                         "Test description",
-                        Animation.fromSingleImage("animation/missing_texture.png")));
+                        Animation.fromSingleImage(new SimpleIPath("animation/missing_texture.png"))));
         assertFalse(
                 ic.add(
                         new Item(
                                 "Test item",
                                 "Test description",
-                                Animation.fromSingleImage("animation/missing_texture.png"))));
+                                Animation.fromSingleImage(new SimpleIPath("animation/missing_texture.png")))));
         assertEquals(1, ic.count());
     }
 
@@ -101,7 +102,7 @@ public class InventoryComponentTest {
                 new Item(
                         "Test item",
                         "Test description",
-                        Animation.fromSingleImage("animation/missing_texture.png"));
+                        Animation.fromSingleImage(new SimpleIPath("animation/missing_texture.png")));
         ic.add(itemData);
         assertTrue(ic.remove(itemData));
 
@@ -118,7 +119,7 @@ public class InventoryComponentTest {
                 new Item(
                         "Test item",
                         "Test description",
-                        Animation.fromSingleImage("animation/missing_texture.png"));
+                        Animation.fromSingleImage(new SimpleIPath("animation/missing_texture.png")));
         ic.add(itemData);
         ic.remove(itemData);
         assertFalse(ic.remove(itemData));
@@ -136,7 +137,7 @@ public class InventoryComponentTest {
                 new Item(
                         "Test item",
                         "Test description",
-                        Animation.fromSingleImage("animation/missing_texture.png"));
+                        Animation.fromSingleImage(new SimpleIPath("animation/missing_texture.png")));
         ic.add(itemData);
         assertFalse(ic.remove(null));
 
@@ -162,7 +163,7 @@ public class InventoryComponentTest {
                 new Item(
                         "Test item",
                         "Test description",
-                        Animation.fromSingleImage("animation/missing_texture.png"));
+                        Animation.fromSingleImage(new SimpleIPath("animation/missing_texture.png")));
         ic.add(itemData);
         Item[] list = ic.items();
         assertEquals("should have one Item", 1, list.length);
@@ -179,13 +180,13 @@ public class InventoryComponentTest {
                 new Item(
                         "Test item",
                         "Test description",
-                        Animation.fromSingleImage("animation/missing_texture.png"));
+                        Animation.fromSingleImage(new SimpleIPath("animation/missing_texture.png")));
         ic.add(itemData1);
         Item itemData2 =
                 new Item(
                         "Test item",
                         "Test description",
-                        Animation.fromSingleImage("animation/missing_texture.png"));
+                        Animation.fromSingleImage(new SimpleIPath("animation/missing_texture.png")));
         ic.add(itemData2);
         Item[] list = ic.items();
         assertEquals("should have two Items", 2, list.length);
@@ -203,7 +204,7 @@ public class InventoryComponentTest {
                 new Item(
                         "Test item",
                         "Test description",
-                        Animation.fromSingleImage("animation/missing_texture.png"));
+                        Animation.fromSingleImage(new SimpleIPath("animation/missing_texture.png")));
         Item[] list = ic.items();
         assertEquals("should have no Items", 0, ic.count());
         assertFalse("Item should not be in returned List", Arrays.asList(list).contains(itemData));

--- a/game/test/contrib/utils/components/item/ItemTest.java
+++ b/game/test/contrib/utils/components/item/ItemTest.java
@@ -20,6 +20,7 @@ import core.utils.IVoidFunction;
 import core.utils.Point;
 import core.utils.components.draw.Animation;
 import core.utils.components.draw.Painter;
+import core.utils.components.draw.SimpleIPath;
 
 import org.junit.After;
 import org.junit.Before;
@@ -31,9 +32,10 @@ import java.util.Arrays;
 
 public class ItemTest {
 
-    Animation defaultAnimation = Animation.fromSingleImage("animation/missing_texture.png");
-    Animation worldAnimation = Animation.fromSingleImage("item/key/gold_key");
-    Animation inventoryAnimation = Animation.fromSingleImage("item/key/red_key");
+    Animation defaultAnimation =
+            Animation.fromSingleImage(new SimpleIPath("animation/missing_texture.png"));
+    Animation worldAnimation = Animation.fromSingleImage(new SimpleIPath("item/key/gold_key"));
+    Animation inventoryAnimation = Animation.fromSingleImage(new SimpleIPath("item/key/red_key"));
 
     @Before
     public void before() {

--- a/game/test/contrib/utils/components/item/ItemTest.java
+++ b/game/test/contrib/utils/components/item/ItemTest.java
@@ -31,9 +31,9 @@ import java.util.Arrays;
 
 public class ItemTest {
 
-    Animation defaultAnimation = Animation.of("animation/missing_texture.png");
-    Animation worldAnimation = Animation.of("item/key/gold_key");
-    Animation inventoryAnimation = Animation.of("item/key/red_key");
+    Animation defaultAnimation = Animation.fromSingleImage("animation/missing_texture.png");
+    Animation worldAnimation = Animation.fromSingleImage("item/key/gold_key");
+    Animation inventoryAnimation = Animation.fromSingleImage("item/key/red_key");
 
     @Before
     public void before() {

--- a/game/test/core/utils/components/draw/AnimationTest.java
+++ b/game/test/core/utils/components/draw/AnimationTest.java
@@ -7,22 +7,21 @@ import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class AnimationTest {
 
-    @Test(expected = NullPointerException.class)
+    /** Creating an Animation without a Collection of frames should not be allowed */
+    @Test(expected = AssertionError.class)
     public void test_constructor_1() {
-        new Animation(null, 10);
+        Animation.fromCollection(null);
     }
 
+    /** Creating an Animation without any frames in the Collection should not be allowed */
     @Test(expected = AssertionError.class)
     public void test_constructor_2() {
-        new Animation(List.of(), 10, 1);
-    }
-
-    @Test(expected = AssertionError.class)
-    public void test_constructor_3() {
-        new Animation(List.of("someValidTexture"), -10, 1);
+        Animation.fromCollection(List.of());
     }
 
     @Test
@@ -30,7 +29,11 @@ public class AnimationTest {
         // Idea: An animation with 3 textures and a frame time of 10 should return 10 (or 11) times
         // the current texture.
 
-        Animation animation = new Animation(List.of("1", "2", "3"), 10, 1);
+        Animation animation =
+                Animation.fromCollection(
+                        Stream.of("1", "2", "3").map(SimpleIPath::new).collect(Collectors.toList()),
+                        10,
+                        1);
         for (int i = 0; i < 100; i++) {
             for (int j = 0; j < 10; j++) {
                 assertEquals(String.valueOf(i % 3 + 1), animation.nextAnimationTexturePath());
@@ -40,51 +43,57 @@ public class AnimationTest {
 
     @Test
     public void CheckAnimation_isFinished_OneMoreFrameAndNotLooping() {
-        List<String> testStrings = List.of("a", "b");
-        Animation ta = new Animation(testStrings, 1, false, 1);
+        List<IPath> testStrings =
+                Stream.of("a", "b").map(SimpleIPath::new).collect(Collectors.toList());
+        Animation ta = Animation.fromCollection(testStrings, 1, false, 1);
         assertFalse("has still one Frame for the Animation to go", ta.isFinished());
     }
 
     @Test
     public void CheckAnimation_isFinished_NoMoreFrameAndNotLooping() {
-        List<String> testStrings = List.of("a", "b");
-        Animation ta = new Animation(testStrings, 1, false, 1);
+        List<IPath> testStrings =
+                Stream.of("a", "b").map(SimpleIPath::new).collect(Collectors.toList());
+        Animation ta = Animation.fromCollection(testStrings, 1, false, 1);
         ta.nextAnimationTexturePath();
         assertTrue("last Frame reached and should not loop", ta.isFinished());
     }
 
     @Test
     public void CheckAnimation_isFinished_OneMoreFrameAndLooping() {
-        List<String> testStrings = List.of("a", "b");
-        Animation ta = new Animation(testStrings, 1, true, 1);
+        List<IPath> testStrings =
+                Stream.of("a", "b").map(SimpleIPath::new).collect(Collectors.toList());
+        Animation ta = Animation.fromCollection(testStrings, 1, true, 1);
         assertFalse("has still one Frame for the Animation to go", ta.isFinished());
     }
 
     @Test
     public void CheckAnimation_isFinished_NoMoreFrameAndLooping() {
-        List<String> testStrings = List.of("a", "b");
-        Animation ta = new Animation(testStrings, 1, true, 1);
+        List<IPath> testStrings =
+                Stream.of("a", "b").map(SimpleIPath::new).collect(Collectors.toList());
+        Animation ta = Animation.fromCollection(testStrings, 1, true, 1);
         ta.nextAnimationTexturePath();
         assertFalse("last Frame reached and should loop", ta.isFinished());
     }
 
     @Test
     public void CheckAnimation_getNextAnimationTexturePath_NonLoopingFrameTime1() {
-        List<String> testStrings = List.of("a", "b");
-        Animation ta = new Animation(testStrings, 1, false, 1);
-        assertEquals(testStrings.get(0), ta.nextAnimationTexturePath());
-        assertEquals(testStrings.get(1), ta.nextAnimationTexturePath());
-        assertEquals(testStrings.get(1), ta.nextAnimationTexturePath());
+        List<IPath> testStrings =
+                Stream.of("a", "b").map(SimpleIPath::new).collect(Collectors.toList());
+        Animation ta = Animation.fromCollection(testStrings, 1, false, 1);
+        assertEquals(testStrings.get(0).pathString(), ta.nextAnimationTexturePath());
+        assertEquals(testStrings.get(1).pathString(), ta.nextAnimationTexturePath());
+        assertEquals(testStrings.get(1).pathString(), ta.nextAnimationTexturePath());
     }
 
     @Test
     public void CheckAnimation_getNextAnimationTexturePath_NonLoopingFrameTime2() {
-        List<String> testStrings = List.of("a", "b");
-        Animation ta = new Animation(testStrings, 2, false, 1);
-        assertEquals(testStrings.get(0), ta.nextAnimationTexturePath());
-        assertEquals(testStrings.get(0), ta.nextAnimationTexturePath());
-        assertEquals(testStrings.get(1), ta.nextAnimationTexturePath());
-        assertEquals(testStrings.get(1), ta.nextAnimationTexturePath());
-        assertEquals(testStrings.get(1), ta.nextAnimationTexturePath());
+        List<IPath> testStrings =
+                Stream.of("a", "b").map(SimpleIPath::new).collect(Collectors.toList());
+        Animation ta = Animation.fromCollection(testStrings, 2, false, 1);
+        assertEquals(testStrings.get(0).pathString(), ta.nextAnimationTexturePath());
+        assertEquals(testStrings.get(0).pathString(), ta.nextAnimationTexturePath());
+        assertEquals(testStrings.get(1).pathString(), ta.nextAnimationTexturePath());
+        assertEquals(testStrings.get(1).pathString(), ta.nextAnimationTexturePath());
+        assertEquals(testStrings.get(1).pathString(), ta.nextAnimationTexturePath());
     }
 }


### PR DESCRIPTION
Ein großer Teil des aufräumen von Pfaden.

- Entfernt String pfade für Animationen
- Entfernt mix aus Factory und konstruktoren

Teil von #1143 
Da es zu viele Baustellen gibt, würde ich hier Schritt für Schritt in einzelnen PRs weiter aufbauen.

