### PR TITLE
[DOC] DSL-Taskdefinition dokumentieren

### DIFF
--- a/dungeon/assets/scripts/example.dng
+++ b/dungeon/assets/scripts/example.dng
@@ -61,7 +61,7 @@ multiple_choice_task task5_m {
   "Man kann Datensätze nach dem Datum sortieren lassen.",
   "Sortierung ist immer aufsteigend.",
   "Keine davon ist richtig."],
-  correct_answer_index: [0, 1]
+  correct_answer_indices: [0, 1]
 }
 
 multiple_choice_task task6_m {
@@ -71,19 +71,19 @@ multiple_choice_task task6_m {
   "MergeSort braucht viel Speicherplatz.",
   "Python ist für Anfänger gut geeignet.",
   "Keine davon ist richtig."],
-  correct_answer_index: [1, 2]
+  correct_answer_indices: [1, 2]
 }
 
 multiple_choice_task task7_m {
   description: "Wählen Sie die Elemente aus, mit denen man jeden Algorithmus darstellen kann.",
   answers: ["Basisanweisungen", "Kontrollstrukturen", "Elementaroperationen", "Fallunterschiedungen", "Schleifen", "Sequenzen", "Nichts davon"],
-  correct_answer_index: [1, 2, 3, 4, 5]
+  correct_answer_indices: [1, 2, 3, 4, 5]
 }
 
 multiple_choice_task task8_m {
   description: "Welche der folgenden Sortierverfahren sind rekursive Verfahren (in unserer Vorlesung)?",
   answers: ["BubbleSort", "MergeSort", "QuickSort", "InsertionSort", "SelectionSort",  "Nichts davon"],
-  correct_answer_index: [0, 1] // kann auch leer bleiben
+  correct_answer_indices: [0, 1] // kann auch leer bleiben
 }
 
 
@@ -111,7 +111,7 @@ multiple_choice_task task10_m {
   "Die Syntax von Pseudocode ist eindeutig festgelegt.",
   "Hochsprachen werden immer compiliert.",
   "Nichts davon"],
-  correct_answer_index: [1]
+  correct_answer_indices: [1]
 }
 
 graph morning_graph {
@@ -193,7 +193,7 @@ multiple_choice_task task5_a {
   description: "Bitte suchen Sie die richtige Ausage:",
   answers: ["Eine Ordnungsrelation erlaubt gleichen Schlüssel.","Man kann Datensätze nach dem Datum sortieren lassen.", "Sortierung ist immer aufsteigend.",
   "Keine davon ist richtig."],
-  correct_answer_index: [0, 1]
+  correct_answer_indices: [0, 1]
 }
 
 
@@ -201,20 +201,20 @@ multiple_choice_task task6_a {
   description: "Bitte suchen Sie die richtige Ausage:",
   answers: ["Pseudocode ist grundsätzlich maschinenlesbar.","MergeSort braucht viel Speicherplatz.", "Python ist für Anfänger gut geeignet.",
   "Keine davon ist richtig."],
-  correct_answer_index: [1, 2]
+  correct_answer_indices: [1, 2]
 }
 
 multiple_choice_task task7_a {
   description: "Wählen Sie die Elemente aus, mit denen man jeden Algorithmus darstellen kann.",
   answers: ["Basisanweisungen", "Kontrollstrukturen", "Elementaroperationen", "Fallunterschiedungen", "Schleifen", "Sequenzen", "Nichts davon"],
-  correct_answer_index: [1, 2, 3, 4, 5]
+  correct_answer_indices: [1, 2, 3, 4, 5]
 }
 
 
 multiple_choice_task task8_a {
   description: "Welche der folgenden Sortierverfahren sind rekursive Verfahren (in unserer Vorlesung)?",
   answers: ["BubbleSort", "MergeSort", "QuickSort", "InsertionSort", "SelectionSort",  "Nichts davon"],
-  correct_answer_index: [0, 1]
+  correct_answer_indices: [0, 1]
 }
 
 assign_task task9_a {
@@ -235,7 +235,7 @@ assign_task task9_a {
 multiple_choice_task task10_a {
   description: "Welchen Aussagen aus der Vorlesung stimmen Sie zu?",
   answers: ["Eine Spezifikation enthält die Wahl des Algorithmus", "Unterprogramme sind nicht unbedingt nötig.", "Mit Struktogrammen lassen sich gut Algorithmen entwickeln.", "Die Syntax von Pseudocode ist eindeutig festgelegt.", "Hochsprachen werden immer compiliert.",  "Nichts davon"],
-  correct_answer_index: [1]
+  correct_answer_indices: [1]
 }
 
 graph afternoon_graph {

--- a/dungeon/doc/dsl/examplescripts/quickstart_task_dependency.dng
+++ b/dungeon/doc/dsl/examplescripts/quickstart_task_dependency.dng
@@ -20,7 +20,7 @@ single_choice_task Aufgabe2 {
 multiple_choice_task Aufgabe3 {
     description: "Welche der folgenden Planeten gehören zu den Gasriesen?",
     answers: [ "Mars", "Jupiter", "Venus", "Saturn", "Erde" ],
-    correct_answer_index: [1, 3],
+    correct_answer_indices: [1, 3],
     explanation: "Jupiter und Saturn sind Gasriesen in unserem Sonnensystem."
 }
 

--- a/dungeon/doc/dsl/task_definition.md
+++ b/dungeon/doc/dsl/task_definition.md
@@ -1,0 +1,171 @@
+---
+title: "Aufgabendefinition"
+---
+
+Dieser Teil der Dokumentation beschreibt, wie Aufgaben definiert werden. Es werden konfigurierbare
+Eigenschaften und die entsprechenden [Datentypen](TODO: Datentyp-Doku) erläutert.
+Zum jetzigen Zeitpunkt sind drei Aufgabentypen verfügbar: Single Choice, Multiple Choice
+und Zuweisungsaufgaben.
+
+## Single Choice Aufgaben
+
+Single Choice Aufgaben werden wie folgt definiert (nicht alle Eigenschaften müssen zwingend definiert werden):
+
+```
+single_choice_task my_task {
+    description: "Dies ist der Aufgabentext",
+    answers: ["Antwort1", "Antwort2", "Antwort3"],
+    correct_answer_index: 1,
+    points: 1,
+    points_to_pass: 1,
+    explanation: "Dieser Text wird angezeigt, falls die Aufgabe falsch beantwortet wird",
+    grading_function: grade_single_choice_task,
+    scenario_builder my_scenario_builder:
+}
+```
+
+### Beschreibung der Eigenschaften
+
+| Name                   | Datentyp                                           | Funktion                                                                                                                                                           | Default-Wert                                                                          |
+|------------------------|----------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------|
+| `description`          | `string`                                           | Der Aufgabentext, der im Spiel als Arbeitsanweisung angezeigt wird.                                                                                                | `""` (leerer `string`)                                                                |
+| `answers`              | `string[]` (Liste von `string`-Werten)             | Die Antwortmöglichkeiten für die Aufgabe                                                                                                                           | `[]` (leere Liste)                                                                    |
+| `correct_answer_index` | `int`                                              | Der Index der korrekten Antwortmöglichkeit aus `answers` (beginnt bei `0`)                                                                                         | `0`                                                                                   |
+| `points`               | `float`                                            | Wie viele Punkte können mit dieser Aufgabe maximal erreicht werden?                                                                                                | `1.0`                                                                                 |
+| `points_to_pass`       | `float`                                            | Wie viele Punkte müssen erreicht werden, um die Aufgabe zu bestehen?                                                                                               | `1.0`                                                                                 |
+| `explanation`          | `string`                                           | Ein optional konfigurierbarer Erklärungstext, der angezeigt wird, falls die Frage falsch beantwortet wird. Falls nicht konfiguriert, wird er auch nicht angezeigt. | `""` (leerer `string`)                                                                |
+| `grading_function`     | `fn (single_choice_task, task_content<>) -> float` | Eine Referenz auf eine Funktion, die zur Bewertung der Aufgabe verwendet wird.                                                                                     | [`grade_single_choice_task`](TODO: Link auf Doku zu nativer Funktion)                 |
+| `scenario_builder`     | `fn (single_choice_task) -> entity<><>`            | Eine Referenz auf eine Funktion, die aus der Aufgabendefinition ein konkretes Spielszenario erstellt.                                                              | [`$default_single_choice_scenario$`](TODO: Link auf Doku zu nativem Szenario-Builder) |
+
+## Multiple Choice Aufgaben
+
+Multiple Choice Aufgaben werden wie folgt definiert (nicht alle Eigenschaften müssen zwingend definiert werden):
+
+```
+multiple_choice_task my_task {
+    description: "Dies ist der Aufgabentext",
+    answers: ["Antwort1", "Antwort2", "Antwort3"],
+    correct_answer_indices: [1,2],
+    points: 1,
+    points_to_pass: 1,
+    explanation: "Dieser Text wird angezeigt, falls die Aufgabe falsch beantwortet wird",
+    grading_function: grade_multiple_choice_task,
+    scenario_builder my_scenario_builder:
+}
+```
+
+### Beschreibung der Eigenschaften
+
+| Name                     | Datentyp                                             | Funktion                                                                                                                                                           | Default-Wert                                                                            |
+|--------------------------|------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------|
+| `description`            | `string`                                             | Der Aufgabentext, der im Spiel als Arbeitsanweisung angezeigt wird.                                                                                                | `""` (leerer `string`)                                                                  |
+| `answers`                | `string[]` (Liste von `string`-Werten)               | Die Antwortmöglichkeiten für die Aufgabe                                                                                                                           | `[]` (leere Liste)                                                                      |
+| `correct_answer_indices` | `int[]` (Liste von `int`-Werten)                     | Die Indizes der korrekten Antwortmöglichkeiten aus `answers` (beginnt bei `0`)                                                                                     | `[]` (leere Liste                                                                       |
+| `points`                 | `float`                                              | Wie viele Punkte können mit dieser Aufgabe maximal erreicht werden?                                                                                                | `1.0`                                                                                   |
+| `points_to_pass`         | `float`                                              | Wie viele Punkte müssen erreicht werden, um die Aufgabe zu bestehen?                                                                                               | `1.0`                                                                                   |
+| `explanation`            | `string`                                             | Ein optional konfigurierbarer Erklärungstext, der angezeigt wird, falls die Frage falsch beantwortet wird. Falls nicht konfiguriert, wird er auch nicht angezeigt. | `""` (leerer `string`)                                                                  |
+| `grading_function`       | `fn (multiple_choice_task, task_content<>) -> float` | Eine Referenz auf eine Funktion, die zur Bewertung der Aufgabe verwendet wird.                                                                                     | [`grade_multiple_choice_task`](TODO: Link auf Doku zu nativer Funktion)                 |
+| `scenario_builder`       | `fn (multiple_choice_task) -> entity<><>`            | Eine Referenz auf eine Funktion, die aus der Aufgabendefinition ein konkretes Spielszenario erstellt.                                                              | [`$default_multiple_choice_scenario$`](TODO: Link auf Doku zu nativem Szenario-Builder) |
+
+## Zuordnungsaufgaben
+
+Zuordnungsaufgaben werden wie folgt definiert (nicht alle Eigenschaften müssen zwingend definiert werden):
+
+```
+multiple_choice_task my_task {
+    description: "Dies ist der Aufgabentext",
+    solution: <
+        ["Term1", "Definition1"],
+        ["Term1", "Definition2"],
+        ["Term2", "Definition3"],
+        [_, "Definition4"],
+        ["Term3", _]
+        >,
+    points: 1,
+    points_to_pass: 1,
+    explanation: "Dieser Text wird angezeigt, falls die Aufgabe falsch beantwortet wird",
+    grading_function: grade_assign_task_easy,
+    scenario_builder my_scenario_builder:
+}
+```
+
+### Beschreibung der Eigenschaften
+
+| Name               | Datentyp                                             | Funktion                                                                                                                                                           | Default-Wert                                                                            |
+|--------------------|------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------|
+| `description`      | `string`                                             | Der Aufgabentext, der im Spiel als Arbeitsanweisung angezeigt wird.                                                                                                | `""` (leerer `string`)                                                                  |
+| `solution`         | `string[]<>`                                         | Die Lösung der Zuordnungsaufgabe (siehe Erläuterung unter der Tabelle)                                                                                             | `<>` (leeres Set)                                                                       |
+| `points`           | `float`                                              | Wie viele Punkte können mit dieser Aufgabe maximal erreicht werden?                                                                                                | `1.0`                                                                                   |
+| `points_to_pass`   | `float`                                              | Wie viele Punkte müssen erreicht werden, um die Aufgabe zu bestehen?                                                                                               | `1.0`                                                                                   |
+| `explanation`      | `string`                                             | Ein optional konfigurierbarer Erklärungstext, der angezeigt wird, falls die Frage falsch beantwortet wird. Falls nicht konfiguriert, wird er auch nicht angezeigt. | `""` (leerer `string`)                                                                  |
+| `grading_function` | `fn (multiple_choice_task, task_content<>) -> float` | Eine Referenz auf eine Funktion, die zur Bewertung der Aufgabe verwendet wird.                                                                                     | [`grade_multiple_choice_task`](TODO: Link auf Doku zu nativer Funktion)                 |
+| `scenario_builder` | `fn (multiple_choice_task) -> entity<><>`            | Eine Referenz auf eine Funktion, die aus der Aufgabendefinition ein konkretes Spielszenario erstellt.                                                              | [`$default_multiple_choice_scenario$`](TODO: Link auf Doku zu nativem Szenario-Builder) |
+
+### Definition der Lösung
+
+In einer Zuordnungsaufgabe werden Elementen aus einer Menge $A$ (z.B.
+Antwortmöglichkeiten) die Elemente aus einer anderen Menge $B$ zuzuordnen.
+Die Zuordnung muss dabei nach der Form
+einer partiellen Funktion $f: A \rightharpoonup B$ erfolgen.
+
+Das heißt:
+
+- Jeder Antwortmöglichkeit $a \in A$ kann maximal einem Element $b \in B$ zugeordnet werden.
+- Jedem Element $b \in B$ können $n$ Elemente $a \in A$ zugeordnet werden, wobei
+  $0 \leq n \leq |A|$ ist
+
+Die Lösung einer Zuordnungsaufgabe wird als Menge `<>` von `string`-Listen (`string[]`) definiert,
+wobei jede `string`-Liste nur zwei Elemente beinhaltet (alle weiteren Elemente werden ignoriert).
+
+Die Interpretation ist dabei wie folgt:
+- das erste Element $b$ einer Liste gibt ein Element aus Menge $B$ an
+- das zweite Element $a$ einer Liste gibt ein Element aus der Menge $A$ an
+- durch die Nennung beider Elemente in einer Liste wird definiert, dass die Zuordnung von
+  $a$ zu $b$ Teil der Lösung ist
+- ist das erste Element `_`, wird das zweite Element zu $A$ hinzugefügt, wird allerdings
+  in der Lösung keinem Element aus $B$ zugeordnet
+- ist das zweite Element `_`, wird das erste Element zu $B$ hinzugefügt, wird allerdings
+  in der Lösung keinem Element aus $A$ zugeordnet
+
+Bildlich am Beispiel eines Szenarios ausgedrückt:
+Die Menge $B$ stellt eine Menge an Truhen dar, denen die Schriftrollen aus Menge $A$ zugeordnet werden
+müssen.
+Gegeben sei folgende Lösungsdefinition:
+
+```
+...
+  solution: <
+      ["Elementaroperation", "anzahl = 0"],
+      ["Elementaroperation", "sinus(30)"],
+      ["Kontrollstruktur", "if"],
+      ["Kontrollstruktur", "if - else"],
+      ["Kontrollstruktur", "while"],
+      ["Basisanweisung", _],
+      [_, "Öffne die Tür."]
+  >
+...
+```
+
+Hieraus werden Truhen mit den folgenden Namen erstellt, denen Items aus $A$ zugeordnet werden müssen:
+- "Elementaroperation"
+- "Kontrollstrukturen"
+- "Basisanweisung"
+
+Aus der Definition werden Items mit folgenden Namen erstellt:
+- "anzahl = 0"
+- "sinus(30)"
+- "if"
+- "if - else"
+- "while"
+- "Öffne die Tür"
+
+Folgende Zuordnung wir als korrekt interpretiert:
+- Inhalt der Truhe "Elementaroperation":
+  - "anzahl = 0"
+  - "sinus(30"
+- Inhalt der Truhe "Kontrollstrukturen":
+  - "if"
+  - "if - else"
+  - "while"
+- Die Truhe "Basisanweisung" ist leer
+- Das Item "Öffne die Tür" ist keiner Truhe zugeordnet

--- a/dungeon/doc/readme.md
+++ b/dungeon/doc/readme.md
@@ -119,7 +119,7 @@ dungeon_config meine_config {
 
 Mit der `single_choice_task`-Definition wird eine neue Aufgabe definiert.
 `single_choice_task` ist dabei der Typ der Aufgabendefinition und legt fest, welche weiteren Informationen
-konfiguriert werden müssen (für weitere Aufgabentypen: siehe [Dokumentation Aufgabenerstellung (TODO)](https://github.com/Programmiermethoden/Dungeon/issues/1212)).
+konfiguriert werden müssen (für weitere Aufgabentypen: siehe [Dokumentation Aufgabenerstellung](dsl/task_definition.md)).
 `meine_aufgabe` ist ein frei wählbarer Name für die Definition und dient dazu,
 die Aufgabendefinition im weiteren Verlauf der `.dng`-Datei zu referenzieren.
 Dabei werden der Aufgabentext (`description`), die möglichen Antworten (als Liste von Strings, `answers`)
@@ -178,7 +178,7 @@ gestartet werden.
 ## Wie geht es weiter?
 
 Die Aufgabendefinitionen lassen noch mehr Konfigurationen zu, als in den Beispielskripten
-verwendet wird. Für eine detaillierte Dokumentation der Aufgabendefinitionen, siehe [Dokumentation: Aufgabendefinition (TODO)](https://github.com/Programmiermethoden/Dungeon/issues/1212).
+verwendet wird. Für eine detaillierte Dokumentation der Aufgabendefinitionen, siehe [Dokumentation: Aufgabendefinition](dsl/task_definition.md).
 
 Die bisher vorgestellten Aufgaben verwenden die Standard-Szenarien. Ein **Szenario**
 beschreibt die Abbilung einer abstrakten Aufgabenbeschreibung in das Spiel.

--- a/dungeon/src/task/dslinterop/DSLMultipleChoice.java
+++ b/dungeon/src/task/dslinterop/DSLMultipleChoice.java
@@ -29,7 +29,7 @@ public class DSLMultipleChoice {
             @DSLTypeMember(name = "answers") List<Quiz.Content> answers,
             @DSLTypeMember(name = "points") float points,
             @DSLTypeMember(name = "points_to_pass") float pointsToPass,
-            @DSLTypeMember(name = "correct_answer_index") List<Integer> correctAnswerIndices,
+            @DSLTypeMember(name = "correct_answer_indices") List<Integer> correctAnswerIndices,
             @DSLTypeMember(name = "explanation") String explanation,
             @DSLTypeMember(name = "grading_function")
                     BiFunction<Task, Set<TaskContent>, Float> gradingFunction,

--- a/dungeon/test/dsl/interpreter/TestDSLInterpreter.java
+++ b/dungeon/test/dsl/interpreter/TestDSLInterpreter.java
@@ -1300,7 +1300,7 @@ public class TestDSLInterpreter {
                     multiple_choice_task t2 {
                         description: "Tschüss",
                         answers: ["4", "5", "6"],
-                        correct_answer_index: [0,1]
+                        correct_answer_indices: [0,1]
                     }
 
                     graph g {
@@ -3558,7 +3558,7 @@ public class TestDSLInterpreter {
             multiple_choice_task t1 {
                 description: "Task1",
                 answers: ["1", "2", "3"],
-                correct_answer_index: [1,2],
+                correct_answer_indices: [1,2],
                 scenario_builder: build_scenario1
             }
 
@@ -3646,7 +3646,7 @@ public class TestDSLInterpreter {
         multiple_choice_task t1 {
             description: "Task1",
             answers: ["1", "2", "3"],
-            correct_answer_index: [2,1],
+            correct_answer_indices: [2,1],
             grading_function: grade_multiple_choice_task
         }
 

--- a/dungeon/test/dsl/semanticanalysis/TestSemanticAnalyzer.java
+++ b/dungeon/test/dsl/semanticanalysis/TestSemanticAnalyzer.java
@@ -944,7 +944,7 @@ public class TestSemanticAnalyzer {
             multiple_choice_task t2 {
                 description: "Tschüss",
                 answers: ["4", "5", "6"],
-                correct_answer_index: [0,1]
+                correct_answer_indices: [0,1]
             }
 
             graph g {
@@ -1000,7 +1000,7 @@ public class TestSemanticAnalyzer {
             multiple_choice_task t2 {
                 description: "Tschüss",
                 answers: ["4", "5", "6"],
-                correct_answer_index: [0,1]
+                correct_answer_indices: [0,1]
             }
 
             """;

--- a/dungeon/test_resources/task_test.dng
+++ b/dungeon/test_resources/task_test.dng
@@ -7,13 +7,13 @@ single_choice_task aufgabe_1 {
 multiple_choice_task wuppie1 {
     description: "Du bist doof, oder?",
     answers: ["Wupie", "Wuppi", "Wuppie", "Fluppie"],
-    correct_answer_index: [2,3]
+    correct_answer_indices: [2,3]
 }
 
 multiple_choice_task wuppie2 {
     description: "Was sind korrekte Wuppies?",
     answers: ["Wupie", "Wuppi", "Wuppie", "Fluppie"],
-    correct_answer_index: [2,3]
+    correct_answer_indices: [2,3]
 }
 
 
@@ -21,13 +21,13 @@ multiple_choice_task wuppie2 {
 multiple_choice_task wuppie3 {
     description: "Was sind korrekte Wuppies?",
     answers: ["Wupie", "Wuppi", "Wuppie", "Fluppie"],
-    correct_answer_index: [2,3]
+    correct_answer_indices: [2,3]
 }
 
 multiple_choice_task wuppie4 {
     description: "Was sind korrekte Wuppies?",
     answers: ["Wupie", "Wuppi", "Wuppie", "Fluppie"],
-    correct_answer_index: [2,3]
+    correct_answer_indices: [2,3]
 }
 
 graph g_one{


### PR DESCRIPTION
Fixes #1212 

Beschreibt, wie die implementierten Aufgabentypen in einer DSL-Konfiguration definiert werden, welche Eigenschaften die Aufgabendefinitionen haben und was diese Eigenschaften bedeuten.