### PR TITLE
[GAME] cleanup class `Entity`

### DIFF
--- a/dungeon/src/dslinterop/dslnativefunction/NativeInstantiate.java
+++ b/dungeon/src/dslinterop/dslnativefunction/NativeInstantiate.java
@@ -94,7 +94,7 @@ public class NativeInstantiate extends NativeFunction {
                     try {
                         Component component = (Component) memberObject;
                         Entity entity = (Entity) entityObject;
-                        entity.addComponent(component);
+                        entity.add(component);
                     } catch (ClassCastException ex) {
                         //
                     }
@@ -114,7 +114,7 @@ public class NativeInstantiate extends NativeFunction {
                 try {
                     Component component = (Component) memberObject;
                     Entity entity = (Entity) entityObject;
-                    entity.addComponent(component);
+                    entity.add(component);
                 } catch (ClassCastException ex) {
                     //
                 }

--- a/dungeon/src/dslinterop/dslnativefunction/NativeInstantiateNamed.java
+++ b/dungeon/src/dslinterop/dslnativefunction/NativeInstantiateNamed.java
@@ -98,7 +98,7 @@ public class NativeInstantiateNamed extends NativeFunction {
                     try {
                         Component component = (Component) memberObject;
                         Entity entity = (Entity) entityObject;
-                        entity.addComponent(component);
+                        entity.add(component);
                     } catch (ClassCastException ex) {
                         //
                     }
@@ -118,7 +118,7 @@ public class NativeInstantiateNamed extends NativeFunction {
                 try {
                     Component component = (Component) memberObject;
                     Entity entity = (Entity) entityObject;
-                    entity.addComponent(component);
+                    entity.add(component);
                 } catch (ClassCastException ex) {
                     //
                 }

--- a/dungeon/src/dslinterop/dsltypeproperties/EntityExtension.java
+++ b/dungeon/src/dslinterop/dsltypeproperties/EntityExtension.java
@@ -50,8 +50,8 @@ public class EntityExtension {
 
         @Override
         public void set(Entity instance, VelocityComponent valueToSet) {
-            instance.removeComponent(VelocityComponent.class);
-            instance.addComponent(valueToSet);
+            instance.remove(VelocityComponent.class);
+            instance.add(valueToSet);
         }
 
         @Override
@@ -71,8 +71,8 @@ public class EntityExtension {
 
         @Override
         public void set(Entity instance, InventoryComponent valueToSet) {
-            instance.removeComponent(InventoryComponent.class);
-            instance.addComponent(valueToSet);
+            instance.remove(InventoryComponent.class);
+            instance.add(valueToSet);
         }
 
         @Override
@@ -91,8 +91,8 @@ public class EntityExtension {
 
         @Override
         public void set(Entity instance, PositionComponent valueToSet) {
-            instance.removeComponent(PositionComponent.class);
-            instance.addComponent(valueToSet);
+            instance.remove(PositionComponent.class);
+            instance.add(valueToSet);
         }
 
         @Override
@@ -111,8 +111,8 @@ public class EntityExtension {
 
         @Override
         public void set(Entity instance, TaskContentComponent valueToSet) {
-            instance.removeComponent(TaskContentComponent.class);
-            instance.addComponent(valueToSet);
+            instance.remove(TaskContentComponent.class);
+            instance.add(valueToSet);
         }
 
         @Override
@@ -131,8 +131,8 @@ public class EntityExtension {
 
         @Override
         public void set(Entity instance, DrawComponent valueToSet) {
-            instance.removeComponent(DrawComponent.class);
-            instance.addComponent(valueToSet);
+            instance.remove(DrawComponent.class);
+            instance.add(valueToSet);
         }
 
         @Override
@@ -151,8 +151,8 @@ public class EntityExtension {
 
         @Override
         public void set(Entity instance, InteractionComponent valueToSet) {
-            instance.removeComponent(InteractionComponent.class);
-            instance.addComponent(valueToSet);
+            instance.remove(InteractionComponent.class);
+            instance.add(valueToSet);
         }
 
         @Override
@@ -171,8 +171,8 @@ public class EntityExtension {
 
         @Override
         public void set(Entity instance, TaskComponent valueToSet) {
-            instance.removeComponent(TaskComponent.class);
-            instance.addComponent(valueToSet);
+            instance.remove(TaskComponent.class);
+            instance.add(valueToSet);
 
             // if the task component references a Task, the manager entity should
             // be updated to the instance entity
@@ -243,7 +243,7 @@ public class EntityExtension {
                                                             ChestAnimations.OPEN_EMPTY);
                                                 }
                                             }));
-            other.addComponent(uiComponent);
+            other.add(uiComponent);
             chest.fetch(DrawComponent.class)
                     .ifPresent(
                             interactedDC -> {
@@ -287,7 +287,7 @@ public class EntityExtension {
             String name = (String) params.get(1);
             Element<String> content = new Element<>(task, name);
             tcc.content(content);
-            instance.addComponent(tcc);
+            instance.add(tcc);
 
             task.addContent(content);
             task.addContainer(content);
@@ -321,7 +321,7 @@ public class EntityExtension {
             Task task = (Task) params.get(0);
             Element<String> content = (Element<String>) params.get(1);
             tcc.content(content);
-            instance.addComponent(tcc);
+            instance.add(tcc);
 
             task.addContent(content);
             task.addContainer(content);

--- a/dungeon/src/dslinterop/nativescenariobuilder/NativeScenarioBuilder.java
+++ b/dungeon/src/dslinterop/nativescenariobuilder/NativeScenarioBuilder.java
@@ -38,15 +38,15 @@ import java.util.function.BiConsumer;
 public class NativeScenarioBuilder {
     public static Set<Set<Entity>> quizOnHud(Quiz quiz) {
         Entity questowner = new Entity("Questgeber");
-        questowner.addComponent(new PositionComponent());
+        questowner.add(new PositionComponent());
         try {
-            questowner.addComponent(new DrawComponent("character/knight"));
+            questowner.add(new DrawComponent("character/knight"));
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
         new TaskComponent(quiz, questowner);
 
-        questowner.addComponent(askOnInteractionQuiz(quiz));
+        questowner.add(askOnInteractionQuiz(quiz));
 
         Set<Set<Entity>> returnSet = new HashSet<>();
         Set<Entity> roomSet = new HashSet<>();
@@ -71,14 +71,14 @@ public class NativeScenarioBuilder {
 
         // setup quest owner
         Entity questowner = new Entity("Questgeber");
-        questowner.addComponent(new PositionComponent());
+        questowner.add(new PositionComponent());
         try {
-            questowner.addComponent(new DrawComponent("character/knight"));
+            questowner.add(new DrawComponent("character/knight"));
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
         new TaskComponent(task, questowner);
-        questowner.addComponent(askOnInteractionYesNo(task));
+        questowner.add(askOnInteractionYesNo(task));
         roomSet.add(questowner);
 
         // setup items and chests
@@ -105,17 +105,17 @@ public class NativeScenarioBuilder {
                     Entity chest = EntityFactory.newChest();
 
                     // empty generated chest
-                    chest.removeComponent(InventoryComponent.class);
-                    chest.addComponent(new InventoryComponent());
+                    chest.remove(InventoryComponent.class);
+                    chest.add(new InventoryComponent());
 
-                    chest.removeComponent(InteractionComponent.class);
-                    chest.addComponent(
+                    chest.remove(InteractionComponent.class);
+                    chest.add(
                             new InteractionComponent(1.5f, true, QuestChestInventoryInteraction()));
 
                     // mark as task container
                     var tcc = new TaskContentComponent();
                     tcc.content(key);
-                    chest.addComponent(tcc);
+                    chest.add(tcc);
 
                     task.addContent(key);
                     task.addContainer(key);
@@ -190,7 +190,7 @@ public class NativeScenarioBuilder {
                                                             ChestAnimations.OPEN_EMPTY);
                                                 }
                                             }));
-            other.addComponent(uiComponent);
+            other.add(uiComponent);
             chest.fetch(DrawComponent.class)
                     .ifPresent(
                             interactedDC -> {
@@ -224,7 +224,7 @@ public class NativeScenarioBuilder {
     private static BiConsumer<Task, Set<TaskContent>> showAnswersOnHud() {
         return (task, taskContents) -> {
             float score = task.gradeTask(taskContents);
-            task.managerEntity().get().removeComponent(InteractionComponent.class);
+            task.managerEntity().get().remove(InteractionComponent.class);
             UITools.generateNewTextDialog("Your score: " + score, "Ok", "Given answer");
         };
     }

--- a/dungeon/src/graph/TaskGraphConverter.java
+++ b/dungeon/src/graph/TaskGraphConverter.java
@@ -228,11 +228,11 @@ public class TaskGraphConverter {
                     doorTiles.forEach(DoorTile::close);
                     task.managerEntity()
                             .ifPresentOrElse(
-                                    entity -> entity.addComponent(doorComponent),
+                                    entity -> entity.add(doorComponent),
                                     () -> {
                                         Entity manager = new Entity();
-                                        manager.addComponent(new TaskComponent(task, manager));
-                                        manager.addComponent(doorComponent);
+                                        manager.add(new TaskComponent(task, manager));
+                                        manager.add(doorComponent);
                                     });
                 });
     }

--- a/dungeon/src/starter/TaskSelector.java
+++ b/dungeon/src/starter/TaskSelector.java
@@ -94,9 +94,9 @@ public class TaskSelector {
 
     protected static Entity npc(SingleChoice selectionQuestion) throws IOException {
         Entity npc = new Entity("Selection NPC");
-        npc.addComponent(new DrawComponent("character/blue_knight"));
-        npc.addComponent(new PositionComponent());
-        npc.addComponent(
+        npc.add(new DrawComponent("character/blue_knight"));
+        npc.add(new PositionComponent());
+        npc.add(
                 new InteractionComponent(
                         1,
                         true,

--- a/dungeon/src/task/game/components/TaskComponent.java
+++ b/dungeon/src/task/game/components/TaskComponent.java
@@ -56,7 +56,7 @@ public final class TaskComponent implements Component {
      */
     public TaskComponent(Task task, final Entity entity) {
         this.task = task;
-        entity.addComponent(this);
+        entity.add(this);
         task.managerEntity(entity);
         onActivate = DOOR_OPENER;
     }

--- a/dungeon/test/dslToGame/TestRuntimeObjectTranslator.java
+++ b/dungeon/test/dslToGame/TestRuntimeObjectTranslator.java
@@ -27,10 +27,10 @@ public class TestRuntimeObjectTranslator {
     @Test
     public void testEntityTranslation() {
         Entity entity = new Entity();
-        entity.addComponent(new CameraComponent());
-        entity.addComponent(new PositionComponent(new Point(0, 0)));
-        entity.addComponent(new VelocityComponent());
-        entity.addComponent(new HealthComponent());
+        entity.add(new CameraComponent());
+        entity.add(new PositionComponent(new Point(0, 0)));
+        entity.add(new VelocityComponent());
+        entity.add(new HealthComponent());
         Game.add(entity);
 
         String program = """
@@ -59,10 +59,10 @@ public class TestRuntimeObjectTranslator {
     @Test
     public void testIsolatedComponentTranslation() {
         Entity entity = new Entity();
-        entity.addComponent(new CameraComponent());
-        entity.addComponent(new PositionComponent(new Point(0, 0)));
-        entity.addComponent(new VelocityComponent());
-        entity.addComponent(new HealthComponent());
+        entity.add(new CameraComponent());
+        entity.add(new PositionComponent(new Point(0, 0)));
+        entity.add(new VelocityComponent());
+        entity.add(new HealthComponent());
         Game.add(entity);
 
         String program = """

--- a/dungeon/test/manual/quizquestion/CallbackTest.java
+++ b/dungeon/test/manual/quizquestion/CallbackTest.java
@@ -102,10 +102,10 @@ public class CallbackTest {
 
     private static Entity questWizard() throws IOException {
         Entity wizard = new Entity("Quest Wizard");
-        wizard.addComponent(new PositionComponent());
-        wizard.addComponent(new DrawComponent("character/wizard"));
-        wizard.addComponent(new TaskComponent(question, wizard));
-        wizard.addComponent(
+        wizard.add(new PositionComponent());
+        wizard.add(new DrawComponent("character/wizard"));
+        wizard.add(new TaskComponent(question, wizard));
+        wizard.add(
                 new InteractionComponent(
                         1,
                         false,

--- a/dungeon/test/manual/taskgeneration/TaskGenerationTest.java
+++ b/dungeon/test/manual/taskgeneration/TaskGenerationTest.java
@@ -115,10 +115,10 @@ public class TaskGenerationTest {
         }
 
         Entity wizard = new Entity("Quest Wizard");
-        wizard.addComponent(new PositionComponent());
-        wizard.addComponent(new DrawComponent(texture));
-        wizard.addComponent(new TaskComponent(quiz, wizard));
-        wizard.addComponent(
+        wizard.add(new PositionComponent());
+        wizard.add(new DrawComponent(texture));
+        wizard.add(new TaskComponent(quiz, wizard));
+        wizard.add(
                 new InteractionComponent(
                         1, true, UIAnswerCallback.askOnInteraction(quiz, showAnswersOnHud())));
         Game.add(wizard);

--- a/dungeon/test/reporting/AnswerPickingFunctionsTest.java
+++ b/dungeon/test/reporting/AnswerPickingFunctionsTest.java
@@ -53,10 +53,10 @@ public class AnswerPickingFunctionsTest {
         // setup Chest
         Entity chest = new Entity("Chest");
         InventoryComponent ic = new InventoryComponent(3);
-        chest.addComponent(ic);
+        chest.add(ic);
         TaskContent containerTaskContent = new Element<>(sc, chest);
         sc.addContainer(containerTaskContent);
-        chest.addComponent(new TaskContentComponent(containerTaskContent));
+        chest.add(new TaskContentComponent(containerTaskContent));
         Game.add(chest);
 
         // setup quest items
@@ -87,10 +87,10 @@ public class AnswerPickingFunctionsTest {
         // setup Chest
         Entity chest = new Entity("Chest");
         InventoryComponent ic = new InventoryComponent(3);
-        chest.addComponent(ic);
+        chest.add(ic);
         TaskContent containerTaskContent = new Element<>(sc, chest);
         sc.addContainer(containerTaskContent);
-        chest.addComponent(new TaskContentComponent(containerTaskContent));
+        chest.add(new TaskContentComponent(containerTaskContent));
         Game.add(chest);
 
         // setup quest items
@@ -122,10 +122,10 @@ public class AnswerPickingFunctionsTest {
         // setup Chest
         Entity chest = new Entity("Chest");
         InventoryComponent ic = new InventoryComponent(3);
-        chest.addComponent(ic);
+        chest.add(ic);
         TaskContent containerTaskContent = new Element<>(sc, chest);
         sc.addContainer(containerTaskContent);
-        chest.addComponent(new TaskContentComponent(containerTaskContent));
+        chest.add(new TaskContentComponent(containerTaskContent));
         Game.add(chest);
 
         // setup quest items
@@ -154,10 +154,10 @@ public class AnswerPickingFunctionsTest {
         // setup Chest
         Entity chest = new Entity("Chest");
         InventoryComponent ic = new InventoryComponent(3);
-        chest.addComponent(ic);
+        chest.add(ic);
         TaskContent containerTaskContent = new Element<>(sc, chest);
         sc.addContainer(containerTaskContent);
-        chest.addComponent(new TaskContentComponent(containerTaskContent));
+        chest.add(new TaskContentComponent(containerTaskContent));
         Game.add(chest);
 
         // setup quest items
@@ -187,10 +187,10 @@ public class AnswerPickingFunctionsTest {
         // setup Chest
         Entity chest = new Entity("Chest");
         InventoryComponent ic = new InventoryComponent(3);
-        chest.addComponent(ic);
+        chest.add(ic);
         TaskContent containerTaskContent = new Element<>(sc, chest);
         sc.addContainer(containerTaskContent);
-        chest.addComponent(new TaskContentComponent(containerTaskContent));
+        chest.add(new TaskContentComponent(containerTaskContent));
         Game.add(chest);
 
         // setup quest items
@@ -218,10 +218,10 @@ public class AnswerPickingFunctionsTest {
         // setup Chest
         Entity chest = new Entity("Chest");
         InventoryComponent ic = new InventoryComponent(3);
-        chest.addComponent(ic);
+        chest.add(ic);
         TaskContent containerTaskContent = new Element<>(sc, chest);
         sc.addContainer(containerTaskContent);
-        chest.addComponent(new TaskContentComponent(containerTaskContent));
+        chest.add(new TaskContentComponent(containerTaskContent));
         Game.add(chest);
 
         // setup quest items
@@ -281,14 +281,14 @@ public class AnswerPickingFunctionsTest {
         // setup Chests
         Entity chestA = new Entity("Chest A");
         InventoryComponent icA = new InventoryComponent(3);
-        chestA.addComponent(icA);
-        chestA.addComponent(new TaskContentComponent(containerA));
+        chestA.add(icA);
+        chestA.add(new TaskContentComponent(containerA));
         Game.add(chestA);
 
         Entity chestB = new Entity("Chest B");
         InventoryComponent icB = new InventoryComponent(3);
-        chestB.addComponent(icB);
-        chestB.addComponent(new TaskContentComponent(containerB));
+        chestB.add(icB);
+        chestB.add(new TaskContentComponent(containerB));
         Game.add(chestB);
 
         // setup quest items
@@ -346,14 +346,14 @@ public class AnswerPickingFunctionsTest {
         // setup Chests
         Entity chestA = new Entity("Chest A");
         InventoryComponent icA = new InventoryComponent(3);
-        chestA.addComponent(icA);
-        chestA.addComponent(new TaskContentComponent(containerA));
+        chestA.add(icA);
+        chestA.add(new TaskContentComponent(containerA));
         Game.add(chestA);
 
         Entity chestB = new Entity("Chest B");
         InventoryComponent icB = new InventoryComponent(3);
-        chestB.addComponent(icB);
-        chestB.addComponent(new TaskContentComponent(containerB));
+        chestB.add(icB);
+        chestB.add(new TaskContentComponent(containerB));
         Game.add(chestB);
 
         // setup quest items
@@ -409,14 +409,14 @@ public class AnswerPickingFunctionsTest {
         // setup Chests
         Entity chestA = new Entity("Chest A");
         InventoryComponent icA = new InventoryComponent(3);
-        chestA.addComponent(icA);
-        chestA.addComponent(new TaskContentComponent(containerA));
+        chestA.add(icA);
+        chestA.add(new TaskContentComponent(containerA));
         Game.add(chestA);
 
         Entity chestB = new Entity("Chest B");
         InventoryComponent icB = new InventoryComponent(3);
-        chestB.addComponent(icB);
-        chestB.addComponent(new TaskContentComponent(containerB));
+        chestB.add(icB);
+        chestB.add(new TaskContentComponent(containerB));
         Game.add(chestB);
 
         // setup quest items
@@ -477,14 +477,14 @@ public class AnswerPickingFunctionsTest {
         // setup Chests
         Entity chestA = new Entity("Chest A");
         InventoryComponent icA = new InventoryComponent(3);
-        chestA.addComponent(icA);
-        chestA.addComponent(new TaskContentComponent(containerA));
+        chestA.add(icA);
+        chestA.add(new TaskContentComponent(containerA));
         Game.add(chestA);
 
         Entity chestB = new Entity("Chest B");
         InventoryComponent icB = new InventoryComponent(3);
-        chestB.addComponent(icB);
-        chestB.addComponent(new TaskContentComponent(containerB));
+        chestB.add(icB);
+        chestB.add(new TaskContentComponent(containerB));
         Game.add(chestB);
 
         // setup quest items
@@ -544,14 +544,14 @@ public class AnswerPickingFunctionsTest {
         // setup Chests
         Entity chestA = new Entity("Chest A");
         InventoryComponent icA = new InventoryComponent(3);
-        chestA.addComponent(icA);
-        chestA.addComponent(new TaskContentComponent(containerA));
+        chestA.add(icA);
+        chestA.add(new TaskContentComponent(containerA));
         Game.add(chestA);
 
         Entity chestB = new Entity("Chest B");
         InventoryComponent icB = new InventoryComponent(3);
-        chestB.addComponent(icB);
-        chestB.addComponent(new TaskContentComponent(containerB));
+        chestB.add(icB);
+        chestB.add(new TaskContentComponent(containerB));
         Game.add(chestB);
 
         // setup quest items
@@ -608,10 +608,10 @@ public class AnswerPickingFunctionsTest {
         Entity hero = EntityFactory.newHero();
         Game.hero(hero);
         InventoryComponent ic = new InventoryComponent(3);
-        hero.addComponent(ic);
+        hero.add(ic);
         TaskContent containerTaskContent = new Element<>(sc, hero);
         sc.addContainer(containerTaskContent);
-        hero.addComponent(new TaskContentComponent(containerTaskContent));
+        hero.add(new TaskContentComponent(containerTaskContent));
         Game.add(hero);
 
         // setup quest items
@@ -643,10 +643,10 @@ public class AnswerPickingFunctionsTest {
         Entity hero = EntityFactory.newHero();
         Game.hero(hero);
         InventoryComponent ic = new InventoryComponent(3);
-        hero.addComponent(ic);
+        hero.add(ic);
         TaskContent containerTaskContent = new Element<>(sc, hero);
         sc.addContainer(containerTaskContent);
-        hero.addComponent(new TaskContentComponent(containerTaskContent));
+        hero.add(new TaskContentComponent(containerTaskContent));
         Game.add(hero);
 
         // setup quest items
@@ -679,10 +679,10 @@ public class AnswerPickingFunctionsTest {
         Entity hero = EntityFactory.newHero();
         Game.hero(hero);
         InventoryComponent ic = new InventoryComponent(3);
-        hero.addComponent(ic);
+        hero.add(ic);
         TaskContent containerTaskContent = new Element<>(sc, hero);
         sc.addContainer(containerTaskContent);
-        hero.addComponent(new TaskContentComponent(containerTaskContent));
+        hero.add(new TaskContentComponent(containerTaskContent));
         Game.add(hero);
 
         // setup quest items
@@ -712,10 +712,10 @@ public class AnswerPickingFunctionsTest {
         Entity hero = EntityFactory.newHero();
         Game.hero(hero);
         InventoryComponent ic = new InventoryComponent(3);
-        hero.addComponent(ic);
+        hero.add(ic);
         TaskContent containerTaskContent = new Element<>(sc, hero);
         sc.addContainer(containerTaskContent);
-        hero.addComponent(new TaskContentComponent(containerTaskContent));
+        hero.add(new TaskContentComponent(containerTaskContent));
         Game.add(hero);
 
         // setup quest items
@@ -746,10 +746,10 @@ public class AnswerPickingFunctionsTest {
         Entity hero = EntityFactory.newHero();
         Game.hero(hero);
         InventoryComponent ic = new InventoryComponent(3);
-        hero.addComponent(ic);
+        hero.add(ic);
         TaskContent containerTaskContent = new Element<>(sc, hero);
         sc.addContainer(containerTaskContent);
-        hero.addComponent(new TaskContentComponent(containerTaskContent));
+        hero.add(new TaskContentComponent(containerTaskContent));
         Game.add(hero);
 
         // setup quest items
@@ -778,10 +778,10 @@ public class AnswerPickingFunctionsTest {
         Entity hero = EntityFactory.newHero();
         Game.hero(hero);
         InventoryComponent ic = new InventoryComponent(3);
-        hero.addComponent(ic);
+        hero.add(ic);
         TaskContent containerTaskContent = new Element<>(sc, hero);
         sc.addContainer(containerTaskContent);
-        hero.addComponent(new TaskContentComponent(containerTaskContent));
+        hero.add(new TaskContentComponent(containerTaskContent));
         Game.add(hero);
 
         // setup quest items

--- a/dungeon/test/task/TaskContentDoorOpenerTest.java
+++ b/dungeon/test/task/TaskContentDoorOpenerTest.java
@@ -44,7 +44,7 @@ public class TaskContentDoorOpenerTest {
                 null; // = GeneratorUtils.doorAt(tuple.a().level(), tuple.b()).orElseThrow();
         door.close();
         DoorComponent dc = new DoorComponent(Set.of(door));
-        manager.addComponent(dc);
+        manager.add(dc);
         taskComponent.onActivate(TaskComponent.DOOR_OPENER);
         task.state(Task.TaskState.ACTIVE);
         assertTrue(door.isOpen());

--- a/game/src/contrib/components/InteractionComponent.java
+++ b/game/src/contrib/components/InteractionComponent.java
@@ -71,7 +71,7 @@ public final class InteractionComponent implements Component {
      */
     public void triggerInteraction(final Entity entity, final Entity who) {
         onInteraction.accept(entity, who);
-        if (!repeatable) entity.removeComponent(InteractionComponent.class);
+        if (!repeatable) entity.remove(InteractionComponent.class);
     }
 
     /**

--- a/game/src/contrib/entities/HeroFactory.java
+++ b/game/src/contrib/entities/HeroFactory.java
@@ -45,11 +45,11 @@ public class HeroFactory {
     public static Entity newHero() throws IOException {
         Entity hero = new Entity("hero");
         CameraComponent cc = new CameraComponent();
-        hero.addComponent(cc);
+        hero.add(cc);
         PositionComponent poc = new PositionComponent();
-        hero.addComponent(poc);
-        hero.addComponent(new VelocityComponent(X_SPEED_HERO, Y_SPEED_HERO));
-        hero.addComponent(new DrawComponent(HERO_FILE_PATH));
+        hero.add(poc);
+        hero.add(new VelocityComponent(X_SPEED_HERO, Y_SPEED_HERO));
+        hero.add(new DrawComponent(HERO_FILE_PATH));
         HealthComponent hc =
                 new HealthComponent(
                         HERO_HP,
@@ -66,12 +66,12 @@ public class HeroFactory {
 
                             // relink components for camera
                             Entity cameraDummy = new Entity();
-                            cameraDummy.addComponent(cc);
-                            cameraDummy.addComponent(poc);
+                            cameraDummy.add(cc);
+                            cameraDummy.add(poc);
                             Game.add(cameraDummy);
                         });
-        hero.addComponent(hc);
-        hero.addComponent(
+        hero.add(hc);
+        hero.add(
                 new CollideComponent(
                         (you, other, direction) ->
                                 other.fetch(SpikyComponent.class)
@@ -90,9 +90,9 @@ public class HeroFactory {
                         (you, other, direction) -> {}));
 
         PlayerComponent pc = new PlayerComponent();
-        hero.addComponent(pc);
+        hero.add(pc);
         InventoryComponent ic = new InventoryComponent(DEFAULT_INVENTORY_SIZE);
-        hero.addComponent(ic);
+        hero.add(ic);
         Skill fireball =
                 new Skill(new FireballSkill(SkillTools::cursorPositionAsPoint), FIREBALL_COOL_DOWN);
 
@@ -152,12 +152,11 @@ public class HeroFactory {
                     if (uiComponent != null) {
                         if (uiComponent.dialog() instanceof GUICombination) {
                             InventoryGUI.inHeroInventory = false;
-                            e.removeComponent(UIComponent.class);
+                            e.remove(UIComponent.class);
                         }
                     } else {
                         InventoryGUI.inHeroInventory = true;
-                        e.addComponent(
-                                new UIComponent(new GUICombination(new InventoryGUI(ic)), true));
+                        e.add(new UIComponent(new GUICombination(new InventoryGUI(ic)), true));
                     }
                 },
                 false,
@@ -198,7 +197,7 @@ public class HeroFactory {
                                     .orElse(null);
                     if (firstUI != null) {
                         InventoryGUI.inHeroInventory = false;
-                        firstUI.a().removeComponent(UIComponent.class);
+                        firstUI.a().remove(UIComponent.class);
                         if (firstUI.a().componentStream().findAny().isEmpty()) {
                             Game.remove(firstUI.a()); // delete unused Entity
                         }

--- a/game/src/contrib/entities/MiscFactory.java
+++ b/game/src/contrib/entities/MiscFactory.java
@@ -65,12 +65,12 @@ public class MiscFactory {
         final float defaultInteractionRadius = 1f;
         Entity chest = new Entity("chest");
 
-        if (position == null) chest.addComponent(new PositionComponent());
-        else chest.addComponent(new PositionComponent(position));
+        if (position == null) chest.add(new PositionComponent());
+        else chest.add(new PositionComponent(position));
         InventoryComponent ic = new InventoryComponent(item.size());
-        chest.addComponent(ic);
+        chest.add(ic);
         item.forEach(ic::add);
-        chest.addComponent(
+        chest.add(
                 new InteractionComponent(
                         defaultInteractionRadius,
                         true,
@@ -128,7 +128,7 @@ public class MiscFactory {
                                                                                                                 .OPEN_EMPTY);
                                                                                     }
                                                                                 }));
-                                                interactor.addComponent(uiComponent);
+                                                interactor.add(uiComponent);
                                             });
                             interacted
                                     .fetch(DrawComponent.class)
@@ -155,7 +155,7 @@ public class MiscFactory {
         // reset Idle Animation
         dc.deQueueByPriority(CoreAnimations.IDLE.priority());
         dc.currentAnimation(CoreAnimations.IDLE);
-        chest.addComponent(dc);
+        chest.add(dc);
 
         return chest;
     }
@@ -168,10 +168,10 @@ public class MiscFactory {
      */
     public static Entity newCraftingCauldron() throws IOException {
         Entity cauldron = new Entity("cauldron");
-        cauldron.addComponent(new PositionComponent());
-        cauldron.addComponent(new DrawComponent("objects/cauldron"));
-        cauldron.addComponent(new CollideComponent());
-        cauldron.addComponent(
+        cauldron.add(new PositionComponent());
+        cauldron.add(new DrawComponent("objects/cauldron"));
+        cauldron.add(new CollideComponent());
+        cauldron.add(
                 new InteractionComponent(
                         1f,
                         true,
@@ -187,7 +187,7 @@ public class MiscFactory {
                                                                             craftingGUI),
                                                                     true);
                                                     component.onClose(craftingGUI::cancel);
-                                                    who.addComponent(component);
+                                                    who.add(component);
                                                 })));
         return cauldron;
     }

--- a/game/src/contrib/entities/MonsterFactory.java
+++ b/game/src/contrib/entities/MonsterFactory.java
@@ -89,7 +89,7 @@ public class MonsterFactory {
             ItemDataGenerator itemDataGenerator = new ItemDataGenerator();
             Item item = itemDataGenerator.generateItemData();
             InventoryComponent ic = new InventoryComponent(1);
-            monster.addComponent(ic);
+            monster.add(ic);
             ic.add(item);
             onDeath =
                     (e, who) -> {
@@ -99,22 +99,22 @@ public class MonsterFactory {
         } else {
             onDeath = (e, who) -> playMonsterDieSound();
         }
-        monster.addComponent(new HealthComponent(health, (e) -> onDeath.accept(e, null)));
-        monster.addComponent(new PositionComponent());
-        monster.addComponent(
+        monster.add(new HealthComponent(health, (e) -> onDeath.accept(e, null)));
+        monster.add(new PositionComponent());
+        monster.add(
                 new AIComponent(
                         AIFactory.generateRandomFightAI(),
                         AIFactory.generateRandomIdleAI(),
                         AIFactory.generateRandomTransitionAI(monster)));
-        monster.addComponent(new DrawComponent(pathToTexture));
-        monster.addComponent(new VelocityComponent(speed, speed));
-        monster.addComponent(new CollideComponent());
-        monster.addComponent(
+        monster.add(new DrawComponent(pathToTexture));
+        monster.add(new VelocityComponent(speed, speed));
+        monster.add(new CollideComponent());
+        monster.add(
                 new SpikyComponent(
                         MONSTER_COLLIDE_DAMAGE,
                         MONSTER_COLLIDE_DAMAGE_TYPE,
                         MONSTER_COLLIDE_COOL_DOWN));
-        monster.addComponent(new IdleSoundComponent(randomMonsterIdleSound()));
+        monster.add(new IdleSoundComponent(randomMonsterIdleSound()));
         return monster;
     }
 

--- a/game/src/contrib/entities/WorldItemBuilder.java
+++ b/game/src/contrib/entities/WorldItemBuilder.java
@@ -21,11 +21,11 @@ public class WorldItemBuilder {
      */
     public static Entity buildWorldItem(Item item) {
         Entity droppedItem = new Entity();
-        droppedItem.addComponent(new PositionComponent(PositionComponent.ILLEGAL_POSITION));
-        droppedItem.addComponent(new DrawComponent(item.worldAnimation()));
-        droppedItem.addComponent(new ItemComponent(item));
+        droppedItem.add(new PositionComponent(PositionComponent.ILLEGAL_POSITION));
+        droppedItem.add(new DrawComponent(item.worldAnimation()));
+        droppedItem.add(new ItemComponent(item));
 
-        droppedItem.addComponent(
+        droppedItem.add(
                 new InteractionComponent(
                         Constants.DEFAULT_ITEM_PICKUP_RADIUS, true, item::collect));
 

--- a/game/src/contrib/hud/UITools.java
+++ b/game/src/contrib/hud/UITools.java
@@ -43,7 +43,7 @@ public class UITools {
      * @param entity entity that stores the {@link UIComponent} with the UI-Elements
      */
     public static void show(Supplier<Dialog> provider, Entity entity) {
-        entity.addComponent(new UIComponent(provider.get(), true));
+        entity.add(new UIComponent(provider.get(), true));
     }
 
     /**

--- a/game/src/contrib/systems/HealthbarSystem.java
+++ b/game/src/contrib/systems/HealthbarSystem.java
@@ -56,7 +56,7 @@ public final class HealthbarSystem extends System {
                     Container<ProgressBar> group = new Container<>(newHealthbar);
                     // disabling layout enforcing from parent
                     group.setLayoutEnabled(false);
-                    e.addComponent(new UIComponent(group, false, false));
+                    e.add(new UIComponent(group, false, false));
                     Game.add(e);
                     LOGGER.log(CustomLogLevel.TRACE, "created a new UIComponent for the Healthbar");
                     healthbarMapping.put(x.id(), newHealthbar);

--- a/game/src/contrib/utils/components/Debugger.java
+++ b/game/src/contrib/utils/components/Debugger.java
@@ -171,17 +171,17 @@ public class Debugger {
             Entity monster = new Entity("Debug Monster");
 
             // Add components to the monster entity
-            monster.addComponent(new PositionComponent(position));
+            monster.add(new PositionComponent(position));
             try {
-                monster.addComponent(new DrawComponent("character/monster/chort"));
+                monster.add(new DrawComponent("character/monster/chort"));
             } catch (IOException e) {
                 LOGGER.warning(
                         "The DrawComponent for the chort cant be created. " + e.getMessage());
             }
-            monster.addComponent(new VelocityComponent(0.1f, 0.1f));
-            monster.addComponent(new HealthComponent());
-            monster.addComponent(new CollideComponent());
-            monster.addComponent(
+            monster.add(new VelocityComponent(0.1f, 0.1f));
+            monster.add(new HealthComponent());
+            monster.add(new CollideComponent());
+            monster.add(
                     new AIComponent(
                             new CollideAI(1), new RadiusWalk(5, 1), new SelfDefendTransition()));
 

--- a/game/src/contrib/utils/components/skill/DamageProjectile.java
+++ b/game/src/contrib/utils/components/skill/DamageProjectile.java
@@ -132,10 +132,10 @@ public abstract class DamageProjectile implements Consumer<Entity> {
                                 () ->
                                         MissingComponentException.build(
                                                 entity, PositionComponent.class));
-        projectile.addComponent(new PositionComponent(epc.position()));
+        projectile.add(new PositionComponent(epc.position()));
 
         try {
-            projectile.addComponent(new DrawComponent(pathToTexturesOfProjectile));
+            projectile.add(new DrawComponent(pathToTexturesOfProjectile));
         } catch (IOException e) {
             LOGGER.warning(
                     "The DrawComponent for the projectile "
@@ -164,10 +164,10 @@ public abstract class DamageProjectile implements Consumer<Entity> {
 
         // Add the VelocityComponent to the projectile
         VelocityComponent vc = new VelocityComponent(velocity.x, velocity.y, onWallHit);
-        projectile.addComponent(vc);
+        projectile.add(vc);
 
         // Add the ProjectileComponent with the initial and target positions to the projectile
-        projectile.addComponent(new ProjectileComponent(startPoint, targetPoint));
+        projectile.add(new ProjectileComponent(startPoint, targetPoint));
 
         // Create a collision handler for the projectile
         TriConsumer<Entity, Entity, Tile.Direction> collide =
@@ -188,7 +188,7 @@ public abstract class DamageProjectile implements Consumer<Entity> {
 
         // Add the CollideComponent with the appropriate hitbox size and collision handler to the
         // projectile
-        projectile.addComponent(
+        projectile.add(
                 new CollideComponent(new Point(0.25f, 0.25f), projectileHitboxSize, collide, null));
         Game.add(projectile);
         playSound();

--- a/game/src/core/Component.java
+++ b/game/src/core/Component.java
@@ -5,8 +5,8 @@ package core;
  *
  * <p>This interface needs to be implemented by each component.
  *
- * <p>Each component can be linked to zero to n entities. Use {@link Entity#addComponent(Component)}
- * to register a component at an entity.
+ * <p>Each component can be linked to zero to n entities. Use {@link Entity#add(Component)} to
+ * register a component at an entity.
  *
  * <p>Components are used to describe an entity. {@link System}s will check the components of an
  * entity and decide if they want to process the entity. The systems will then modify the values of

--- a/game/src/core/Entity.java
+++ b/game/src/core/Entity.java
@@ -13,37 +13,39 @@ import java.util.stream.Stream;
 /**
  * An Entity is a container for {@link Component}s.
  *
- * <p>A new entity will automatically register itself with the {@link Game} via {@link Game#add} and
- * will be added to the game on the next frame.
+ * <p>An entity needs to be registered with the {@link Game} via {@link Game#add}.
  *
  * <p>Add different components to an entity to define it. Based on the components inside an entity,
  * the {@link System}s will decide whether to process the entity.
  *
- * <p>Use {@link #addComponent} to add a Component to this entity. Normally, a component will add
- * itself to its associated entity, so you will not have to do it manually. Remember that an entity
- * can only store one component of each component class. For example, your entity can't have two
- * {@link core.components.DrawComponent}s.
+ * <p>Use {@link #add} to add a Component to this entity. Remember that an entity can only store one
+ * component of each component class. For example, your entity can't have two {@link
+ * core.components.DrawComponent}s.
  *
- * <p>If you want to remove a component from an entity, use {@link #removeComponent} and provide the
- * Class of the component you want to remove as a parameter.
+ * <p>If you want to remove a component from an entity, use {@link #remove} and provide the Class of
+ * the component you want to remove as a parameter.
  *
- * <p>With {@link #fetch}, you can check if the entity has a component of the given class.
+ * <p>Use {@link #fetch(Class)} to retrieve the component of the given class in this entity.
+ *
+ * <p>With {@link #isPresent(Class)}, you can check if the entity has a component of the given
+ * class.
  *
  * @see Component
  * @see System
- * @see Optional
  */
 @DSLType(name = "entity")
 @DSLContextPush(name = "entity")
 public final class Entity implements Comparable<Entity> {
-    private static final Logger LOGGER = Logger.getLogger(Entity.class.getName());
+    private static final Logger LOGGER = Logger.getLogger(Entity.class.getSimpleName());
     private static int nextId = 0;
     private final int id;
-    private String name;
     private final HashMap<Class<? extends Component>, Component> components;
+    private String name;
 
     /**
-     * Create a new Entity you have to register it in {@link Game} using {@link Game#add}.
+     * Create a new Entity.
+     *
+     * <p>Remember to register it in {@link Game} using {@link Game#add}.
      *
      * @param name the name of the entity, used for better logging and debugging
      */
@@ -55,7 +57,9 @@ public final class Entity implements Comparable<Entity> {
     }
 
     /**
-     * Create a new Entity and register it in {@link Game} using {@link Game#add}.
+     * Create a new Entity.
+     *
+     * <p>Remember to register it in {@link Game} using {@link Game#add}.
      *
      * <p>The name of the entity will be its id
      */
@@ -69,12 +73,11 @@ public final class Entity implements Comparable<Entity> {
      * <p>Changes in the component map of the entity will trigger a call to {@link
      * ECSManagment#informAboutChanges}.
      *
-     * <p>Normally, a component will add itself to its associated entity, so you will not have to do
-     * it manually. Remember that an entity can only store one component of each component class.
+     * <p>Remember that an entity can only store one component of each component class.
      *
      * @param component The component to add
      */
-    public void addComponent(final Component component) {
+    public void add(final Component component) {
         components.put(component.getClass(), component);
         ECSManagment.informAboutChanges(this);
         LOGGER.info(component.getClass().getName() + " Components from " + this + " was added.");
@@ -88,7 +91,7 @@ public final class Entity implements Comparable<Entity> {
      *
      * @param klass the Class of the component
      */
-    public void removeComponent(final Class<? extends Component> klass) {
+    public void remove(final Class<? extends Component> klass) {
         if (components.remove(klass) != null) {
             ECSManagment.informAboutChanges(this);
             LOGGER.info(klass.getName() + " from " + name + " was removed.");
@@ -96,10 +99,11 @@ public final class Entity implements Comparable<Entity> {
     }
 
     /**
-     * Get the component
+     * Get the component.
      *
-     * @param klass Class of the component
-     * @return Optional that can contain the requested component
+     * @param klass Class of the component.
+     * @return Optional that can contain the requested component, is empty if this entity does not
+     *     store a component of the given class.
      * @see Optional
      */
     public <T extends Component> Optional<T> fetch(final Class<T> klass) {

--- a/game/test/contrib/components/CollisionComponentTest.java
+++ b/game/test/contrib/components/CollisionComponentTest.java
@@ -22,10 +22,10 @@ public class CollisionComponentTest {
     public void onEnterNoMethod() {
         Entity e1 = new Entity();
         CollideComponent hb1 = new CollideComponent(null, null);
-        e1.addComponent(hb1);
+        e1.add(hb1);
         Entity e2 = new Entity();
         CollideComponent hb2 = new CollideComponent(null, null);
-        e2.addComponent(hb2);
+        e2.add(hb2);
         hb1.onEnter(e1, e2, Tile.Direction.N);
     }
 
@@ -45,8 +45,8 @@ public class CollisionComponentTest {
                 new CollideComponent(
                         (a, b, c) -> counterE2Enter.inc(), (a, b, c) -> counterE2Leave.inc());
 
-        e1.addComponent(hb1);
-        e2.addComponent(hb2);
+        e1.add(hb1);
+        e2.add(hb2);
         hb1.onEnter(e1, e2, Tile.Direction.N);
 
         assertEquals("Der Counter von Entität 1 Enter soll ", 1, counterE1Enter.getCount());
@@ -63,8 +63,8 @@ public class CollisionComponentTest {
         Entity e2 = new Entity();
         CollideComponent hb2 = new CollideComponent(null, null);
 
-        e1.addComponent(hb1);
-        e2.addComponent(hb2);
+        e1.add(hb1);
+        e2.add(hb2);
         hb1.onLeave(e1, e2, Tile.Direction.N);
     }
 
@@ -84,8 +84,8 @@ public class CollisionComponentTest {
                 new CollideComponent(
                         (a, b, c) -> counterE2Enter.inc(), (a, b, c) -> counterE2Leave.inc());
 
-        e1.addComponent(hb1);
-        e2.addComponent(hb2);
+        e1.add(hb1);
+        e2.add(hb2);
         hb1.onLeave(e1, e2, Tile.Direction.N);
         assertEquals("Der Counter von Entität 1 Enter soll ", 0, counterE1Enter.getCount());
         assertEquals("Der Counter von Entität 1 Leave soll ", 1, counterE1Leave.getCount());
@@ -100,8 +100,8 @@ public class CollisionComponentTest {
         CollideComponent hb1 = new CollideComponent((a, b, c) -> counterE1Enter.inc(), null);
         Entity e2 = new Entity();
         CollideComponent hb2 = new CollideComponent(null, null);
-        e1.addComponent(hb1);
-        e2.addComponent(hb2);
+        e1.add(hb1);
+        e2.add(hb2);
         hb1.collideEnter(null);
         hb1.onEnter(e1, e2, Tile.Direction.N);
         assertEquals(
@@ -118,8 +118,8 @@ public class CollisionComponentTest {
         CollideComponent hb1 = new CollideComponent((a, b, c) -> counterE1Enter.inc(), null);
         Entity e2 = new Entity();
         CollideComponent hb2 = new CollideComponent(null, null);
-        e1.addComponent(hb1);
-        e2.addComponent(hb2);
+        e1.add(hb1);
+        e2.add(hb2);
         hb1.collideEnter((a, b, c) -> newCounterE1Enter.inc());
         hb1.onEnter(e1, e2, Tile.Direction.N);
         assertEquals(
@@ -136,8 +136,8 @@ public class CollisionComponentTest {
         CollideComponent hb1 = new CollideComponent(null, (a, b, c) -> counterE1Enter.inc());
         Entity e2 = new Entity();
         CollideComponent hb2 = new CollideComponent(null, null);
-        e1.addComponent(hb1);
-        e2.addComponent(hb2);
+        e1.add(hb1);
+        e2.add(hb2);
         hb1.collideLeave(null);
         hb1.onLeave(e1, e2, Tile.Direction.N);
         assertEquals(
@@ -154,8 +154,8 @@ public class CollisionComponentTest {
         CollideComponent hb1 = new CollideComponent(null, (a, b, c) -> counterE1Leave.inc());
         Entity e2 = new Entity();
         CollideComponent hb2 = new CollideComponent(null, null);
-        e1.addComponent(hb1);
-        e2.addComponent(hb2);
+        e1.add(hb1);
+        e2.add(hb2);
         hb1.collideLeave((a, b, c) -> newCounterE1Leave.inc());
         hb1.onLeave(e1, e2, Tile.Direction.N);
         assertEquals(
@@ -172,7 +172,7 @@ public class CollisionComponentTest {
         CollideComponent hb =
                 new CollideComponent(
                         new Point(0, 0), new Point(0, 0), (a, b, c) -> {}, (a, b, c) -> {});
-        e.addComponent(hb);
+        e.add(hb);
         MissingComponentException missingComponentException =
                 assertThrows(MissingComponentException.class, () -> hb.center(e));
         assertTrue(
@@ -196,9 +196,9 @@ public class CollisionComponentTest {
         Point offset = new Point(0, 0);
         Point size = new Point(1, 1);
         TriConsumer<Entity, Entity, Tile.Direction> iCollide = (a, b, c) -> {};
-        e.addComponent(new PositionComponent(position));
+        e.add(new PositionComponent(position));
         CollideComponent hb = new CollideComponent(offset, size, iCollide, iCollide);
-        e.addComponent(hb);
+        e.add(hb);
 
         Point center = hb.center(e);
         assertEquals(0.5f, center.x, DELTA);
@@ -213,9 +213,9 @@ public class CollisionComponentTest {
         Point offset = new Point(0, 0);
         Point size = new Point(1, 1);
         TriConsumer<Entity, Entity, Tile.Direction> iCollide = (a, b, c) -> {};
-        e.addComponent(new PositionComponent(position));
+        e.add(new PositionComponent(position));
         CollideComponent hb = new CollideComponent(offset, size, iCollide, iCollide);
-        e.addComponent(hb);
+        e.add(hb);
 
         Point center = hb.center(e);
         assertEquals(1.5f, center.x, DELTA);
@@ -230,9 +230,9 @@ public class CollisionComponentTest {
         Point offset = new Point(0, 0);
         Point size = new Point(1, 1);
         TriConsumer<Entity, Entity, Tile.Direction> iCollide = (a, b, c) -> {};
-        e.addComponent(new PositionComponent(position));
+        e.add(new PositionComponent(position));
         CollideComponent hb = new CollideComponent(offset, size, iCollide, iCollide);
-        e.addComponent(hb);
+        e.add(hb);
         Point center = hb.center(e);
 
         assertEquals(-.5f, center.x, DELTA);
@@ -247,9 +247,9 @@ public class CollisionComponentTest {
         Point offset = new Point(0, 0);
         Point size = new Point(1, 1);
         TriConsumer<Entity, Entity, Tile.Direction> iCollide = (a, b, c) -> {};
-        e.addComponent(new PositionComponent(position));
+        e.add(new PositionComponent(position));
         CollideComponent hb = new CollideComponent(offset, size, iCollide, iCollide);
-        e.addComponent(hb);
+        e.add(hb);
         Point center = hb.center(e);
 
         assertEquals(1, center.x, DELTA);
@@ -264,9 +264,9 @@ public class CollisionComponentTest {
         Point offset = new Point(-1, -1);
         Point size = new Point(1, 1);
         TriConsumer<Entity, Entity, Tile.Direction> iCollide = (a, b, c) -> {};
-        e.addComponent(new PositionComponent(position));
+        e.add(new PositionComponent(position));
         CollideComponent hb = new CollideComponent(offset, size, iCollide, iCollide);
-        e.addComponent(hb);
+        e.add(hb);
         Point center = hb.center(e);
 
         assertEquals(0, center.x, DELTA);
@@ -281,9 +281,9 @@ public class CollisionComponentTest {
         Point offset = new Point(0, 0);
         Point size = new Point(2, 2);
         TriConsumer<Entity, Entity, Tile.Direction> iCollide = (a, b, c) -> {};
-        e.addComponent(new PositionComponent(position));
+        e.add(new PositionComponent(position));
         CollideComponent hb = new CollideComponent(offset, size, iCollide, iCollide);
-        e.addComponent(hb);
+        e.add(hb);
         Point center = hb.center(e);
 
         assertEquals(.5, center.x, DELTA);
@@ -295,7 +295,7 @@ public class CollisionComponentTest {
     public void getTopRightMissingPosition() {
         Entity e = new Entity();
         CollideComponent hb = new CollideComponent();
-        e.addComponent(hb);
+        e.add(hb);
         MissingComponentException missingComponentException =
                 assertThrows(MissingComponentException.class, () -> hb.topRight(e));
         assertTrue(
@@ -310,9 +310,9 @@ public class CollisionComponentTest {
         Point offset = new Point(0, 0);
         Point size = new Point(1, 1);
         TriConsumer<Entity, Entity, Tile.Direction> iCollide = (a, b, c) -> {};
-        e.addComponent(new PositionComponent(position));
+        e.add(new PositionComponent(position));
         CollideComponent hb = new CollideComponent(offset, size, iCollide, iCollide);
-        e.addComponent(hb);
+        e.add(hb);
         Point center = hb.topRight(e);
 
         assertEquals(1, center.x, DELTA);
@@ -327,9 +327,9 @@ public class CollisionComponentTest {
         Point offset = new Point(0, 0);
         Point size = new Point(2, 2);
         TriConsumer<Entity, Entity, Tile.Direction> iCollide = (a, b, c) -> {};
-        e.addComponent(new PositionComponent(position));
+        e.add(new PositionComponent(position));
         CollideComponent hb = new CollideComponent(offset, size, iCollide, iCollide);
-        e.addComponent(hb);
+        e.add(hb);
         Point center = hb.topRight(e);
 
         assertEquals(2, center.x, DELTA);
@@ -344,9 +344,9 @@ public class CollisionComponentTest {
         Point offset = new Point(0, 0);
         Point size = new Point(1, 1);
         TriConsumer<Entity, Entity, Tile.Direction> iCollide = (a, b, c) -> {};
-        e.addComponent(new PositionComponent(position));
+        e.add(new PositionComponent(position));
         CollideComponent hb = new CollideComponent(offset, size, iCollide, iCollide);
-        e.addComponent(hb);
+        e.add(hb);
         Point center = hb.topRight(e);
 
         assertEquals(3, center.x, DELTA);
@@ -361,9 +361,9 @@ public class CollisionComponentTest {
         Point offset = new Point(1, 2);
         Point size = new Point(1, 1);
         TriConsumer<Entity, Entity, Tile.Direction> iCollide = (a, b, c) -> {};
-        e.addComponent(new PositionComponent(position));
+        e.add(new PositionComponent(position));
         CollideComponent hb = new CollideComponent(offset, size, iCollide, iCollide);
-        e.addComponent(hb);
+        e.add(hb);
         Point center = hb.topRight(e);
 
         assertEquals(2, center.x, DELTA);
@@ -378,9 +378,9 @@ public class CollisionComponentTest {
         Point offset = new Point(2, 4);
         Point size = new Point(1, 1);
         TriConsumer<Entity, Entity, Tile.Direction> iCollide = (a, b, c) -> {};
-        e.addComponent(new PositionComponent(position));
+        e.add(new PositionComponent(position));
         CollideComponent hb = new CollideComponent(offset, size, iCollide, iCollide);
-        e.addComponent(hb);
+        e.add(hb);
         Point center = hb.topRight(e);
 
         assertEquals(6, center.x, DELTA);
@@ -395,9 +395,9 @@ public class CollisionComponentTest {
         Point offset = new Point(2, 4);
         Point size = new Point(3, 3);
         TriConsumer<Entity, Entity, Tile.Direction> iCollide = (a, b, c) -> {};
-        e.addComponent(new PositionComponent(position));
+        e.add(new PositionComponent(position));
         CollideComponent hb = new CollideComponent(offset, size, iCollide, iCollide);
-        e.addComponent(hb);
+        e.add(hb);
         Point center = hb.topRight(e);
 
         assertEquals(8, center.x, DELTA);
@@ -409,7 +409,7 @@ public class CollisionComponentTest {
     public void getBottomLeftMissingPosition() {
         Entity e = new Entity();
         CollideComponent hb = new CollideComponent();
-        e.addComponent(hb);
+        e.add(hb);
         MissingComponentException missingComponentException =
                 assertThrows(MissingComponentException.class, () -> hb.center(e));
         assertTrue(
@@ -424,9 +424,9 @@ public class CollisionComponentTest {
         Point offset = new Point(0, 0);
         Point size = new Point(1, 1);
         TriConsumer<Entity, Entity, Tile.Direction> iCollide = (a, b, c) -> {};
-        e.addComponent(new PositionComponent(position));
+        e.add(new PositionComponent(position));
         CollideComponent hb = new CollideComponent(offset, size, iCollide, iCollide);
-        e.addComponent(hb);
+        e.add(hb);
         Point center = hb.bottomLeft(e);
 
         assertEquals(0, center.x, DELTA);
@@ -441,9 +441,9 @@ public class CollisionComponentTest {
         Point offset = new Point(0, 0);
         Point size = new Point(1, 1);
         TriConsumer<Entity, Entity, Tile.Direction> iCollide = (a, b, c) -> {};
-        e.addComponent(new PositionComponent(position));
+        e.add(new PositionComponent(position));
         CollideComponent hb = new CollideComponent(offset, size, iCollide, iCollide);
-        e.addComponent(hb);
+        e.add(hb);
         Point center = hb.bottomLeft(e);
 
         assertEquals(2, center.x, DELTA);
@@ -458,9 +458,9 @@ public class CollisionComponentTest {
         Point offset = new Point(1, 2);
         Point size = new Point(1, 1);
         TriConsumer<Entity, Entity, Tile.Direction> iCollide = (a, b, c) -> {};
-        e.addComponent(new PositionComponent(position));
+        e.add(new PositionComponent(position));
         CollideComponent hb = new CollideComponent(offset, size, iCollide, iCollide);
-        e.addComponent(hb);
+        e.add(hb);
         Point center = hb.bottomLeft(e);
 
         assertEquals(1, center.x, DELTA);
@@ -475,9 +475,9 @@ public class CollisionComponentTest {
         Point offset = new Point(2, 4);
         Point size = new Point(1, 1);
         TriConsumer<Entity, Entity, Tile.Direction> iCollide = (a, b, c) -> {};
-        e.addComponent(new PositionComponent(position));
+        e.add(new PositionComponent(position));
         CollideComponent hb = new CollideComponent(offset, size, iCollide, iCollide);
-        e.addComponent(hb);
+        e.add(hb);
         Point center = hb.bottomLeft(e);
 
         assertEquals(5, center.x, DELTA);

--- a/game/test/contrib/components/HealthComponentTest.java
+++ b/game/test/contrib/components/HealthComponentTest.java
@@ -21,7 +21,7 @@ public class HealthComponentTest {
         Game.removeAllEntities();
         Entity entity = new Entity();
         HealthComponent hc = new HealthComponent();
-        entity.addComponent(hc);
+        entity.add(hc);
         Damage fdmg = new Damage(3, DamageType.FIRE, null);
         Damage fdmg2 = new Damage(5, DamageType.FIRE, null);
         Damage mdmg = new Damage(-1, DamageType.MAGIC, null);
@@ -43,7 +43,7 @@ public class HealthComponentTest {
         Entity damager = new Entity();
         Entity damager2 = new Entity();
         HealthComponent hc = new HealthComponent();
-        entity.addComponent(hc);
+        entity.add(hc);
         Damage dmg = new Damage(3, DamageType.FIRE, damager);
         Damage dmg2 = new Damage(5, DamageType.FIRE, damager2);
         hc.receiveHit(dmg);
@@ -58,7 +58,7 @@ public class HealthComponentTest {
         Game.removeAllEntities();
         Entity entity = new Entity();
         HealthComponent hc = new HealthComponent(10, null);
-        entity.addComponent(hc);
+        entity.add(hc);
         assertEquals(10, hc.maximalHealthpoints());
         assertEquals(10, hc.currentHealthpoints());
         hc.maximalHealthpoints(8);
@@ -71,7 +71,7 @@ public class HealthComponentTest {
         Game.removeAllEntities();
         Entity entity = new Entity();
         HealthComponent hc = new HealthComponent(10, null);
-        entity.addComponent(hc);
+        entity.add(hc);
         assertEquals(10, hc.maximalHealthpoints());
         assertEquals(10, hc.currentHealthpoints());
         hc.maximalHealthpoints(12);
@@ -84,7 +84,7 @@ public class HealthComponentTest {
         Game.removeAllEntities();
         Entity entity = new Entity();
         HealthComponent hc = new HealthComponent(10, null);
-        entity.addComponent(hc);
+        entity.add(hc);
         hc.currentHealthpoints(12);
         assertEquals(10, hc.currentHealthpoints());
     }
@@ -94,7 +94,7 @@ public class HealthComponentTest {
         Game.removeAllEntities();
         Entity entity = new Entity();
         HealthComponent hc = new HealthComponent(10, null);
-        entity.addComponent(hc);
+        entity.add(hc);
         hc.currentHealthpoints(8);
         assertEquals(8, hc.currentHealthpoints());
     }
@@ -105,7 +105,7 @@ public class HealthComponentTest {
         Entity entity = new Entity();
         Consumer<Entity> onDeathFunction = Mockito.mock(Consumer.class);
         HealthComponent hc = new HealthComponent(10, onDeathFunction);
-        entity.addComponent(hc);
+        entity.add(hc);
         hc.triggerOnDeath(entity);
         Mockito.verify(onDeathFunction, times(1)).accept(entity);
     }

--- a/game/test/contrib/components/InteractionComponentTest.java
+++ b/game/test/contrib/components/InteractionComponentTest.java
@@ -17,7 +17,7 @@ public class InteractionComponentTest {
     public void createSimpleConstructor() {
         Entity e = new Entity();
         InteractionComponent component = new InteractionComponent();
-        e.addComponent(component);
+        e.add(component);
         assertEquals(InteractionComponent.DEFAULT_INTERACTION_RADIUS, component.radius(), 0.0001);
     }
 
@@ -30,7 +30,7 @@ public class InteractionComponentTest {
         BiConsumer<Entity, Entity> iInteraction = Mockito.mock(BiConsumer.class);
 
         InteractionComponent component = new InteractionComponent(radius, repeat, iInteraction);
-        e.addComponent(component);
+        e.add(component);
 
         assertEquals(radius, component.radius(), 0.0001);
     }
@@ -41,7 +41,7 @@ public class InteractionComponentTest {
         BiConsumer<Entity, Entity> iInteraction = Mockito.mock(BiConsumer.class);
         Entity e = new Entity();
         InteractionComponent component = new InteractionComponent(1, true, iInteraction);
-        e.addComponent(component);
+        e.add(component);
         component.triggerInteraction(e, null);
         verify(iInteraction).accept(e, null);
         assertTrue(e.fetch(InteractionComponent.class).isPresent());
@@ -53,7 +53,7 @@ public class InteractionComponentTest {
         BiConsumer<Entity, Entity> iInteraction = Mockito.mock(BiConsumer.class);
         Entity e = new Entity();
         InteractionComponent component = new InteractionComponent(1, false, iInteraction);
-        e.addComponent(component);
+        e.add(component);
         component.triggerInteraction(e, null);
         verify(iInteraction).accept(e, null);
         assertFalse(e.fetch(InteractionComponent.class).isPresent());
@@ -67,9 +67,9 @@ public class InteractionComponentTest {
         Entity e = new Entity();
         Entity e2 = new Entity();
         InteractionComponent component = new InteractionComponent(1, true, iInteraction);
-        e.addComponent(component);
+        e.add(component);
         InteractionComponent component2 = new InteractionComponent(1, true, iInteraction2);
-        e2.addComponent(component2);
+        e2.add(component2);
         component.triggerInteraction(e, null);
         verify(iInteraction2, never()).accept(e, null);
     }
@@ -82,9 +82,9 @@ public class InteractionComponentTest {
         Entity e = new Entity();
         Entity e2 = new Entity();
         InteractionComponent component = new InteractionComponent(1, false, iInteraction);
-        e.addComponent(component);
+        e.add(component);
         InteractionComponent component2 = new InteractionComponent(1, false, iInteraction2);
-        e2.addComponent(component2);
+        e2.add(component2);
         component.triggerInteraction(e, null);
         assertTrue(e2.fetch(InteractionComponent.class).isPresent());
     }

--- a/game/test/contrib/components/InventoryComponentTest.java
+++ b/game/test/contrib/components/InventoryComponentTest.java
@@ -33,7 +33,7 @@ public class InventoryComponentTest {
 
         Entity e = new Entity();
         InventoryComponent ic = new InventoryComponent(1);
-        e.addComponent(ic);
+        e.add(ic);
         assertEquals(0, ic.count());
     }
 
@@ -42,7 +42,7 @@ public class InventoryComponentTest {
     public void addItemValid() {
         Entity e = new Entity();
         InventoryComponent ic = new InventoryComponent(1);
-        e.addComponent(ic);
+        e.add(ic);
         Item itemData =
                 new Item(
                         "Test item",
@@ -59,7 +59,7 @@ public class InventoryComponentTest {
     public void addItemValidMultiple() {
         Entity e = new Entity();
         InventoryComponent ic = new InventoryComponent(3);
-        e.addComponent(ic);
+        e.add(ic);
         ic.add(
                 new Item(
                         "Test item",
@@ -80,7 +80,7 @@ public class InventoryComponentTest {
     public void addItemOverSize() {
         Entity e = new Entity();
         InventoryComponent ic = new InventoryComponent(1);
-        e.addComponent(ic);
+        e.add(ic);
         ic.add(
                 new Item(
                         "Test item",
@@ -100,7 +100,7 @@ public class InventoryComponentTest {
     public void removeItemExisting() {
         Entity e = new Entity();
         InventoryComponent ic = new InventoryComponent(1);
-        e.addComponent(ic);
+        e.add(ic);
         Item itemData =
                 new Item(
                         "Test item",
@@ -117,7 +117,7 @@ public class InventoryComponentTest {
     public void removeItemTwice() {
         Entity e = new Entity();
         InventoryComponent ic = new InventoryComponent(1);
-        e.addComponent(ic);
+        e.add(ic);
         Item itemData =
                 new Item(
                         "Test item",
@@ -135,7 +135,7 @@ public class InventoryComponentTest {
     public void removeItemNull() {
         Entity e = new Entity();
         InventoryComponent ic = new InventoryComponent(1);
-        e.addComponent(ic);
+        e.add(ic);
         Item itemData =
                 new Item(
                         "Test item",
@@ -152,7 +152,7 @@ public class InventoryComponentTest {
     public void getAllItemsEmptyInventory() {
         Entity e = new Entity();
         InventoryComponent ic = new InventoryComponent(0);
-        e.addComponent(ic);
+        e.add(ic);
         assertEquals("should have no Items", 0, ic.count());
     }
 
@@ -161,7 +161,7 @@ public class InventoryComponentTest {
     public void getAllItemsInventoryWithOnlyOneItem() {
         Entity e = new Entity();
         InventoryComponent ic = new InventoryComponent(1);
-        e.addComponent(ic);
+        e.add(ic);
         Item itemData =
                 new Item(
                         "Test item",
@@ -178,7 +178,7 @@ public class InventoryComponentTest {
     public void getAllItemsInventoryWithTwoItems() {
         Entity e = new Entity();
         InventoryComponent ic = new InventoryComponent(2);
-        e.addComponent(ic);
+        e.add(ic);
         Item itemData1 =
                 new Item(
                         "Test item",
@@ -202,7 +202,7 @@ public class InventoryComponentTest {
     public void getAllItemsInventoryNoAddedItemButCreated() {
         Entity e = new Entity();
         InventoryComponent ic = new InventoryComponent(1);
-        e.addComponent(ic);
+        e.add(ic);
         Item itemData =
                 new Item(
                         "Test item",

--- a/game/test/contrib/systems/AISystemTest.java
+++ b/game/test/contrib/systems/AISystemTest.java
@@ -24,7 +24,7 @@ public class AISystemTest {
         system = new AISystem();
         Game.add(system);
         entity = new Entity();
-        entity.addComponent(
+        entity.add(
                 new AIComponent(
                         null,
                         e -> {},

--- a/game/test/contrib/systems/CollisionSystemTest.java
+++ b/game/test/contrib/systems/CollisionSystemTest.java
@@ -58,7 +58,7 @@ public class CollisionSystemTest {
      */
     private static Entity prepareEntityWithPosition(Point point1) {
         Entity e1 = new Entity();
-        e1.addComponent(new PositionComponent(point1));
+        e1.add(new PositionComponent(point1));
 
         return e1;
     }
@@ -85,8 +85,8 @@ public class CollisionSystemTest {
         CollideComponent hb2 =
                 new CollideComponent(new Point(offset), new Point(size), collider, collider);
 
-        e1.addComponent(hb1);
-        e2.addComponent(hb2);
+        e1.add(hb1);
+        e2.add(hb2);
         Game.add(e1);
         Game.add(e2);
         assertTrue(COLLISION_DETECTED_MESSSAGE, cs.checkForCollision(e1, hb1, e2, hb2));
@@ -122,8 +122,8 @@ public class CollisionSystemTest {
         CollideComponent hb2 =
                 new CollideComponent(new Point(offset), new Point(size), collider, collider);
 
-        e1.addComponent(hb1);
-        e2.addComponent(hb2);
+        e1.add(hb1);
+        e2.add(hb2);
         Game.add(e1);
         Game.add(e2);
         assertFalse(NO_COLLISION_DETECTION_MESSAGE, cs.checkForCollision(e1, hb1, e2, hb2));
@@ -156,8 +156,8 @@ public class CollisionSystemTest {
         CollideComponent hb2 =
                 new CollideComponent(new Point(offset), new Point(size), collider, collider);
 
-        e1.addComponent(hb1);
-        e2.addComponent(hb2);
+        e1.add(hb1);
+        e2.add(hb2);
         Game.add(e1);
         Game.add(e2);
         assertTrue(COLLISION_DETECTED_MESSSAGE, cs.checkForCollision(e1, hb1, e2, hb2));
@@ -190,8 +190,8 @@ public class CollisionSystemTest {
         CollideComponent hb2 =
                 new CollideComponent(new Point(offset), new Point(size), collider, collider);
 
-        e1.addComponent(hb1);
-        e2.addComponent(hb2);
+        e1.add(hb1);
+        e2.add(hb2);
         Game.add(e1);
         Game.add(e2);
         assertFalse(NO_COLLISION_DETECTION_MESSAGE, cs.checkForCollision(e1, hb1, e2, hb2));
@@ -220,8 +220,8 @@ public class CollisionSystemTest {
         CollideComponent hb2 =
                 new CollideComponent(new Point(offset), new Point(size), collider, collider);
 
-        e1.addComponent(hb1);
-        e2.addComponent(hb2);
+        e1.add(hb1);
+        e2.add(hb2);
         Game.add(e1);
         Game.add(e2);
         assertTrue(COLLISION_DETECTED_MESSSAGE, cs.checkForCollision(e1, hb1, e2, hb2));
@@ -251,8 +251,8 @@ public class CollisionSystemTest {
         CollideComponent hb2 =
                 new CollideComponent(new Point(offset), new Point(size), collider, collider);
 
-        e1.addComponent(hb1);
-        e2.addComponent(hb2);
+        e1.add(hb1);
+        e2.add(hb2);
         Game.add(e1);
         Game.add(e2);
         assertFalse(NO_COLLISION_DETECTION_MESSAGE, cs.checkForCollision(e1, hb1, e2, hb2));
@@ -281,8 +281,8 @@ public class CollisionSystemTest {
         CollideComponent hb2 =
                 new CollideComponent(new Point(offset), new Point(size), collider, collider);
 
-        e1.addComponent(hb1);
-        e2.addComponent(hb2);
+        e1.add(hb1);
+        e2.add(hb2);
         Game.add(e1);
         Game.add(e2);
         assertTrue(COLLISION_DETECTED_MESSSAGE, cs.checkForCollision(e1, hb1, e2, hb2));
@@ -312,8 +312,8 @@ public class CollisionSystemTest {
         CollideComponent hb2 =
                 new CollideComponent(new Point(offset), new Point(size), collider, collider);
 
-        e1.addComponent(hb1);
-        e2.addComponent(hb2);
+        e1.add(hb1);
+        e2.add(hb2);
         Game.add(e1);
         Game.add(e2);
         assertFalse(NO_COLLISION_DETECTION_MESSAGE, cs.checkForCollision(e1, hb1, e2, hb2));
@@ -344,8 +344,8 @@ public class CollisionSystemTest {
                 new CollideComponent(
                         new Point(new Point(0, 0)), new Point(new Point(1, 1)), collider, collider);
 
-        e1.addComponent(hb1);
-        e2.addComponent(hb2);
+        e1.add(hb1);
+        e2.add(hb2);
         Game.add(e1);
         Game.add(e2);
         assertTrue(COLLISION_DETECTED_MESSSAGE, cs.checkForCollision(e1, hb1, e2, hb2));
@@ -375,8 +375,8 @@ public class CollisionSystemTest {
                         collider,
                         collider);
 
-        e1.addComponent(hb1);
-        e2.addComponent(hb2);
+        e1.add(hb1);
+        e2.add(hb2);
         Game.add(e1);
         Game.add(e2);
         assertTrue(COLLISION_DETECTED_MESSSAGE, cs.checkForCollision(e1, hb1, e2, hb2));
@@ -455,7 +455,7 @@ public class CollisionSystemTest {
         Entity e1 = prepareEntityWithPosition(new Point(0, 0));
         SimpleCounter sc1OnEnter = new SimpleCounter();
         SimpleCounter sc1OnLeave = new SimpleCounter();
-        e1.addComponent(
+        e1.add(
                 new CollideComponent(
                         new Point(0, 0),
                         new Point(1, 1),
@@ -476,7 +476,7 @@ public class CollisionSystemTest {
         Entity e1 = prepareEntityWithPosition(new Point(0, 0));
         SimpleCounter sc1OnEnter = new SimpleCounter();
         SimpleCounter sc1OnLeave = new SimpleCounter();
-        e1.addComponent(
+        e1.add(
                 new CollideComponent(
                         new Point(0, 0),
                         new Point(1, 1),
@@ -485,7 +485,7 @@ public class CollisionSystemTest {
         Entity e2 = prepareEntityWithPosition(new Point(1, 1));
         SimpleCounter sc2OnEnter = new SimpleCounter();
         SimpleCounter sc2OnLeave = new SimpleCounter();
-        e2.addComponent(
+        e2.add(
                 new CollideComponent(
                         new Point(0, 0),
                         new Point(1, 1),

--- a/game/test/contrib/systems/HealthSystemTest.java
+++ b/game/test/contrib/systems/HealthSystemTest.java
@@ -35,8 +35,8 @@ public class HealthSystemTest {
         Consumer<Entity> onDeath = Mockito.mock(Consumer.class);
         DrawComponent ac = new DrawComponent(ANIMATION_PATH);
         HealthComponent component = new HealthComponent(1, onDeath);
-        entity.addComponent(ac);
-        entity.addComponent(component);
+        entity.add(ac);
+        entity.add(component);
         Game.add(entity);
         HealthSystem system = new HealthSystem();
         Game.add(system);
@@ -55,8 +55,8 @@ public class HealthSystemTest {
         DrawComponent ac = new DrawComponent(ANIMATION_PATH);
         HealthComponent component = new HealthComponent(1, onDeath);
         component.godMode(true);
-        entity.addComponent(ac);
-        entity.addComponent(component);
+        entity.add(ac);
+        entity.add(component);
         Game.add(entity);
         HealthSystem system = new HealthSystem();
         Game.add(system);
@@ -76,8 +76,8 @@ public class HealthSystemTest {
         Consumer<Entity> onDeath = Mockito.mock(Consumer.class);
         DrawComponent ac = new DrawComponent(ANIMATION_PATH);
         HealthComponent component = new HealthComponent(10, onDeath);
-        entity.addComponent(ac);
-        entity.addComponent(component);
+        entity.add(ac);
+        entity.add(component);
         Game.add(entity);
         component.receiveHit(new Damage(5, DamageType.FIRE, null));
         component.receiveHit(new Damage(2, DamageType.FIRE, null));
@@ -96,8 +96,8 @@ public class HealthSystemTest {
         Consumer<Entity> onDeath = Mockito.mock(Consumer.class);
         DrawComponent ac = new DrawComponent(ANIMATION_PATH);
         HealthComponent component = new HealthComponent(10, onDeath);
-        entity.addComponent(ac);
-        entity.addComponent(component);
+        entity.add(ac);
+        entity.add(component);
         Game.add(entity);
         component.currentHealthpoints(3);
         component.receiveHit(new Damage(-3, DamageType.FIRE, null));
@@ -115,8 +115,8 @@ public class HealthSystemTest {
         Consumer<Entity> onDeath = Mockito.mock(Consumer.class);
         DrawComponent ac = new DrawComponent(ANIMATION_PATH);
         HealthComponent component = new HealthComponent(10, onDeath);
-        entity.addComponent(ac);
-        entity.addComponent(component);
+        entity.add(ac);
+        entity.add(component);
         Game.add(entity);
         component.receiveHit(new Damage(0, DamageType.FIRE, null));
         HealthSystem system = new HealthSystem();

--- a/game/test/contrib/utils/components/ai/ProtectOnApproachTest.java
+++ b/game/test/contrib/utils/components/ai/ProtectOnApproachTest.java
@@ -29,10 +29,10 @@ public class ProtectOnApproachTest {
         // Add AI Component
         AIComponent protectedAI =
                 new AIComponent(new CollideAI(0.2f), new RadiusWalk(0, 50), new RangeTransition(2));
-        entity.addComponent(protectedAI);
+        entity.add(protectedAI);
 
         // Add Position Component
-        entity.addComponent(new PositionComponent(pointOfProtect));
+        entity.add(new PositionComponent(pointOfProtect));
 
         // Protecting Entity
         entity = new Entity();
@@ -43,10 +43,10 @@ public class ProtectOnApproachTest {
                         new CollideAI(0.2f),
                         new RadiusWalk(0, 50),
                         new ProtectOnApproach(2f, protectedEntity));
-        entity.addComponent(entityAI);
+        entity.add(entityAI);
 
         // Add Position Component
-        entity.addComponent(new PositionComponent(new Point(0f, 0f)));
+        entity.add(new PositionComponent(new Point(0f, 0f)));
 
         // Hero
         hero = Game.hero().orElse(new Entity());

--- a/game/test/contrib/utils/components/ai/ProtectOnAttackTest.java
+++ b/game/test/contrib/utils/components/ai/ProtectOnAttackTest.java
@@ -33,17 +33,17 @@ public class ProtectOnAttackTest {
         // Get a victim and its HealthComponent
         protectedEntity = new Entity();
         entityHC = new HealthComponent();
-        protectedEntity.addComponent(entityHC);
+        protectedEntity.add(entityHC);
 
         // Get an attacker
         attacker = new Entity();
-        attacker.addComponent(new PlayerComponent());
+        attacker.add(new PlayerComponent());
 
         // Prepare a list of entities with a HealthComponent
         entitiesToProtect = new ArrayList<>();
         for (int i = 0; i < 5; i++) {
             Entity e = new Entity();
-            e.addComponent(new HealthComponent());
+            e.add(new HealthComponent());
             entitiesToProtect.add(e);
         }
         updateCounter = 0;
@@ -60,7 +60,7 @@ public class ProtectOnAttackTest {
                         },
                         new RadiusWalk(2, 2),
                         new ProtectOnAttack(protectedEntity));
-        protector.addComponent(attackerAI);
+        protector.add(attackerAI);
         // when
         entityHC.receiveHit(new Damage(1, null, attacker));
 
@@ -80,7 +80,7 @@ public class ProtectOnAttackTest {
                         },
                         new RadiusWalk(2, 2),
                         new ProtectOnAttack(protectedEntity));
-        protector.addComponent(attackerAI);
+        protector.add(attackerAI);
 
         // then
         attackerAI.execute(protector);
@@ -98,7 +98,7 @@ public class ProtectOnAttackTest {
                         },
                         new RadiusWalk(2, 2),
                         new ProtectOnAttack(entitiesToProtect));
-        protector.addComponent(attackerAI);
+        protector.add(attackerAI);
         // when
         for (Entity e : entitiesToProtect) {
             if (e.fetch(HealthComponent.class).isPresent()) {
@@ -125,7 +125,7 @@ public class ProtectOnAttackTest {
                         new RadiusWalk(2, 2),
                         new ProtectOnAttack(protectedEntity));
 
-        protector.addComponent(attackerAI);
+        protector.add(attackerAI);
         // then
         attackerAI.execute(protector);
         assertEquals(0, updateCounter);

--- a/game/test/contrib/utils/components/ai/SelfDefendTransitionTest.java
+++ b/game/test/contrib/utils/components/ai/SelfDefendTransitionTest.java
@@ -22,7 +22,7 @@ public class SelfDefendTransitionTest {
     public void isInFightModeHealtpointsAreMax() {
         Entity entity = new Entity();
         HealthComponent hc = new HealthComponent();
-        entity.addComponent(hc);
+        entity.add(hc);
         hc.maximalHealthpoints(10);
         hc.currentHealthpoints(10);
         Function<Entity, Boolean> defend = new SelfDefendTransition();
@@ -37,7 +37,7 @@ public class SelfDefendTransitionTest {
     public void isInFightModeHealthpointsAreLowerThenMax() {
         Entity entity = new Entity();
         HealthComponent hc = new HealthComponent();
-        entity.addComponent(hc);
+        entity.add(hc);
         hc.maximalHealthpoints(10);
         hc.currentHealthpoints(10);
         Function<Entity, Boolean> defend = new SelfDefendTransition();

--- a/game/test/contrib/utils/components/health/DropLootTest.java
+++ b/game/test/contrib/utils/components/health/DropLootTest.java
@@ -33,7 +33,7 @@ public class DropLootTest {
     public void entityMissingPositionComponent() {
         DropLoot dropLoot = new DropLoot();
         Entity entity = new Entity();
-        entity.addComponent(new InventoryComponent(10));
+        entity.add(new InventoryComponent(10));
         MissingComponentException mce =
                 assertThrows(MissingComponentException.class, () -> dropLoot.accept(entity));
         assertTrue(mce.getMessage().contains(PositionComponent.class.getName()));
@@ -44,8 +44,8 @@ public class DropLootTest {
     public void entityInventoryComponentEmpty() {
         DropLoot dropLoot = new DropLoot();
         Entity entity = new Entity();
-        entity.addComponent(new PositionComponent(new Point(1, 2)));
-        entity.addComponent(new InventoryComponent(10));
+        entity.add(new PositionComponent(new Point(1, 2)));
+        entity.add(new InventoryComponent(10));
         dropLoot.accept(entity);
         Game.remove(entity);
         assertEquals(0, Game.entityStream().count());

--- a/game/test/contrib/utils/components/interaction/ControlPointReachableTest.java
+++ b/game/test/contrib/utils/components/interaction/ControlPointReachableTest.java
@@ -71,9 +71,9 @@ public class ControlPointReachableTest {
         SimpleCounter s1 = new SimpleCounter();
         Entity e1 = new Entity();
         PositionComponent e1PC = new PositionComponent(e1Point);
-        e1.addComponent(e1PC);
+        e1.add(e1PC);
         InteractionComponent e1IC = new InteractionComponent(3, false, (e, who) -> s1.inc());
-        e1.addComponent(e1IC);
+        e1.add(e1IC);
         PreparedEntityWithCounter first = new PreparedEntityWithCounter(e1, s1, e1PC, e1IC);
         return first;
     }

--- a/game/test/contrib/utils/components/interaction/InteractionToolTest.java
+++ b/game/test/contrib/utils/components/interaction/InteractionToolTest.java
@@ -41,7 +41,7 @@ public class InteractionToolTest {
      */
     private static Entity testHero(boolean havingPositionComponent) {
         Entity hero = new Entity();
-        if (havingPositionComponent) hero.addComponent(new PositionComponent(new Point(0, 0)));
+        if (havingPositionComponent) hero.add(new PositionComponent(new Point(0, 0)));
         return hero;
     }
 
@@ -103,10 +103,10 @@ public class InteractionToolTest {
         Game.currentLevel(prepareLevel());
 
         Entity e = new Entity();
-        e.addComponent(new PositionComponent(new Point(10, 10)));
+        e.add(new PositionComponent(new Point(10, 10)));
 
         SimpleCounter sc_e = new SimpleCounter();
-        e.addComponent(new InteractionComponent(5f, false, (x, who) -> sc_e.inc()));
+        e.add(new InteractionComponent(5f, false, (x, who) -> sc_e.inc()));
 
         InteractionTool.interactWithClosestInteractable(Game.hero().get());
         assertEquals("No interaction should happen", 0, sc_e.getCount());

--- a/game/test/contrib/utils/components/item/ItemTest.java
+++ b/game/test/contrib/utils/components/item/ItemTest.java
@@ -217,7 +217,7 @@ public class ItemTest {
         item.drop(null, new Point(0, 0));
         assertEquals("There should only be one entity in the game", 1, Game.entityStream().count());
         Entity collector = new Entity();
-        collector.addComponent(new InventoryComponent(3));
+        collector.add(new InventoryComponent(3));
         Entity worldItem = Game.entityStream().findFirst().get();
 
         assertTrue(item.collect(worldItem, collector));
@@ -256,7 +256,7 @@ public class ItemTest {
         item.drop(null, new Point(0, 0));
         assertEquals("There should only be one entity in the game", 1, Game.entityStream().count());
         Entity collector = new Entity();
-        collector.addComponent(new InventoryComponent(0));
+        collector.add(new InventoryComponent(0));
         Entity worldItem = Game.entityStream().findFirst().get();
 
         assertFalse(item.collect(worldItem, collector));
@@ -270,7 +270,7 @@ public class ItemTest {
         Item item = new Item("Test item", "Test description", defaultAnimation);
         Entity entity = new Entity();
         InventoryComponent inventoryComponent = new InventoryComponent(2);
-        entity.addComponent(inventoryComponent);
+        entity.add(inventoryComponent);
         inventoryComponent.add(item);
         assertTrue(
                 "ItemActive needs to be in entities inventory.",

--- a/game/test/core/EntityTest.java
+++ b/game/test/core/EntityTest.java
@@ -15,7 +15,7 @@ public class EntityTest {
     @Before
     public void setup() {
         entity = new Entity();
-        entity.addComponent(testComponent);
+        entity.add(testComponent);
     }
 
     @Test
@@ -26,13 +26,13 @@ public class EntityTest {
     @Test
     public void addAlreadyExistingComponent() {
         Component newComponent = Mockito.mock(Component.class);
-        entity.addComponent(newComponent);
+        entity.add(newComponent);
         assertEquals(newComponent, entity.fetch(testComponent.getClass()).get());
     }
 
     @Test
     public void removeComponent() {
-        entity.removeComponent(testComponent.getClass());
+        entity.remove(testComponent.getClass());
         assertTrue(entity.fetch(testComponent.getClass()).isEmpty());
     }
 

--- a/game/test/core/GameTest.java
+++ b/game/test/core/GameTest.java
@@ -54,7 +54,7 @@ public class GameTest {
     public void find_exisiting() {
         Entity e = new Entity();
         DummyComponent dc = new DummyComponent();
-        e.addComponent(dc);
+        e.add(dc);
         Game.add(e);
         assertEquals(e, Game.find(dc).get());
         // load ne level to check if it still works

--- a/game/test/core/level/TileLevelAPITest.java
+++ b/game/test/core/level/TileLevelAPITest.java
@@ -200,8 +200,8 @@ public class TileLevelAPITest {
         when(generator.level(any(), Mockito.any())).thenReturn(level);
         api.loadLevel();
         Entity hero = new Entity();
-        hero.addComponent(new PositionComponent());
-        hero.addComponent(new PlayerComponent());
+        hero.add(new PositionComponent());
+        hero.add(new PlayerComponent());
         Game.add(hero);
 
         Tile end = Mockito.mock(Tile.class);

--- a/game/test/core/systems/CameraSystemTest.java
+++ b/game/test/core/systems/CameraSystemTest.java
@@ -54,8 +54,8 @@ public class CameraSystemTest {
         Entity entity = new Entity();
         expectedFocusPoint = new Point(3, 3);
         PositionComponent positionComponent = new PositionComponent(expectedFocusPoint);
-        entity.addComponent(positionComponent);
-        entity.addComponent(new CameraComponent());
+        entity.add(positionComponent);
+        entity.add(new CameraComponent());
 
         cameraSystem.execute();
         assertEquals(expectedFocusPoint.x, CameraSystem.camera().position.x, 0.001);

--- a/game/test/core/systems/PositionSystemTest.java
+++ b/game/test/core/systems/PositionSystemTest.java
@@ -36,7 +36,7 @@ public class PositionSystemTest {
         entity = new Entity();
         Game.add(entity);
 
-        entity.addComponent(pc);
+        entity.add(pc);
 
         Mockito.when(level.randomTile(LevelElement.FLOOR)).thenReturn(mock);
         Mockito.when(mock.position()).thenReturn(point);

--- a/game/test/core/systems/VelocitySystemTest.java
+++ b/game/test/core/systems/VelocitySystemTest.java
@@ -50,9 +50,9 @@ public class VelocitySystemTest {
         velocityComponent = new VelocityComponent(xVelocity, yVelocity);
         positionComponent = new PositionComponent(new Point(startXPosition, startYPosition));
         animationComponent = new DrawComponent("textures/test_hero");
-        entity.addComponent(velocityComponent);
-        entity.addComponent(positionComponent);
-        entity.addComponent(animationComponent);
+        entity.add(velocityComponent);
+        entity.add(positionComponent);
+        entity.add(animationComponent);
         Game.add(entity);
     }
 


### PR DESCRIPTION
setzt https://github.com/Programmiermethoden/Dungeon/issues/1025 für die Klasse `Entity` um.

Nennenswerte änderung:
Aus `addComponent` und `removeComponent`. wurde `add` bzw. `remove` 