### PR TITLE
[GAME/DSL] Fix ArithmeticException in QuestItems von SzenarioBuildern

### DIFF
--- a/dungeon/src/dslinterop/dsltypeadapters/QuestItemAdapter.java
+++ b/dungeon/src/dslinterop/dsltypeadapters/QuestItemAdapter.java
@@ -1,7 +1,6 @@
 package dslinterop.dsltypeadapters;
 
 import core.utils.components.draw.Animation;
-import core.utils.components.draw.CoreAnimationPriorities;
 import core.utils.components.draw.SimpleIPath;
 
 import dsl.semanticanalysis.typesystem.typebuilding.annotation.DSLTypeAdapter;
@@ -26,8 +25,7 @@ public class QuestItemAdapter {
             @DSLTypeMember(name = "display_name") String displayName,
             @DSLTypeMember(name = "description") String description,
             @DSLTypeMember(name = "texture_path") String texturePath) {
-        Animation animation =
-                Animation.fromSingleImage(new SimpleIPath(texturePath));
+        Animation animation = Animation.fromSingleImage(new SimpleIPath(texturePath));
         TaskContentComponent tcc = new TaskContentComponent();
         return new QuestItem(animation, tcc);
     }

--- a/dungeon/src/dslinterop/dsltypeadapters/QuestItemAdapter.java
+++ b/dungeon/src/dslinterop/dsltypeadapters/QuestItemAdapter.java
@@ -27,8 +27,7 @@ public class QuestItemAdapter {
             @DSLTypeMember(name = "description") String description,
             @DSLTypeMember(name = "texture_path") String texturePath) {
         Animation animation =
-                Animation.fromSingleImage(
-                        new SimpleIPath(texturePath), CoreAnimationPriorities.DEFAULT.priority());
+                Animation.fromSingleImage(new SimpleIPath(texturePath));
         TaskContentComponent tcc = new TaskContentComponent();
         return new QuestItem(animation, tcc);
     }

--- a/dungeon/src/dslinterop/nativescenariobuilder/NativeScenarioBuilder.java
+++ b/dungeon/src/dslinterop/nativescenariobuilder/NativeScenarioBuilder.java
@@ -15,7 +15,6 @@ import core.Entity;
 import core.components.DrawComponent;
 import core.components.PositionComponent;
 import core.utils.components.draw.Animation;
-import core.utils.components.draw.CoreAnimationPriorities;
 import core.utils.components.draw.SimpleIPath;
 
 import task.Task;

--- a/dungeon/src/dslinterop/nativescenariobuilder/NativeScenarioBuilder.java
+++ b/dungeon/src/dslinterop/nativescenariobuilder/NativeScenarioBuilder.java
@@ -89,8 +89,7 @@ public class NativeScenarioBuilder {
                 if (!element.equals(AssignTask.EMPTY_ELEMENT)) {
                     Animation animation =
                             Animation.fromSingleImage(
-                                    new SimpleIPath("items/book/wisdom_scroll.png"),
-                                    CoreAnimationPriorities.DEFAULT.priority());
+                                    new SimpleIPath("items/book/wisdom_scroll.png"));
                     TaskContentComponent tcc = new TaskContentComponent(element);
                     QuestItem questItem = new QuestItem(animation, tcc);
                     Entity worldItem = WorldItemBuilder.buildWorldItem(questItem);

--- a/game/src/core/utils/components/draw/Animation.java
+++ b/game/src/core/utils/components/draw/Animation.java
@@ -63,7 +63,8 @@ public final class Animation {
         this.animationFrames = new ArrayList<>(animationFrames);
         frames = animationFrames.size();
         if (frameTime == 0) {
-            throw new IllegalArgumentException("Parameter frameTime is set to 0, frameTime must be greater than 0!");
+            throw new IllegalArgumentException(
+                    "Parameter frameTime is set to 0, frameTime must be greater than 0!");
         }
         this.timeBetweenFrames = frameTime;
         this.looping = looping;

--- a/game/src/core/utils/components/draw/Animation.java
+++ b/game/src/core/utils/components/draw/Animation.java
@@ -62,6 +62,9 @@ public final class Animation {
         assert (animationFrames != null && !animationFrames.isEmpty());
         this.animationFrames = new ArrayList<>(animationFrames);
         frames = animationFrames.size();
+        if (frameTime == 0) {
+            throw new IllegalArgumentException("Parameter frameTime is set to 0, frameTime must be greater than 0!");
+        }
         this.timeBetweenFrames = frameTime;
         this.looping = looping;
         this.priority = prio;


### PR DESCRIPTION
Fixes #1241 

Die `Animation.fromSingleImage` waren falsch, die `priority` wurden als `frameTime = 0` übergeben. Habe eine `IllegalArgumentException` im ctor von `Animation` hinzugefügt, um das in Zukunft besser debuggen zu können. 