### PR TITLE
[Org] remove global code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,2 @@
-# global owner
-* @Programmiermethoden/dungeon
-
 # game owner
 /game/ @AMatutat @Programmiermethoden/codrs


### PR DESCRIPTION
Wie im letzten Meeting schon einmal angesprochen, haben wir aktuell für das `dungeon`-Projekt nicht die Kapazitäten, die einzelnen Pull Requests richtig zu reviewen (teilweise aus Zeitgründen, teilweise aus Know-How-Gründen). Praktisch führt das dazu, dass @malt-r und ich uns die Pull Requests zuschicken und mehr oder weniger blind abnicken.

Was die Sache noch ärgerlicher macht, ist, dass wir aktuell am Refaktorisieren/Aufräumen sind, und @malt-r mir jetzt immer ein OK geben muss, wenn ich im Framework einen Methodennamen ändere... Das bedeutet Zeitverlust auf beiden Seiten.

Daher mein Vorschlag: Raus mit den Owner-Rechten auf dieser Ebene. Da nur @Programmiermethoden/dungeon in den Master mergen kann, haben wir eine gewisse Absicherung.

Im Framework behalte ich das Vier-Augen-Prinzip bei.

@cagix, ich weiß, du bist (zurecht) Fan vom Vier-Augen-Prinzip, aber aktuell funktioniert es nicht. Wenn du dennoch streng gegen eine Öffnung bist, mach hier zu, ansonsten mergen ^^