### PR TITLE
[GAME] remove need to explicit register the hero

### DIFF
--- a/blockly/src/client/Client.java
+++ b/blockly/src/client/Client.java
@@ -134,7 +134,6 @@ public class Client {
             throw new RuntimeException(e);
         }
         Game.add(hero);
-        Game.hero(hero);
     }
 
     private static void createSystems() {

--- a/dungeon/src/starter/Starter.java
+++ b/dungeon/src/starter/Starter.java
@@ -212,7 +212,6 @@ public class Starter {
             throw new RuntimeException(e);
         }
         Game.add(hero);
-        Game.hero(hero);
     }
 
     private static void configGame() throws IOException {

--- a/dungeon/test/manual/quizquestion/CallbackTest.java
+++ b/dungeon/test/manual/quizquestion/CallbackTest.java
@@ -77,7 +77,6 @@ public class CallbackTest {
                         Game.add(new ProjectileSystem());
                         Game.add(new HudSystem());
                         Entity hero = EntityFactory.newHero();
-                        Game.hero(hero);
                         Game.add(hero);
                     } catch (IOException e) {
                         throw new RuntimeException(e);

--- a/dungeon/test/manual/taskgeneration/TaskGenerationTest.java
+++ b/dungeon/test/manual/taskgeneration/TaskGenerationTest.java
@@ -60,7 +60,6 @@ public class TaskGenerationTest {
                         Game.add(new HealthBarSystem());
                         Game.add(new HudSystem());
                         Entity hero = EntityFactory.newHero();
-                        Game.hero(hero);
                         Game.add(hero);
                     } catch (IOException e) {
                         throw new RuntimeException(e);

--- a/dungeon/test/reporting/AnswerPickingFunctionsTest.java
+++ b/dungeon/test/reporting/AnswerPickingFunctionsTest.java
@@ -606,7 +606,6 @@ public class AnswerPickingFunctionsTest {
 
         // setup hero
         Entity hero = EntityFactory.newHero();
-        Game.hero(hero);
         InventoryComponent ic = new InventoryComponent(3);
         hero.add(ic);
         TaskContent containerTaskContent = new Element<>(sc, hero);
@@ -641,7 +640,7 @@ public class AnswerPickingFunctionsTest {
 
         // setup hero
         Entity hero = EntityFactory.newHero();
-        Game.hero(hero);
+        Game.add(hero);
         InventoryComponent ic = new InventoryComponent(3);
         hero.add(ic);
         TaskContent containerTaskContent = new Element<>(sc, hero);
@@ -677,7 +676,6 @@ public class AnswerPickingFunctionsTest {
 
         // setup hero
         Entity hero = EntityFactory.newHero();
-        Game.hero(hero);
         InventoryComponent ic = new InventoryComponent(3);
         hero.add(ic);
         TaskContent containerTaskContent = new Element<>(sc, hero);
@@ -710,7 +708,6 @@ public class AnswerPickingFunctionsTest {
 
         // setup hero
         Entity hero = EntityFactory.newHero();
-        Game.hero(hero);
         InventoryComponent ic = new InventoryComponent(3);
         hero.add(ic);
         TaskContent containerTaskContent = new Element<>(sc, hero);
@@ -744,7 +741,6 @@ public class AnswerPickingFunctionsTest {
 
         // setup hero
         Entity hero = EntityFactory.newHero();
-        Game.hero(hero);
         InventoryComponent ic = new InventoryComponent(3);
         hero.add(ic);
         TaskContent containerTaskContent = new Element<>(sc, hero);
@@ -776,7 +772,6 @@ public class AnswerPickingFunctionsTest {
 
         // setup hero
         Entity hero = EntityFactory.newHero();
-        Game.hero(hero);
         InventoryComponent ic = new InventoryComponent(3);
         hero.add(ic);
         TaskContent containerTaskContent = new Element<>(sc, hero);

--- a/dungeon/test/reporting/GradingFunctionsTest.java
+++ b/dungeon/test/reporting/GradingFunctionsTest.java
@@ -30,7 +30,7 @@ public class GradingFunctionsTest {
     @Before
     public void setup() {
         try {
-            Game.hero(EntityFactory.newHero());
+            Game.add(EntityFactory.newHero());
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/game/src/core/Game.java
+++ b/game/src/core/Game.java
@@ -293,17 +293,6 @@ public final class Game {
     }
 
     /**
-     * Set the reference of the playable character.
-     *
-     * <p>Be careful: the old hero will not be removed from the game.
-     *
-     * @param hero the new reference of the hero
-     */
-    public static void hero(Entity hero) {
-        ECSManagment.hero(hero);
-    }
-
-    /**
      * Remove the stored system of the given class from the game. If the System is successfully
      * removed, the {@link System#triggerOnRemove(Entity)} method of the System will be called for
      * each existing Entity that was associated with the removed System.

--- a/game/src/core/game/ECSManagment.java
+++ b/game/src/core/game/ECSManagment.java
@@ -3,6 +3,7 @@ package core.game;
 import core.Component;
 import core.Entity;
 import core.System;
+import core.components.PlayerComponent;
 import core.level.elements.ILevel;
 import core.utils.EntitySystemMapper;
 
@@ -29,7 +30,6 @@ public final class ECSManagment {
     private static final Logger LOGGER = Logger.getLogger(ECSManagment.class.getSimpleName());
     private static final Map<Class<? extends System>, System> SYSTEMS = new LinkedHashMap<>();
     private static final Map<ILevel, Set<EntitySystemMapper>> LEVEL_STORAGE_MAP = new HashMap<>();
-    private static Entity hero;
     private static Set<EntitySystemMapper> activeEntityStorage = new HashSet<>();
 
     static {
@@ -207,18 +207,7 @@ public final class ECSManagment {
      * @see Optional
      */
     public static Optional<Entity> hero() {
-        return Optional.ofNullable(hero);
-    }
-
-    /**
-     * Set the reference of the playable character.
-     *
-     * <p>Be careful: the old hero will not be removed from the game.
-     *
-     * @param hero the new reference of the hero
-     */
-    public static void hero(final Entity hero) {
-        ECSManagment.hero = hero;
+        return entityStream().filter(e -> e.isPresent(PlayerComponent.class)).findFirst();
     }
 
     /**

--- a/game/src/core/game/GameLoop.java
+++ b/game/src/core/game/GameLoop.java
@@ -57,9 +57,10 @@ public final class GameLoop extends ScreenAdapter {
     private final IVoidFunction onLevelLoad =
             () -> {
                 newLevelWasLoadedInThisLoop = true;
+                Optional<Entity> hero = ECSManagment.hero();
                 boolean firstLoad =
                         !ECSManagment.levelStorageMap().containsKey(Game.currentLevel());
-                ECSManagment.hero().ifPresent(ECSManagment::remove);
+                hero.ifPresent(ECSManagment::remove);
                 // Remove the systems so that each triggerOnRemove(entity) will be called (basically
                 // cleanup).
                 Map<Class<? extends System>, System> s = ECSManagment.systems();
@@ -72,11 +73,11 @@ public final class GameLoop extends ScreenAdapter {
                 s.values().forEach(ECSManagment::add);
 
                 try {
-                    ECSManagment.hero().ifPresent(this::placeOnLevelStart);
+                    hero.ifPresent(this::placeOnLevelStart);
                 } catch (MissingComponentException e) {
                     LOGGER.warning(e.getMessage());
                 }
-                ECSManagment.hero().ifPresent(ECSManagment::add);
+                hero.ifPresent(ECSManagment::add);
                 Game.currentLevel().onLoad();
                 PreRunConfiguration.userOnLevelLoad().accept(firstLoad);
             };

--- a/game/src/core/systems/DrawSystem.java
+++ b/game/src/core/systems/DrawSystem.java
@@ -87,7 +87,7 @@ public final class DrawSystem extends System {
                         .collect(
                                 Collectors.partitioningBy(
                                         entity -> entity.isPresent(PlayerComponent.class)));
-
+        entityStream().forEach(e -> java.lang.System.out.println(e));
         List<Entity> players = partitionedEntities.get(true);
         List<Entity> npcs = partitionedEntities.get(false);
 

--- a/game/src/starter/RandomDungeon.java
+++ b/game/src/starter/RandomDungeon.java
@@ -68,7 +68,6 @@ public class RandomDungeon {
     private static void createHero() throws IOException {
         Entity hero = EntityFactory.newHero();
         Game.add(hero);
-        Game.hero(hero);
     }
 
     private static void setupMusic() {

--- a/game/src/starter/RoomBasedDungeon.java
+++ b/game/src/starter/RoomBasedDungeon.java
@@ -87,7 +87,6 @@ public class RoomBasedDungeon {
     private static void createHero() throws IOException {
         Entity hero = EntityFactory.newHero();
         Game.add(hero);
-        Game.hero(hero);
     }
 
     private static void createSystems() {

--- a/game/test/contrib/entities/MonsterTest.java
+++ b/game/test/contrib/entities/MonsterTest.java
@@ -46,7 +46,7 @@ public class MonsterTest {
                         },
                         DesignLabel.DEFAULT));
 
-        Game.hero(EntityFactory.newHero());
+        Game.add(EntityFactory.newHero());
         Entity m = EntityFactory.randomMonster();
 
         Optional<DrawComponent> drawComponent = m.fetch(DrawComponent.class);

--- a/game/test/contrib/utils/components/interaction/InteractionToolTest.java
+++ b/game/test/contrib/utils/components/interaction/InteractionToolTest.java
@@ -6,6 +6,7 @@ import contrib.components.InteractionComponent;
 
 import core.Entity;
 import core.Game;
+import core.components.PlayerComponent;
 import core.components.PositionComponent;
 import core.level.TileLevel;
 import core.level.elements.ILevel;
@@ -39,6 +40,7 @@ public class InteractionToolTest {
      */
     private static Entity testHero(boolean havingPositionComponent) {
         Entity hero = new Entity();
+        hero.add(new PlayerComponent());
         if (havingPositionComponent) hero.add(new PositionComponent(new Point(0, 0)));
         return hero;
     }
@@ -46,7 +48,6 @@ public class InteractionToolTest {
     /** cleanup to reset static Attributes from Game used by the InteractionTool */
     private static void cleanup() {
         Game.removeAllEntities();
-        Game.hero(null);
         Game.currentLevel(null);
     }
 
@@ -54,7 +55,7 @@ public class InteractionToolTest {
     @Test
     public void interactWithClosestInteractableHeroMissingPositionComponent() {
         cleanup();
-        Game.hero(testHero(false));
+        Game.add(testHero(false));
         Game.currentLevel(prepareLevel());
 
         MissingComponentException e =
@@ -71,7 +72,7 @@ public class InteractionToolTest {
     @Test
     public void interactWithClosestInteractableNoEntities() {
         cleanup();
-        Game.hero(testHero(true));
+        Game.add(testHero(true));
         Game.currentLevel(prepareLevel());
         InteractionTool.interactWithClosestInteractable(Game.hero().get());
         cleanup();
@@ -83,7 +84,7 @@ public class InteractionToolTest {
     @Test
     public void interactWithClosestInteractableNoInteractable() {
         cleanup();
-        Game.hero(testHero(true));
+        Game.add(testHero(true));
         Game.currentLevel(prepareLevel());
         Game.add(Game.hero().get());
         InteractionTool.interactWithClosestInteractable(Game.hero().get());
@@ -97,7 +98,7 @@ public class InteractionToolTest {
     @Test
     public void interactWithClosestInteractableOneInteractableOutOfRange() {
         cleanup();
-        Game.hero(testHero(true));
+        Game.add(testHero(true));
         Game.currentLevel(prepareLevel());
 
         Entity e = new Entity();

--- a/game/test/contrib/utils/components/item/ItemTest.java
+++ b/game/test/contrib/utils/components/item/ItemTest.java
@@ -96,7 +96,6 @@ public class ItemTest {
     public void cleanup() {
         Game.removeAllEntities();
         Game.removeAllSystems();
-        Game.hero(null);
         Game.currentLevel(null);
     }
 


### PR DESCRIPTION
Wir hatten eine seltsame Bedingung, bei der man den Helden explizit im Spiel als Helden registrieren musste (`Game#hero`). Da ein Held sich aber dadurch auszeichnet, dass er ein `PlayerComponent` besitzt, habe ich die Abfrage vereinfacht und filtere mir die erste Entität heraus, die ein `PlayerComponent` hat. Der Setter für den Helden wird daher nicht mehr benötigt. 
Ist natürlich nicht mehr für den Multiplayer geeignet, aber das alte System war es auch nicht.