### PR TITLE
[GAME] fix bug where jar would crash, use Game as Resource Reference root in `Crafting` 

### DIFF
--- a/game/src/contrib/crafting/Crafting.java
+++ b/game/src/contrib/crafting/Crafting.java
@@ -5,6 +5,7 @@ import com.badlogic.gdx.utils.JsonValue;
 
 import contrib.item.Item;
 
+import core.Game;
 import core.utils.logging.CustomLogLevel;
 
 import java.io.*;
@@ -95,7 +96,7 @@ public final class Crafting {
     private static void loadFromJar() {
         try {
             String path =
-                    new File(Objects.requireNonNull(Crafting.class.getResource("")).getPath())
+                    new File(Objects.requireNonNull(Game.class.getResource("")).getPath())
                             .getParent()
                             // for windows
                             .replaceAll("(!|file:\\\\)", "")
@@ -109,7 +110,7 @@ public final class Crafting {
                     LOGGER.info("Load recipe: " + entry.getName());
                     Recipe r =
                             parseRecipe(
-                                    Crafting.class.getResourceAsStream("/" + entry.getName()),
+                                    Game.class.getResourceAsStream("/" + entry.getName()),
                                     entry.getName());
                     if (r != null) Crafting.RECIPES.add(r);
                 }


### PR DESCRIPTION
Im `Crafting` wird (wenn das Dungeon im jar ausgeführt wird) eine Resourcen-Referenz als Root benötigt. 
Ich habe das damals (dummerweise) von `Main.class` auf `Crafting.class` geändert. Mit `Game.class` geht es wieder + die Klasse `Game` läuft nicht Gefahr gelöscht zu werden. 

So richtig sexy ist das aber auch nicht. 