### PR TITLE
[GAME] replace last String-Paths with `IPath` 

### DIFF
--- a/blockly/src/client/Client.java
+++ b/blockly/src/client/Client.java
@@ -12,6 +12,7 @@ import core.level.elements.ILevel;
 import core.level.utils.DesignLabel;
 import core.level.utils.LevelSize;
 import core.utils.MissingHeroException;
+import core.utils.components.path.SimpleIPath;
 
 import server.Server;
 
@@ -86,7 +87,7 @@ public class Client {
 
     private static void configGame() throws IOException {
         Game.loadConfig(
-                "dungeon_config.json",
+                new SimpleIPath("dungeon_config.json"),
                 contrib.configuration.KeyboardConfig.class,
                 core.configuration.KeyboardConfig.class);
         Game.frameRate(30);

--- a/dungeon/src/starter/Starter.java
+++ b/dungeon/src/starter/Starter.java
@@ -14,6 +14,7 @@ import core.Game;
 import core.components.PlayerComponent;
 import core.level.elements.ILevel;
 import core.utils.components.MissingComponentException;
+import core.utils.components.path.SimpleIPath;
 
 import dsl.interpreter.DSLEntryPointFinder;
 import dsl.interpreter.DSLInterpreter;
@@ -220,9 +221,10 @@ public class Starter {
         Game.frameRate(30);
         Game.disableAudio(false);
         Game.loadConfig(
-                "dungeon_config.json",
+                new SimpleIPath("dungeon_config.json"),
                 contrib.configuration.KeyboardConfig.class,
-                core.configuration.KeyboardConfig.class);
+                core.configuration.KeyboardConfig.class,
+                starter.KeyboardConfig.class);
     }
 
     private static void createSystems() {

--- a/dungeon/test/manual/quizquestion/CallbackTest.java
+++ b/dungeon/test/manual/quizquestion/CallbackTest.java
@@ -64,7 +64,7 @@ public class CallbackTest {
 
         LevelSystem.levelSize(LevelSize.SMALL);
         Game.loadConfig(
-                "dungeon_config.json",
+                new SimpleIPath("dungeon_config.json"),
                 contrib.configuration.KeyboardConfig.class,
                 core.configuration.KeyboardConfig.class);
         Game.frameRate(30);

--- a/dungeon/test/manual/taskgeneration/TaskGenerationTest.java
+++ b/dungeon/test/manual/taskgeneration/TaskGenerationTest.java
@@ -45,7 +45,7 @@ public class TaskGenerationTest {
         Game.initBaseLogger();
         LevelSystem.levelSize(LevelSize.MEDIUM);
         Game.loadConfig(
-                "dungeon_config.json",
+                new SimpleIPath("dungeon_config.json"),
                 contrib.configuration.KeyboardConfig.class,
                 core.configuration.KeyboardConfig.class);
         Game.disableAudio(true);

--- a/game/doc/quickstart.md
+++ b/game/doc/quickstart.md
@@ -345,7 +345,7 @@ public class Main {
                     }
                 };
         Game.userOnSetup(onSetup);
-        Game.loadConfig("dungeon_config.json", core.configuration.KeyboardConfig.class);
+        Game.loadConfig(new SimplePath("dungeon_config.json"), core.configuration.KeyboardConfig.class);
         Game.run();
     }
 }

--- a/game/src/contrib/components/IdleSoundComponent.java
+++ b/game/src/contrib/components/IdleSoundComponent.java
@@ -1,6 +1,7 @@
 package contrib.components;
 
 import core.Component;
+import core.utils.components.path.IPath;
 
 /**
  * Stores a String path to a sound file that can be played by the {@link
@@ -9,4 +10,4 @@ import core.Component;
  * @param soundEffect Path to the sound file to play.
  * @see contrib.systems.IdleSoundSystem
  */
-public record IdleSoundComponent(String soundEffect) implements Component {}
+public record IdleSoundComponent(IPath soundEffect) implements Component {}

--- a/game/src/contrib/entities/MonsterFactory.java
+++ b/game/src/contrib/entities/MonsterFactory.java
@@ -132,19 +132,19 @@ public final class MonsterFactory {
         dieSoundEffect.setVolume(soundID, 0.35f);
     }
 
-    private static String randomMonsterIdleSound() {
+    private static IPath randomMonsterIdleSound() {
         switch (RANDOM.nextInt(4)) {
             case 0 -> {
-                return "sounds/monster1.wav";
+                return new SimpleIPath("sounds/monster1.wav");
             }
             case 1 -> {
-                return "sounds/monster2.wav";
+                return new SimpleIPath("sounds/monster2.wav");
             }
             case 2 -> {
-                return "sounds/monster3.wav";
+                return new SimpleIPath("sounds/monster3.wav");
             }
             default -> {
-                return "sounds/monster4.wav";
+                return new SimpleIPath("sounds/monster4.wav");
             }
         }
     }

--- a/game/src/contrib/hud/UIUtils.java
+++ b/game/src/contrib/hud/UIUtils.java
@@ -9,6 +9,8 @@ import contrib.components.UIComponent;
 
 import core.Entity;
 import core.Game;
+import core.utils.components.path.IPath;
+import core.utils.components.path.SimpleIPath;
 
 import java.util.function.Supplier;
 
@@ -16,9 +18,10 @@ import java.util.function.Supplier;
 public final class UIUtils {
 
     /** The default UI-Skin. */
-    private static final String SKIN_FOR_DIALOG = "skin/uiskin.json";
+    private static final IPath SKIN_FOR_DIALOG = new SimpleIPath("skin/uiskin.json");
 
-    public static final Skin DEFAULT_SKIN = new Skin(Gdx.files.internal(SKIN_FOR_DIALOG));
+    public static final Skin DEFAULT_SKIN =
+            new Skin(Gdx.files.internal(SKIN_FOR_DIALOG.pathString()));
     /**
      * Limits the length of the string to 40 characters, after which a line break occurs
      * automatically.

--- a/game/src/contrib/hud/crafting/CraftingGUI.java
+++ b/game/src/contrib/hud/crafting/CraftingGUI.java
@@ -25,6 +25,7 @@ import contrib.item.Item;
 import core.Game;
 import core.utils.components.draw.Animation;
 import core.utils.components.draw.TextureMap;
+import core.utils.components.path.IPath;
 import core.utils.components.path.SimpleIPath;
 
 import java.util.ArrayList;
@@ -53,8 +54,8 @@ import java.util.Arrays;
  */
 public class CraftingGUI extends CombinableGUI {
 
-    private static final String FONT_FNT = "skin/myFont.fnt";
-    private static final String FONT_PNG = "skin/myFont.png";
+    private static final IPath FONT_FNT = new SimpleIPath("skin/myFont.fnt");
+    private static final IPath FONT_PNG = new SimpleIPath("skin/myFont.png");
 
     // Position settings
     private static final int NUMBER_PADDING = 5;
@@ -117,7 +118,10 @@ public class CraftingGUI extends CombinableGUI {
 
         // Init Font
         bitmapFont =
-                new BitmapFont(Gdx.files.internal(FONT_FNT), Gdx.files.internal(FONT_PNG), false);
+                new BitmapFont(
+                        Gdx.files.internal(FONT_FNT.pathString()),
+                        Gdx.files.internal(FONT_PNG.pathString()),
+                        false);
     }
 
     private final ArrayList<Item> items = new ArrayList<>();

--- a/game/src/contrib/hud/elements/Button.java
+++ b/game/src/contrib/hud/elements/Button.java
@@ -8,6 +8,7 @@ import com.badlogic.gdx.scenes.scene2d.InputListener;
 
 import core.Game;
 import core.utils.components.draw.TextureMap;
+import core.utils.components.path.SimpleIPath;
 
 import java.util.function.Consumer;
 
@@ -27,9 +28,12 @@ public class Button {
     private static final Texture TEXTURE_BUTTON_PRESS;
 
     static {
-        TEXTURE_BUTTON = TextureMap.instance().textureAt("hud/button/button_idle.png");
-        TEXTURE_BUTTON_HOVER = TextureMap.instance().textureAt("hud/button/button_hover.png");
-        TEXTURE_BUTTON_PRESS = TextureMap.instance().textureAt("hud/button/button_press.png");
+        TEXTURE_BUTTON =
+                TextureMap.instance().textureAt(new SimpleIPath("hud/button/button_idle.png"));
+        TEXTURE_BUTTON_HOVER =
+                TextureMap.instance().textureAt(new SimpleIPath("hud/button/button_hover.png"));
+        TEXTURE_BUTTON_PRESS =
+                TextureMap.instance().textureAt(new SimpleIPath("hud/button/button_press.png"));
     }
 
     protected final CombinableGUI parent;

--- a/game/src/contrib/hud/inventory/InventoryGUI.java
+++ b/game/src/contrib/hud/inventory/InventoryGUI.java
@@ -25,11 +25,13 @@ import core.Game;
 import core.components.PositionComponent;
 import core.utils.MissingHeroException;
 import core.utils.components.MissingComponentException;
+import core.utils.components.path.IPath;
+import core.utils.components.path.SimpleIPath;
 
 public class InventoryGUI extends CombinableGUI {
 
-    private static final String FONT_FNT = "skin/myFont.fnt";
-    private static final String FONT_PNG = "skin/myFont.png";
+    private static final IPath FONT_FNT = new SimpleIPath("skin/myFont.fnt");
+    private static final IPath FONT_PNG = new SimpleIPath("skin/myFont.png");
     private static final int MAX_ITEMS_PER_ROW = 8;
     private static final int BORDER_COLOR = 0x9dc1ebff;
     private static final int BACKGROUND_COLOR = 0x3e3e63e1;
@@ -57,7 +59,10 @@ public class InventoryGUI extends CombinableGUI {
         background = new TextureRegion(texture, 0, 0, 1, 1);
         hoverBackground = new TextureRegion(texture, 1, 0, 1, 1);
         bitmapFont =
-                new BitmapFont(Gdx.files.internal(FONT_FNT), Gdx.files.internal(FONT_PNG), false);
+                new BitmapFont(
+                        Gdx.files.internal(FONT_FNT.pathString()),
+                        Gdx.files.internal(FONT_PNG.pathString()),
+                        false);
     }
 
     private final InventoryComponent inventoryComponent;
@@ -145,7 +150,8 @@ public class InventoryGUI extends CombinableGUI {
                             this.inventoryComponent
                                     .items()[i]
                                     .inventoryAnimation()
-                                    .nextAnimationTexturePath()),
+                                    .nextAnimationTexturePath()
+                                    .pathString()),
                     x,
                     y,
                     this.slotSize - (4 * BORDER_PADDING),
@@ -259,7 +265,8 @@ public class InventoryGUI extends CombinableGUI {
                                 new Image(
                                         new Texture(
                                                 item.inventoryAnimation()
-                                                        .nextAnimationTexturePath()));
+                                                        .nextAnimationTexturePath()
+                                                        .pathString()));
                         image.setSize(InventoryGUI.this.slotSize, InventoryGUI.this.slotSize);
                         payload.setDragActor(image);
                         dragAndDrop.setDragActorPosition(

--- a/game/src/contrib/systems/IdleSoundSystem.java
+++ b/game/src/contrib/systems/IdleSoundSystem.java
@@ -45,9 +45,9 @@ public final class IdleSoundSystem extends System {
     private void playSound(final IdleSoundComponent component) {
         float chanceToPlaySound = 0.001f;
         if (RANDOM.nextFloat(0f, 1f) < chanceToPlaySound) {
-            Sound soundEffect = Gdx.audio.newSound(Gdx.files.internal(component.soundEffect()));
+            Sound soundEffect =
+                    Gdx.audio.newSound(Gdx.files.internal(component.soundEffect().pathString()));
             long soundID = soundEffect.play();
-
             soundEffect.setLooping(soundID, false);
             soundEffect.setVolume(soundID, 0.35f);
         }

--- a/game/src/core/Game.java
+++ b/game/src/core/Game.java
@@ -16,6 +16,7 @@ import core.systems.LevelSystem;
 import core.utils.IVoidFunction;
 import core.utils.Point;
 import core.utils.components.MissingComponentException;
+import core.utils.components.path.IPath;
 
 import java.io.IOException;
 import java.util.Map;
@@ -121,6 +122,24 @@ public final class Game {
     }
 
     /**
+     * Gets the path to the game logo.
+     *
+     * @return The path to the game logo.
+     */
+    public static IPath logoPath() {
+        return PreRunConfiguration.logoPath();
+    }
+
+    /**
+     * Sets the path to the game logo.
+     *
+     * @param logoPath The path to the game logo.
+     */
+    public static void logoPath(IPath logoPath) {
+        PreRunConfiguration.logoPath(logoPath);
+    }
+
+    /**
      * Sets the audio disable setting in the pre-run configuration.
      *
      * @param disableAudio True to disable audio, false otherwise.
@@ -168,13 +187,13 @@ public final class Game {
      * Loads the configuration from the given path. If the configuration has already been loaded,
      * the cached version will be used.
      *
-     * @param pathAsString The path to the config file as a string.
+     * @param path The path to the config file.
      * @param keyboardConfigClass The class where the ConfigKey fields are located.
      * @throws IOException If the file could not be read.
      */
-    public static void loadConfig(final String pathAsString, final Class<?>... keyboardConfigClass)
+    public static void loadConfig(final IPath path, final Class<?>... keyboardConfigClass)
             throws IOException {
-        PreRunConfiguration.loadConfig(pathAsString, keyboardConfigClass);
+        PreRunConfiguration.loadConfig(path, keyboardConfigClass);
     }
 
     /**

--- a/game/src/core/configuration/Configuration.java
+++ b/game/src/core/configuration/Configuration.java
@@ -4,6 +4,8 @@ import com.badlogic.gdx.utils.JsonReader;
 import com.badlogic.gdx.utils.JsonValue;
 import com.badlogic.gdx.utils.JsonWriter;
 
+import core.utils.components.path.IPath;
+
 import java.io.*;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
@@ -29,16 +31,15 @@ import java.util.stream.Stream;
  */
 public class Configuration {
 
-    private static final HashMap<String, Configuration> LOADED_CONFIGURATION_FILES =
-            new HashMap<>();
+    private static final HashMap<IPath, Configuration> LOADED_CONFIGURATION_FILES = new HashMap<>();
     private static final JsonValue.PrettyPrintSettings PRETTY_PRINT_SETTINGS =
             new JsonValue.PrettyPrintSettings();
     private final Class<?>[] configClasses;
-    private final String configFilePath;
+    private final IPath configFilePath;
     private boolean fieldsLoaded = false;
     private JsonValue configRoot;
 
-    private Configuration(Class<?>[] configMapClasses, String configFilePath) {
+    private Configuration(Class<?>[] configMapClasses, IPath configFilePath) {
         this.configFilePath = configFilePath;
         configClasses = configMapClasses;
         PRETTY_PRINT_SETTINGS.outputType = JsonWriter.OutputType.json;
@@ -57,7 +58,7 @@ public class Configuration {
      * @return Configuration
      * @throws IOException If the file could not be read
      */
-    public static Configuration loadAndGetConfiguration(String path, Class<?>... configMapClasses)
+    public static Configuration loadAndGetConfiguration(IPath path, Class<?>... configMapClasses)
             throws IOException {
         if (LOADED_CONFIGURATION_FILES.containsKey(path)) {
             return LOADED_CONFIGURATION_FILES.get(path);
@@ -74,7 +75,7 @@ public class Configuration {
      * @throws IOException If the file could not be read
      */
     private void load() throws IOException {
-        File file = new File(configFilePath);
+        File file = new File(configFilePath.pathString());
         if (file.createNewFile()) { // Create file & load default config if not exists
             loadDefault();
             saveConfiguration();
@@ -122,7 +123,7 @@ public class Configuration {
     /** Save the current configuration to the file */
     public void saveConfiguration() {
         try {
-            File file = new File(configFilePath);
+            File file = new File(configFilePath.pathString());
             FileOutputStream fos = new FileOutputStream(file, false);
             OutputStreamWriter osw = new OutputStreamWriter(fos, StandardCharsets.UTF_8);
             osw.write(configRoot.prettyPrint(PRETTY_PRINT_SETTINGS));

--- a/game/src/core/game/GameLoop.java
+++ b/game/src/core/game/GameLoop.java
@@ -92,7 +92,7 @@ public final class GameLoop extends ScreenAdapter {
                 PreRunConfiguration.windowWidth(), PreRunConfiguration.windowHeight(), 9999, 9999);
         config.setForegroundFPS(PreRunConfiguration.frameRate());
         config.setTitle(PreRunConfiguration.windowTitle());
-        config.setWindowIcon(PreRunConfiguration.logoPath());
+        config.setWindowIcon(PreRunConfiguration.logoPath().pathString());
         config.disableAudio(PreRunConfiguration.disableAudio());
 
         if (PreRunConfiguration.fullScreen()) {

--- a/game/src/core/game/PreRunConfiguration.java
+++ b/game/src/core/game/PreRunConfiguration.java
@@ -2,6 +2,8 @@ package core.game;
 
 import core.configuration.Configuration;
 import core.utils.IVoidFunction;
+import core.utils.components.path.IPath;
+import core.utils.components.path.SimpleIPath;
 import core.utils.logging.LoggerConfig;
 
 import java.io.IOException;
@@ -26,7 +28,7 @@ public final class PreRunConfiguration {
     private static int FRAME_RATE = 30;
     private static boolean FULL_SCREEN = false;
     private static String WINDOW_TITLE = "PM-Dungeon";
-    private static String LOGO_PATH = "logo/cat_logo_35x35.png";
+    private static IPath LOGO_PATH = new SimpleIPath("logo/cat_logo_35x35.png");
     private static boolean DISABLE_AUDIO = false;
     private static IVoidFunction userOnFrame = () -> {};
     private static IVoidFunction userOnSetup = () -> {};
@@ -127,7 +129,7 @@ public final class PreRunConfiguration {
      *
      * @return The path to the game logo.
      */
-    public static String logoPath() {
+    public static IPath logoPath() {
         return LOGO_PATH;
     }
 
@@ -136,7 +138,7 @@ public final class PreRunConfiguration {
      *
      * @param logoPath The path to the game logo.
      */
-    public static void logoPath(String logoPath) {
+    public static void logoPath(IPath logoPath) {
         LOGO_PATH = logoPath;
     }
 
@@ -224,11 +226,11 @@ public final class PreRunConfiguration {
      * Loads the configuration from the given path. If the configuration has already been loaded,
      * the cached version will be used.
      *
-     * @param pathAsString The path to the config file as a string.
+     * @param path The path to the config file.
      * @param klass The class where the ConfigKey fields are located.
      * @throws IOException If the file could not be read.
      */
-    public static void loadConfig(final String pathAsString, Class<?>... klass) throws IOException {
-        Configuration.loadAndGetConfiguration(pathAsString, klass);
+    public static void loadConfig(final IPath path, Class<?>... klass) throws IOException {
+        Configuration.loadAndGetConfiguration(path, klass);
     }
 }

--- a/game/src/core/systems/DrawSystem.java
+++ b/game/src/core/systems/DrawSystem.java
@@ -46,7 +46,7 @@ public final class DrawSystem extends System {
     /** Draws objects */
     private static final Painter PAINTER = new Painter(BATCH);
 
-    private final Map<String, PainterConfig> configs;
+    private final Map<IPath, PainterConfig> configs;
 
     /** Create a new DrawSystem. */
     public DrawSystem() {
@@ -98,7 +98,7 @@ public final class DrawSystem extends System {
         reduceFrameTimer(dsd.dc);
         setNextAnimation(dsd.dc);
         final Animation animation = dsd.dc.currentAnimation();
-        String currentAnimationTexture = animation.nextAnimationTexturePath();
+        IPath currentAnimationTexture = animation.nextAnimationTexturePath();
         if (!configs.containsKey(currentAnimationTexture)) {
             configs.put(currentAnimationTexture, new PainterConfig(currentAnimationTexture));
         }

--- a/game/src/core/systems/LevelSystem.java
+++ b/game/src/core/systems/LevelSystem.java
@@ -183,10 +183,9 @@ public final class LevelSystem extends System {
                     IPath texturePath = t.texturePath();
                     if (!mapping.containsKey(texturePath)) {
                         mapping.put(
-                                texturePath,
-                                new PainterConfig(texturePath.pathString(), X_OFFSET, Y_OFFSET));
+                                texturePath, new PainterConfig(texturePath, X_OFFSET, Y_OFFSET));
                     }
-                    painter.draw(t.position(), texturePath.pathString(), mapping.get(texturePath));
+                    painter.draw(t.position(), texturePath, mapping.get(texturePath));
                 }
             }
         }

--- a/game/src/core/utils/components/draw/Animation.java
+++ b/game/src/core/utils/components/draw/Animation.java
@@ -145,16 +145,16 @@ public final class Animation {
      *
      * @return The texture of the next animation step (draw this).
      */
-    public String nextAnimationTexturePath() {
+    public IPath nextAnimationTexturePath() {
         if (isFinished()) {
-            return animationFrames.get(currentFrameIndex).pathString();
+            return animationFrames.get(currentFrameIndex);
         }
-        String stringToReturn = animationFrames.get(currentFrameIndex).pathString();
+        IPath pathToReturn = animationFrames.get(currentFrameIndex);
         frameTimeCounter = (frameTimeCounter + 1) % timeBetweenFrames;
         if (frameTimeCounter == 0) {
             currentFrameIndex = (currentFrameIndex + 1) % frames;
         }
-        return stringToReturn;
+        return pathToReturn;
     }
 
     /**

--- a/game/src/core/utils/components/draw/Painter.java
+++ b/game/src/core/utils/components/draw/Painter.java
@@ -5,13 +5,14 @@ import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 
 import core.systems.CameraSystem;
 import core.utils.Point;
+import core.utils.components.path.IPath;
 
 /**
  * Draws the sprites on the batch.
  *
  * <p>This class is a custom, easy-to-use API for LibGDX to draw systems.
  *
- * <p>Use {@link #draw(Point, String, PainterConfig)} to draw a sprite on the screen.
+ * <p>Use {@link #draw(Point, IPath, PainterConfig)} to draw a sprite on the screen.
  *
  * <p>The Painter will only draw sprites that are currently visible on the camera. The Painter uses
  * the {@link TextureMap} to store already loaded textures to save performance and storage.
@@ -46,7 +47,7 @@ public class Painter {
      * @param texturePath Path to the texture to draw.
      * @param config Painting configuration.
      */
-    public void draw(final Point position, final String texturePath, final PainterConfig config) {
+    public void draw(final Point position, final IPath texturePath, final PainterConfig config) {
         float realX = position.x + config.xOffset(); // including the drawOffset
         float realY = position.y + config.yOffset(); // including the drawOffset
         if (CameraSystem.isPointInFrustum(realX, realY)) {

--- a/game/src/core/utils/components/draw/PainterConfig.java
+++ b/game/src/core/utils/components/draw/PainterConfig.java
@@ -2,6 +2,8 @@ package core.utils.components.draw;
 
 import com.badlogic.gdx.graphics.Texture;
 
+import core.utils.components.path.IPath;
+
 /**
  * Configuration for the {@link Painter}
  *
@@ -24,7 +26,7 @@ public final class PainterConfig {
      * @param xOffset The texture will be moved on the x-axis, based on this value.
      * @param yOffset The texture will be moved on the y-axis, based on this value.
      */
-    public PainterConfig(final String texturePath, float xOffset, float yOffset) {
+    public PainterConfig(final IPath texturePath, float xOffset, float yOffset) {
         // half the texture xOffset, yOffset is a quarter texture down
         this(xOffset, yOffset, 1, TextureMap.instance().textureAt(texturePath));
     }
@@ -36,7 +38,7 @@ public final class PainterConfig {
      *
      * @param texturePath Path to the texture.
      */
-    public PainterConfig(final String texturePath) {
+    public PainterConfig(final IPath texturePath) {
         this(TextureMap.instance().textureAt(texturePath));
     }
 

--- a/game/src/core/utils/components/draw/TextureMap.java
+++ b/game/src/core/utils/components/draw/TextureMap.java
@@ -2,17 +2,19 @@ package core.utils.components.draw;
 
 import com.badlogic.gdx.graphics.Texture;
 
+import core.utils.components.path.IPath;
+
 import java.util.HashMap;
 
 /**
  * Maps Paths to libGDX {@link Texture}s, to reduce unnecessary loading of textures.
  *
  * <p>Use {@link #instance()} to get the only instance of the {@link TextureMap}, and use {@link
- * #textureAt(String)} to get the texture that is stored at the given path.
+ * #textureAt(IPath)} to get the texture that is stored at the given path.
  *
  * @see Painter
  */
-public final class TextureMap extends HashMap<String, Texture> {
+public final class TextureMap extends HashMap<IPath, Texture> {
     private static final TextureMap INSTANCE = new TextureMap();
 
     /**
@@ -31,9 +33,9 @@ public final class TextureMap extends HashMap<String, Texture> {
      * @param path Path to the texture.
      * @return The Texture at the given path.
      */
-    public Texture textureAt(final String path) {
+    public Texture textureAt(final IPath path) {
         if (!containsKey(path)) {
-            put(path, new Texture(path));
+            put(path, new Texture(path.pathString()));
         }
 
         return get(path);

--- a/game/src/core/utils/components/draw/TextureMap.java
+++ b/game/src/core/utils/components/draw/TextureMap.java
@@ -14,7 +14,7 @@ import java.util.HashMap;
  *
  * @see Painter
  */
-public final class TextureMap extends HashMap<IPath, Texture> {
+public final class TextureMap extends HashMap<String, Texture> {
     private static final TextureMap INSTANCE = new TextureMap();
 
     /**
@@ -35,7 +35,7 @@ public final class TextureMap extends HashMap<IPath, Texture> {
      */
     public Texture textureAt(final IPath path) {
         if (!containsKey(path)) {
-            put(path, new Texture(path.pathString()));
+            put(path.pathString(), new Texture(path.pathString()));
         }
 
         return get(path);

--- a/game/src/core/utils/components/draw/TextureMap.java
+++ b/game/src/core/utils/components/draw/TextureMap.java
@@ -34,7 +34,7 @@ public final class TextureMap extends HashMap<String, Texture> {
      * @return The Texture at the given path.
      */
     public Texture textureAt(final IPath path) {
-        if (!containsKey(path)) {
+        if (!containsKey(path.pathString())) {
             // We still store the string in the map to make sure we only store each Texture once.
             // SimplePath("file.png").equals(SimplePath("file.png")) would return false, and so we
             // would add it twice in the map.
@@ -43,6 +43,6 @@ public final class TextureMap extends HashMap<String, Texture> {
             put(path.pathString(), new Texture(path.pathString()));
         }
 
-        return get(path);
+        return get(path.pathString());
     }
 }

--- a/game/src/core/utils/components/draw/TextureMap.java
+++ b/game/src/core/utils/components/draw/TextureMap.java
@@ -35,6 +35,11 @@ public final class TextureMap extends HashMap<String, Texture> {
      */
     public Texture textureAt(final IPath path) {
         if (!containsKey(path)) {
+            // We still store the string in the map to make sure we only store each Texture once.
+            // SimplePath("file.png").equals(SimplePath("file.png")) would return false, and so we
+            // would add it twice in the map.
+            // IPath cannot override the equals method because it's an interface, and it can't be
+            // called. If it could be called, then the enums could not implement it.
             put(path.pathString(), new Texture(path.pathString()));
         }
 

--- a/game/src/starter/RandomDungeon.java
+++ b/game/src/starter/RandomDungeon.java
@@ -11,6 +11,7 @@ import contrib.utils.components.Debugger;
 import core.Entity;
 import core.Game;
 import core.level.utils.LevelSize;
+import core.utils.components.path.SimpleIPath;
 
 import java.io.IOException;
 
@@ -79,7 +80,7 @@ public class RandomDungeon {
 
     private static void configGame() throws IOException {
         Game.loadConfig(
-                "dungeon_config.json",
+                new SimpleIPath("dungeon_config.json"),
                 contrib.configuration.KeyboardConfig.class,
                 core.configuration.KeyboardConfig.class);
         Game.frameRate(30);

--- a/game/src/starter/RoomBasedDungeon.java
+++ b/game/src/starter/RoomBasedDungeon.java
@@ -13,6 +13,7 @@ import core.Entity;
 import core.Game;
 import core.level.elements.ILevel;
 import core.level.utils.DesignLabel;
+import core.utils.components.path.SimpleIPath;
 
 import java.io.IOException;
 import java.util.HashSet;
@@ -109,7 +110,7 @@ public class RoomBasedDungeon {
 
     private static void configGame() throws IOException {
         Game.loadConfig(
-                "dungeon_config.json",
+                new SimpleIPath("dungeon_config.json"),
                 contrib.configuration.KeyboardConfig.class,
                 core.configuration.KeyboardConfig.class);
         Game.frameRate(30);

--- a/game/test/core/level/TileLevelAPITest.java
+++ b/game/test/core/level/TileLevelAPITest.java
@@ -54,7 +54,7 @@ public class TileLevelAPITest {
         TextureMap textureMap = Mockito.mock(TextureMap.class);
         PowerMockito.mockStatic(TextureMap.class);
         when(TextureMap.instance()).thenReturn(textureMap);
-        when(textureMap.textureAt(anyString())).thenReturn(texture);
+        when(textureMap.textureAt(any())).thenReturn(texture);
 
         painter = Mockito.mock(Painter.class);
         generator = Mockito.mock(IGenerator.class);
@@ -162,7 +162,7 @@ public class TileLevelAPITest {
         verify(layout[0][0]).position();
         // for some reason mockito.verify can't compare the points of the tile correctly
         verify(painter, times(3))
-                .draw(any(Point.class), any(String.class), any(PainterConfig.class));
+                .draw(any(Point.class), any(IPath.class), any(PainterConfig.class));
         verifyNoMoreInteractions(layout[0][0]);
 
         verify(layout[0][1]).levelElement();
@@ -170,14 +170,14 @@ public class TileLevelAPITest {
         verify(layout[0][1]).position();
         // for some reason mockito.verify can't compare the points of the tile correctly
         verify(painter, times(3))
-                .draw(any(Point.class), any(String.class), any(PainterConfig.class));
+                .draw(any(Point.class), any(IPath.class), any(PainterConfig.class));
         verifyNoMoreInteractions(layout[0][1]);
         verify(layout[1][0]).levelElement();
         verify(layout[1][0]).texturePath();
         verify(layout[1][0]).position();
         // for some reason mockito.verify can't compare the points of the tile correctly
         verify(painter, times(3))
-                .draw(any(Point.class), any(String.class), any(PainterConfig.class));
+                .draw(any(Point.class), any(IPath.class), any(PainterConfig.class));
         verifyNoMoreInteractions(layout[1][0]);
 
         // do not draw skip tiles

--- a/game/test/core/utils/components/draw/AnimationTest.java
+++ b/game/test/core/utils/components/draw/AnimationTest.java
@@ -37,7 +37,9 @@ public class AnimationTest {
                         1);
         for (int i = 0; i < 100; i++) {
             for (int j = 0; j < 10; j++) {
-                assertEquals(String.valueOf(i % 3 + 1), animation.nextAnimationTexturePath());
+                assertEquals(
+                        String.valueOf(i % 3 + 1),
+                        animation.nextAnimationTexturePath().pathString());
             }
         }
     }
@@ -81,9 +83,9 @@ public class AnimationTest {
         List<IPath> testStrings =
                 Stream.of("a", "b").map(SimpleIPath::new).collect(Collectors.toList());
         Animation ta = Animation.fromCollection(testStrings, 1, false, 1);
-        assertEquals(testStrings.get(0).pathString(), ta.nextAnimationTexturePath());
-        assertEquals(testStrings.get(1).pathString(), ta.nextAnimationTexturePath());
-        assertEquals(testStrings.get(1).pathString(), ta.nextAnimationTexturePath());
+        assertEquals(testStrings.get(0), ta.nextAnimationTexturePath());
+        assertEquals(testStrings.get(1), ta.nextAnimationTexturePath());
+        assertEquals(testStrings.get(1), ta.nextAnimationTexturePath());
     }
 
     @Test
@@ -91,10 +93,10 @@ public class AnimationTest {
         List<IPath> testStrings =
                 Stream.of("a", "b").map(SimpleIPath::new).collect(Collectors.toList());
         Animation ta = Animation.fromCollection(testStrings, 2, false, 1);
-        assertEquals(testStrings.get(0).pathString(), ta.nextAnimationTexturePath());
-        assertEquals(testStrings.get(0).pathString(), ta.nextAnimationTexturePath());
-        assertEquals(testStrings.get(1).pathString(), ta.nextAnimationTexturePath());
-        assertEquals(testStrings.get(1).pathString(), ta.nextAnimationTexturePath());
-        assertEquals(testStrings.get(1).pathString(), ta.nextAnimationTexturePath());
+        assertEquals(testStrings.get(0), ta.nextAnimationTexturePath());
+        assertEquals(testStrings.get(0), ta.nextAnimationTexturePath());
+        assertEquals(testStrings.get(1), ta.nextAnimationTexturePath());
+        assertEquals(testStrings.get(1), ta.nextAnimationTexturePath());
+        assertEquals(testStrings.get(1), ta.nextAnimationTexturePath());
     }
 }


### PR DESCRIPTION
fixes #1143 

Ich bin noch einmal rum gegangen und habe alle String-Pfade durch `IPath`s ausgetauscht.

Das `Dungeon`-Projekt hab ich nicht durchwühlt, aber wichtig ist das Framework


@AHeinisch damit wäre das dann auch durch. 