### PR TITLE
[ORG] set cagix as global code owner, archive project (30.11.2023)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-# game owner
-/game/ @AMatutat @Programmiermethoden/codrs
+# global owner
+* @cagix


### PR DESCRIPTION
fixes #1048 

Macht @cagix zum globalen code owner. 