### PR TITLE
tool: remove spotbugs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,6 @@
-import com.github.spotbugs.snom.Confidence;
-
 plugins {
     // we can not use ext variables here
     id "java"
-    id "com.github.spotbugs" version "6.0.4"
     id "com.diffplug.spotless" version "6.23.3"
     id 'antlr'
 }
@@ -139,40 +136,6 @@ task debug(dependsOn: classes, type: JavaExec) {
 test {
     testLogging {
         events "passed", "skipped", "failed"
-    }
-}
-
-spotbugs {
-    ignoreFailures = true
-    showStackTraces = false
-    reportLevel = Confidence.valueOf("LOW")
-}
-
-spotbugsMain {
-    reports {
-        xml {
-            required = true
-            outputLocation = file("$buildDir/reports/spotbugs/main/spotbugs.xml")
-        }
-        html {
-            required = true
-            outputLocation = file("$buildDir/reports/spotbugs/main/spotbugs.html")
-            stylesheet = "fancy-hist.xsl"
-        }
-    }
-}
-
-spotbugsTest {
-    reports {
-        xml {
-            required = true
-            outputLocation = file("$buildDir/reports/spotbugs/test/spotbugs.xml")
-        }
-        html {
-            required = true
-            outputLocation = file("$buildDir/reports/spotbugs/test/spotbugs.html")
-            stylesheet = "fancy-hist.xsl"
-        }
     }
 }
 

--- a/doc/wiki/code-conventions.md
+++ b/doc/wiki/code-conventions.md
@@ -28,11 +28,3 @@ Sie können alle Java-Dateien mit dem Aufruf `./gradlew :spotlessApply` formatie
             </component>
         </project>
         ```
-
-## Code-Checks
-
-Das Tool SpotBugs prüft für uns den Code auf typische Anti-Pattern.
-
-Die von SpotBugs verwendete Standard-Konfiguration haben wir unverändert gelassen.
-
-> SpotBugs checks for more than 400 bug patterns. Bug descriptions can be found [here](https://spotbugs.readthedocs.io/en/latest/bugDescriptions.html)


### PR DESCRIPTION
SpotBugs ist ganz nett, um typische Anti-Pattern zu finden bzw. gar nicht erst einzubauen. Allerdings wurde während der gesamten aktiven Projektentwicklung nicht darauf geachtet, und wer soll das jetzt nachträglich alles gerade ziehen?! 

=> SpotBugs wird mit diesem PR aus der Konfiguration entfernt.

(siehe auch #1226)