### PR TITLE
Gradle: remove superfluous repositories

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,9 +27,6 @@ tasks.withType(JavaCompile).configureEach {
 
 repositories {
     mavenCentral()
-    maven { url 'https://oss.sonatype.org/content/repositories/snapshots/' }
-    gradlePluginPortal()
-    google()
 }
 
 dependencies {


### PR DESCRIPTION
https://github.com/Programmiermethoden/Dungeon/blob/a5aaa0ab62fa11c4fdbd2e66d0a7d70d1d93db20/build.gradle#L25-L27

Es wird für die `repositories` eigentlich nur noch der Standardeintrag `mavenCentral()` benötigt. Dort werden alle `dependencies` gefunden, und es baut und läuft ohne die extra Einträge.

fixes #1329