### PR TITLE
Gradle: simplify recognition of macOS

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,8 +59,6 @@ sourceSets.main.antlr.srcDirs = ['dungeon/src/dsl/antlr']
 project.ext.mainClassName = 'starter.BasicStarter'
 project.ext.assetsDir = new File('game/assets')
 
-import org.gradle.nativeplatform.platform.internal.DefaultNativePlatform
-
 application {
     mainClass = project.mainClassName
 }
@@ -173,7 +171,7 @@ tasks.withType(JavaExec).configureEach {
     doFirst {
         println(DefaultNativePlatform.currentOperatingSystem)
     }
-    if (DefaultNativePlatform.currentOperatingSystem.isMacOsX()) {
+    if (System.properties['os.name'].toLowerCase().contains('mac')) {
         jvmArgs('-XstartOnFirstThread')
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -169,7 +169,7 @@ tasks.withType(JavaExec).configureEach {
     standardInput = System.in
     ignoreExitValue true
     doFirst {
-        println(DefaultNativePlatform.currentOperatingSystem)
+        println(System.properties['os.name'])
     }
     if (System.properties['os.name'].toLowerCase().contains('mac')) {
         jvmArgs('-XstartOnFirstThread')


### PR DESCRIPTION
According to the Gradle documentation `org.gradle.nativeplatform.platform.internal.DefaultNativePlatform` is supposed an _internal_ package and not to be used in customers code.

Using `System.properties['os.name'].toLowerCase().contains('mac')` instead of `DefaultNativePlatform.currentOperatingSystem.isMacOsX()` we can also avoid the solo import `import org.gradle.nativeplatform.platform.internal.DefaultNativePlatform` ... 

fixes #1331