### PR TITLE
Dependabot: disable all labels

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,4 +9,4 @@ updates:
         directory: "/"
         schedule:
             interval: "weekly"
-        labels: [ ]
+        labels: []

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,9 @@ updates:
         directory: "/"
         schedule:
             interval: "weekly"
+        labels: [ ]
     -   package-ecosystem: "gradle"
         directory: "/"
         schedule:
             interval: "weekly"
+        labels: [ ]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
         directory: "/"
         schedule:
             interval: "weekly"
-        labels: [ ]
+        labels: []
     -   package-ecosystem: "gradle"
         directory: "/"
         schedule:


### PR DESCRIPTION
Depandabot fügt selbstständig neue Label in das Projekt ein, die es für die PR braucht. Das nervt auf Dauer, deshalb soll dieser PR das Verhalten abstellen.

Lt. Doku soll ein `labels: [ ]` hinzugefügt werden, um das Nutzen (und entsprechend Neudefinieren) von Labels durch Dependabot abzuschalten.

Dokumentation: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#labels