### PR TITLE
Blockly: Fixed HUD not working after Level-Change

### DIFF
--- a/blockly/src/client/Client.java
+++ b/blockly/src/client/Client.java
@@ -58,6 +58,8 @@ public class Client {
 
     onFrame(debugger);
 
+    onLevelLoad();
+
     // build and start game
     Game.run();
 
@@ -83,11 +85,20 @@ public class Client {
 
           TileLevel firstLevel = initLevels();
           Game.currentLevel(firstLevel);
+        });
+  }
 
-          VariableHUD variableHUD = new VariableHUD(Game.stage());
+  private static void onLevelLoad() {
+    Game.userOnLevelLoad(
+        (firstLoad) -> {
+          VariableHUD variableHUD = Server.instance().variableHUD;
+          if (variableHUD == null) { // should only be on first level load
+            variableHUD = new VariableHUD(Game.stage());
+            Server.instance().variableHUD = variableHUD;
+          }
+
+          // (Re-)add the variable HUD to the game
           Game.add(variableHUD.createEntity());
-
-          Server.instance().variableHUD = variableHUD;
         });
   }
 


### PR DESCRIPTION
Jetzt update sich das `VariableHUD` auch nach dem Level-Wechsel.
Das Problem war das jedes Entity nach dem Level-Wechsel vom Spiel entfernt wird, so konnte das HUD sich nicht mehr update beim ändern der Bildschirm-Größe. Jetzt wird die alte Referenze vom Server wieder ins Spiel hinzugefügt beim Level-Wechsel.

fixes #1700 
