### PR TITLE
Blockly: Schedule restart to avoid race conditions

### DIFF
--- a/blockly/src/level/produs/Chapter18Level.java
+++ b/blockly/src/level/produs/Chapter18Level.java
@@ -118,8 +118,11 @@ public class Chapter18Level extends BlocklyLevel {
 
   @Override
   protected void onTick() {
-    if (EntityUtils.getHeroCoordinate().y < 10)
-      LevelManagementUtils.cameraFocusOn(new Coordinate(10, 5));
+    Coordinate heroCoord = EntityUtils.getHeroCoordinate();
+    if (heroCoord == null) {
+      return; // Hero not yet spawned
+    }
+    if (heroCoord.y < 10) LevelManagementUtils.cameraFocusOn(new Coordinate(10, 5));
     else LevelManagementUtils.cameraFocusOn(new Coordinate(10, 15));
 
     if (switch1.isOn()) door1.open();


### PR DESCRIPTION
Fix für #1886 und #2025. Der Blockly Server plant jetzt den Restart, statt ihn direkt auszuführen, um `ConcurrentModificationException` und Race Conditions zu verhindern. In Level 8 wird außerdem korrekt auf `null` geprüft, falls der Held noch nicht gespawnt wurde. Im Blockly-Frontend werden die Start-Buttons schon beim Versuch, das Programm zu starten, deaktiviert, um parallele Durchläufe zu verhindern. (Das sollte am Besten später auch Server-side verhindert werden)

* `Server.java`: Änderung, sodass `restart()` den Restart plant wenn ein anderen Thread es aufruft, statt sofort ausgeführt zu werden. Dafür wird ein System verwendet um ein static boolean abzufragen.
* `Level8.java`: Hinzufügen eines `null`-Checks für den Helden, um Abstürze zu verhindern.
* `index.ts`: Deaktivieren der Start-Buttons direkt beim Startversuch, um parallele Ausführungen zu unterbinden.

closes #1886
closes #2025
