### PR TITLE
Blockly: Reduce sleep & add new config in VS Code extension

### DIFF
--- a/blockly/src/utils/BlocklyCodeRunner.java
+++ b/blockly/src/utils/BlocklyCodeRunner.java
@@ -39,7 +39,7 @@ public class BlocklyCodeRunner {
    */
   public static String TEMP_FOLDER_NAME = "blockly";
 
-  private static final int SLEEP_AFTER_EACH_LINE = 1; // seconds
+  private static final int DEFAULT_SLEEP_AFTER_EACH_LINE = 500; // milliseconds
 
   private static final String CodeWrapper =
       """
@@ -100,9 +100,20 @@ public class BlocklyCodeRunner {
    * @throws RuntimeException If an error occurs during execution.
    */
   public void executeJavaCode(String code) throws RuntimeException {
-    code = addSleepCalls(code);
+    executeJavaCode(code, DEFAULT_SLEEP_AFTER_EACH_LINE);
+  }
+
+  /**
+   * Executes the given Java code.
+   *
+   * @param code Java code that should be executed.
+   * @param sleepAfterEachLine The time to sleep after each line of code execution, in milliseconds.
+   * @throws RuntimeException If an error occurs during execution.
+   */
+  public void executeJavaCode(String code, int sleepAfterEachLine) throws RuntimeException {
+    if (sleepAfterEachLine > 0) code = addSleepCalls(code); // no sleep if time is 0
     codeRunning.set(true);
-    code = String.format(CodeWrapper, code, SLEEP_AFTER_EACH_LINE);
+    code = String.format(CodeWrapper, code, sleepAfterEachLine);
 
     // In system temp directory
     Path tempDir = tempFolder();

--- a/blockly/vs-code-extension/package.json
+++ b/blockly/vs-code-extension/package.json
@@ -47,6 +47,13 @@
           "type": "string",
           "default": "http://localhost:8080",
           "description": "Server-URL für Blockly"
+        },
+        "blocklyServer.sleepAfterEachLine": {
+          "type": "integer",
+          "default": 500,
+          "description": "Zeit in Millisekunden, die nach jeder Zeile gewartet wird, um die Ausführung zu verlangsamen. Setze auf 0, um keine Verzögerung zu haben.",
+          "minimum": 0,
+          "maximum": 10000
         }
       }
     },

--- a/blockly/vs-code-extension/src/extension.ts
+++ b/blockly/vs-code-extension/src/extension.ts
@@ -3,6 +3,7 @@ import { fetchLanguageConfig, BlocklyCompletionItem } from './handlers/languageP
 import sendBlocklyFile, {stopBlocklyExecution} from './handlers/sendBlocklyFile';
 
 export const BLOCKLY_URL = () => vscode.workspace.getConfiguration('blocklyServer').get('url', 'http://localhost:8080');
+export const SLEEP_AFTER_EACH_LINE = () => vscode.workspace.getConfiguration('blocklyServer').get('sleepAfterEachLine', 1000);
 const codeObjects = {
     'hero': {
         kind: vscode.CompletionItemKind.Class,

--- a/blockly/vs-code-extension/src/handlers/sendBlocklyFile.ts
+++ b/blockly/vs-code-extension/src/handlers/sendBlocklyFile.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import axios, {AxiosError} from 'axios';
 import {showMessageWithTimeout} from '../utils/utils';
-import {BLOCKLY_URL} from '../extension';
+import {BLOCKLY_URL, SLEEP_AFTER_EACH_LINE} from '../extension';
 
 // Create a diagnostic collection to manage error diagnostics
 const diagnosticCollection = vscode.languages.createDiagnosticCollection('blockly');
@@ -33,7 +33,7 @@ export default async function sendBlocklyFile() {
 
     try {
         await axios.post(BLOCKLY_URL() + "/reset", {}, {headers: {'Content-Type': 'text/plain'}}); // reset before any input
-        await axios.post(BLOCKLY_URL() + "/code", code, {headers: {'Content-Type': 'text/plain'}});
+        await axios.post(BLOCKLY_URL() + "/code?sleep=" + SLEEP_AFTER_EACH_LINE(), code, {headers: {'Content-Type': 'text/plain'}});
         showMessageWithTimeout('Blockly file sent successfully!');
     } catch (error: unknown) {
         if (!(error instanceof AxiosError))
@@ -84,7 +84,7 @@ function displayErrorsInEditor(errorMessage: string, document: vscode.TextDocume
     // Parse Java compilation errors
     // Format is typically: "filename:line: error: message"
     const errorLines = errorMessage.split('\n');
-    
+
     const errorRegex = /UserScript\.java:(\d+): ([fF]ehler|[eE]rror): (.+)/;
     // Try to determine a more specific range for the error
     // For example, if the error message mentions a specific symbol


### PR DESCRIPTION
Ich habe die Standard-Sleep-Dauer für im VS Code generierten User-Code von 1000 ms auf 500 ms reduziert und eine Konfigurationsmöglichkeit ergänzt, um den Wert per VS Code Extension anpassen zu können.

* `BlocklyCodeRunner.java`: Standard-Delay im Runner von 1000 ms auf 500 ms gesenkt.
* `Server.java`: Akzeptiert nun einen optionalen Query-Parameter `sleepDelay`, der an den Runner weitergereicht wird (Default: 500 ms).
* VS-Code-Extension: Erweiterung der Extension-Konfiguration um `sleepAfterEachLine`; übergibt den Wert beim Senden des Codes an den Server. (Default: 500)

closes #2024
