### PR TITLE
Escape: add source 'maddox2005delayed'

### DIFF
--- a/escape-room/doc/research/sources/maddox2005delayed.md
+++ b/escape-room/doc/research/sources/maddox2005delayed.md
@@ -1,0 +1,41 @@
+---
+title: "Delayed Feedback Disrupts the Procedural-Learning System but Not the Hypothesis-Testing System in Perceptual Category Learning"
+---
+
+## Bibtex
+
+```bibtex
+@article{maddox2005delayed,
+  title     = "Delayed feedback disrupts the procedural-learning system but not
+               the hypothesis-testing system in perceptual category learning",
+  author    = "Maddox, W Todd and Ing, A David",
+  journal   = "J. Exp. Psychol. Learn. Mem. Cogn.",
+  publisher = "American Psychological Association (APA)",
+  volume    =  31,
+  number    =  1,
+  pages     = "100--107",
+  month     =  jan,
+  year      =  2005
+}
+```
+
+## Zusammenfassung
+
+Beim Erlernen von Kategorien haben Verzögerungen des Feedbacks für bestimmte Lernstrategien negative Auswirkungen auf den Lernerfolg.
+
+> Rule-based category-learning tasks are those in which the category structures can be learned via some explicit reasoning proces.
+
+> [..] it is assumed that learning in rule-based tasks is dominated by an explicit hypothesis-testing system that uses working memory and executive attention [..]
+
+> learning in information-integration tasks is assumed to be dominated by an implicit, procedural-learning-based system that depends on a reward signal to strengthen the appropriate (stimulu-category) associations [..]
+
+> In reward-mediated learning, it is essential to strengthen those (and only those) synapses that actively participated in the response that elicited the reward.
+> Because there is necessarily some delay between response and reward delivery, a chemical trace must be maintained that signals which spines were recently active.
+> [..]
+> If the reward is delayed, then the perceptual signal will degrade, and the ensuing dopamine release will modify inappropriate synapses, which causes learning to be adversely affected.
+
+## Übertragung auf unsere Arbeit
+
+Um die Spannung in der Geschichte zu steigern (was einen Mehrwert für den Lernerfolg bieten kann) bietet es sich unter Umständen an, die Rückmeldung der Ergebnisse für die Spieler zu verzögern.
+Allerdings sollte dieses Vorgehen in bestimmten Szenarien nur bedacht eingesetzt werden. Vlt. durch die gezielte Bewusstmachung von Merkmalen.
+Wahrscheinlich lässt sich diese Erkenntnis nicht oder nur schwer in das Tooling einbauen. Da wir bisher nicht voraussetzen, dass die Benutzer Erfahrung mit interaktivem Lernen haben, sollte dieser Umstand zumindest in der Dokumentation erwähnt werden.


### PR DESCRIPTION
Die Frage nach der Verzögerung von Rückmeldungen zu Rätseln kam durch den Beschluss der Kategorien von Feedback in Miro auf