### PR TITLE
Blockly: active Blocks now correctly checks releative direction

### DIFF
--- a/blockly/src/utils/BlocklyCommands.java
+++ b/blockly/src/utils/BlocklyCommands.java
@@ -316,10 +316,15 @@ public class BlocklyCommands {
     if (targetTile == null) {
       return false; // no tile in the given direction
     }
-    if (targetTile instanceof DoorTile) return ((DoorTile) targetTile).isOpen();
-    return Game.entityAtTile(targetTile)
-        .flatMap(e -> e.fetch(LeverComponent.class).stream())
-        .allMatch(LeverComponent::isOn);
+
+    if (targetTile instanceof DoorTile doorTile) {
+      return doorTile.isOpen();
+    }
+
+    List<LeverComponent> levers =
+        Game.entityAtTile(targetTile).flatMap(e -> e.fetch(LeverComponent.class).stream()).toList();
+
+    return !levers.isEmpty() && levers.stream().allMatch(LeverComponent::isOn);
   }
 
   /**


### PR DESCRIPTION
Der `aktiv` Block kontrolliert nun korrekt ob die relative Richtung (vom Helden) aktiv ist statt die Absolute.
Zusätzlich wurde die Logik, wenn kein Schalter auf dem Tile ist angepasst, sodass es jetzt wie eigentlich erwartet `false` zurück gibt statt `true`.

closes #2068 