### PR TITLE
Core: use workaround for mac os resize crashes

### DIFF
--- a/game/src/core/game/GameLoop.java
+++ b/game/src/core/game/GameLoop.java
@@ -9,6 +9,7 @@ import com.badlogic.gdx.backends.lwjgl3.Lwjgl3ApplicationConfiguration;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.scenes.scene2d.Stage;
 import com.badlogic.gdx.utils.Scaling;
+import com.badlogic.gdx.utils.SharedLibraryLoader;
 import com.badlogic.gdx.utils.viewport.ScalingViewport;
 import core.Entity;
 import core.Game;
@@ -95,7 +96,9 @@ public final class GameLoop extends ScreenAdapter {
     config.setWindowIcon(PreRunConfiguration.logoPath().pathString());
     config.disableAudio(PreRunConfiguration.disableAudio());
     config.setWindowListener(WindowEventManager.windowListener());
-
+    if (SharedLibraryLoader.isMac && Gdx.app == null) {
+      org.lwjgl.system.Configuration.GLFW_LIBRARY_NAME.set("glfw_async");
+    }
     if (PreRunConfiguration.fullScreen()) {
       config.setFullscreenMode(Lwjgl3ApplicationConfiguration.getDisplayMode());
     } else {

--- a/game/src/core/game/PreRunConfiguration.java
+++ b/game/src/core/game/PreRunConfiguration.java
@@ -28,7 +28,7 @@ public final class PreRunConfiguration {
   private static int FRAME_RATE = 30;
   private static boolean FULL_SCREEN = false;
 
-  private static boolean RESIZEABLE = false;
+  private static boolean RESIZEABLE = true;
   private static String WINDOW_TITLE = "PM-Dungeon";
   private static IPath LOGO_PATH = new SimpleIPath("logo/cat_logo_35x35.png");
   private static boolean DISABLE_AUDIO = false;


### PR DESCRIPTION
fixes #1842 (sort of)

Im Grunde setzte ich den Workaround von https://github.com/libgdx/libgdx/issues/6987#issuecomment-1595699883 ein. 
Die XStartOnFirstThread-Geschichte machen wir bereits über Gradle.

Wenn ich das richtig verstehe:
setzt dieser Code auf macOS vor der Initialisierung von LibGDX die GLFW-Bibliothek auf eine asynchrone Variante („glfw_async“), um mögliche Deadlocks oder Startprobleme zu vermeiden. 

Auf der anderen Seite sagt https://libgdx.com/wiki/start/import-and-running das `glfw_async` und `XStartOnFirstThread` eigentlich das selbe machen. Doch Plazebo? 

>On macOS, LWJGL3 projects require one extra step: Either, in your Run Configuration, set the VM Options to -XstartOnFirstThread. Or, add the following experimental code snippet to your main() method: if (SharedLibraryLoader.isMac) Configuration.GLFW_LIBRARY_NAME.set("glfw_async"); Additional information on this can be found [here](https://libgdx.com/news/2021/07/devlog-7-lwjgl3#do-i-need-to-do-anything-else).


Ich habe das getestet und (bis auf einmal) keine Abstürze gehabt. Das kann aber auch Zufall gewesen sein.
Ich will das im Auge behalten, mich aber nicht 2 h hinstellen und Fenster verschieben.
Solange es nichts kaputt macht => In den Master und wenn ich merke "Geht doch nicht", dann ziehen wir es wieder raus. 

- Außerdem aktiviere ich das Resizing per Default. 


@Flamtky guckst du mal, ob das was unter Windows kaputt macht. 