### PR TITLE
Blockly: Close Blockly Server on error

### DIFF
--- a/blockly/src/client/Client.java
+++ b/blockly/src/client/Client.java
@@ -63,9 +63,14 @@ public class Client {
     onLevelLoad();
 
     // build and start game
-    Game.run();
-
-    httpServer.stop(0);
+    try {
+      Game.run();
+    } finally {
+      // Ensure that the server is stopped when the game ends
+      if (httpServer != null) {
+        httpServer.stop(0);
+      }
+    }
   }
 
   private static void onFrame(Debugger debugger) {


### PR DESCRIPTION
Als Ergänzung zu #2142 

Jetzt sollte, falls das Spiel abstürzt trotzdem der Blockly Server beendet werden.