### PR TITLE
Dungeon: Replace `.fetch(...).isPresent()` with a direct call to `.isPresent(...)`

### DIFF
--- a/dungeon/src/contrib/entities/AIFactory.java
+++ b/dungeon/src/contrib/entities/AIFactory.java
@@ -187,8 +187,8 @@ public final class AIFactory {
   private static Optional<Entity> randomMonster() {
     Stream<Entity> monsterStream =
         Game.entityStream()
-            .filter(m -> m.fetch(HealthComponent.class).isPresent())
-            .filter(m -> m.fetch(AIComponent.class).isPresent());
+            .filter(m -> m.isPresent(HealthComponent.class))
+            .filter(m -> m.isPresent(AIComponent.class));
 
     List<Entity> monsterList = monsterStream.toList();
     Entity monster = null;

--- a/dungeon/test/contrib/components/InteractionComponentTest.java
+++ b/dungeon/test/contrib/components/InteractionComponentTest.java
@@ -44,7 +44,7 @@ public class InteractionComponentTest {
     e.add(component);
     component.triggerInteraction(e, null);
     verify(iInteraction).accept(e, null);
-    assertTrue(e.fetch(InteractionComponent.class).isPresent());
+    assertTrue(e.isPresent(InteractionComponent.class));
   }
 
   /** Checks if after the interaction the component gets removed. */
@@ -56,7 +56,7 @@ public class InteractionComponentTest {
     e.add(component);
     component.triggerInteraction(e, null);
     verify(iInteraction).accept(e, null);
-    assertFalse(e.fetch(InteractionComponent.class).isPresent());
+    assertFalse(e.isPresent(InteractionComponent.class));
   }
 
   /** Checks that the interaction only gets triggered for the linked iInteraction. */
@@ -86,6 +86,6 @@ public class InteractionComponentTest {
     InteractionComponent component2 = new InteractionComponent(1, false, iInteraction2);
     e2.add(component2);
     component.triggerInteraction(e, null);
-    assertTrue(e2.fetch(InteractionComponent.class).isPresent());
+    assertTrue(e2.isPresent(InteractionComponent.class));
   }
 }

--- a/dungeon/test/contrib/entities/ChestTest.java
+++ b/dungeon/test/contrib/entities/ChestTest.java
@@ -38,7 +38,7 @@ public class ChestTest {
     Entity c = null;
     c = EntityFactory.newChest(itemData, position);
 
-    assertTrue(c.fetch(DrawComponent.class).isPresent());
+    assertTrue(c.isPresent(DrawComponent.class));
     Optional<InventoryComponent> inventoryComponent = c.fetch(InventoryComponent.class);
     assertTrue(inventoryComponent.isPresent());
     assertArrayEquals(
@@ -112,7 +112,7 @@ public class ChestTest {
 
     // assertTrue("Chest is added to Game", Game.getEntitiesStream().anyMatch(e -> e ==
     // newChest));
-    assertTrue(newChest.fetch(DrawComponent.class).isPresent());
+    assertTrue(newChest.isPresent(DrawComponent.class));
     Optional<InventoryComponent> inventoryComponent = newChest.fetch(InventoryComponent.class);
     assertTrue(inventoryComponent.isPresent());
     assertTrue(1 <= inventoryComponent.map(InventoryComponent.class::cast).get().items().length);

--- a/dungeon/test/contrib/utils/components/ai/ProtectOnAttackTest.java
+++ b/dungeon/test/contrib/utils/components/ai/ProtectOnAttackTest.java
@@ -117,7 +117,7 @@ public class ProtectOnAttackTest {
     protector.add(attackerAI);
     // when
     for (Entity e : entitiesToProtect) {
-      if (e.fetch(HealthComponent.class).isPresent()) {
+      if (e.isPresent(HealthComponent.class)) {
         HealthComponent hCp = e.fetch(HealthComponent.class).get();
         hCp.receiveHit(new Damage(1, null, attacker));
       }


### PR DESCRIPTION
Ersetzung von `.fetch(...).isPresent()` durch den direkten Aufruf von `.isPresent(...)` in:

dungeon/src/contrib/entities/AIFactory.java
dungeon/test/contrib/components/InteractionComponentTest.java
dungeon/test/contrib/entities/ChestTest.java
dungeon/test/contrib/utils/components/ai/ProtectOnAttackTest.java