### PR TITLE
Dungeon/Blockly: fix blockly movement and update  `ECSManagment` API for more clearity

### DIFF
--- a/advancedDungeon/src/produsAdvanced/AdvancedDungeon.java
+++ b/advancedDungeon/src/produsAdvanced/AdvancedDungeon.java
@@ -202,7 +202,7 @@ public class AdvancedDungeon {
    * @throws IOException If hero creation fails.
    */
   private static void createHero() throws IOException {
-    Game.entityStream(Set.of(PlayerComponent.class)).forEach(Game::remove);
+    Game.levelEntities(Set.of(PlayerComponent.class)).forEach(Game::remove);
     Entity heroEntity = EntityFactory.newHero();
     Game.add(heroEntity);
     hero = new Hero(heroEntity, fireballSkill);

--- a/advancedDungeon/src/produsAdvanced/abstraction/Berry.java
+++ b/advancedDungeon/src/produsAdvanced/abstraction/Berry.java
@@ -107,7 +107,7 @@ public class Berry extends Item {
                 .filter(i -> i.equals(this))
                 .isPresent();
 
-    return Game.entityStream(Set.of(ItemComponent.class))
+    return Game.levelEntities(Set.of(ItemComponent.class))
         .filter(isThisBerry::test)
         .findFirst()
         .orElse(null);

--- a/advancedDungeon/src/produsAdvanced/level/AdvancedBerryLevel.java
+++ b/advancedDungeon/src/produsAdvanced/level/AdvancedBerryLevel.java
@@ -254,7 +254,7 @@ public class AdvancedBerryLevel extends AdvancedLevel {
               // Falls noch weitere Nachrichten vorhanden sind, zum nächsten Text wechseln
               if (currentIndex.get() < messages.size() - 1) {
                 currentIndex.incrementAndGet();
-                Game.entityStream(Set.of(SignComponent.class))
+                Game.levelEntities(Set.of(SignComponent.class))
                     .filter(signEntity -> signEntity.equals(entity))
                     .findFirst()
                     .ifPresent(

--- a/advancedDungeon/src/produsAdvanced/level/AdvancedControlLevel3.java
+++ b/advancedDungeon/src/produsAdvanced/level/AdvancedControlLevel3.java
@@ -114,7 +114,7 @@ public class AdvancedControlLevel3 extends AdvancedLevel {
     else door1.close();
     if (l2.isOn() && l3.isOn()) door2.open();
     else door2.close();
-    if (Game.entityStream(Set.of(AIComponent.class)).findAny().isEmpty()) exit.open();
+    if (Game.levelEntities(Set.of(AIComponent.class)).findAny().isEmpty()) exit.open();
   }
 
   private void addSign() {
@@ -128,7 +128,7 @@ public class AdvancedControlLevel3 extends AdvancedLevel {
               // Falls noch weitere Nachrichten vorhanden sind, zum nächsten Text wechseln
               if (currentIndex.get() < messages.size() - 1) {
                 currentIndex.incrementAndGet();
-                Game.entityStream(Set.of(SignComponent.class))
+                Game.levelEntities(Set.of(SignComponent.class))
                     .filter(signEntity -> signEntity.equals(entity))
                     .findFirst()
                     .ifPresent(

--- a/advancedDungeon/src/produsAdvanced/level/AdvancedControlLevel4.java
+++ b/advancedDungeon/src/produsAdvanced/level/AdvancedControlLevel4.java
@@ -96,7 +96,7 @@ public class AdvancedControlLevel4 extends AdvancedLevel {
               // Falls noch weitere Nachrichten vorhanden sind, zum nächsten Text wechseln
               if (currentIndex.get() < messages.size() - 1) {
                 currentIndex.incrementAndGet();
-                Game.entityStream(Set.of(SignComponent.class))
+                Game.levelEntities(Set.of(SignComponent.class))
                     .filter(signEntity -> signEntity.equals(entity))
                     .findFirst()
                     .ifPresent(

--- a/advancedDungeon/src/produsAdvanced/level/AdvancedSortLevel.java
+++ b/advancedDungeon/src/produsAdvanced/level/AdvancedSortLevel.java
@@ -226,7 +226,7 @@ public class AdvancedSortLevel extends AdvancedLevel {
               // Falls noch weitere Nachrichten vorhanden sind, zum nächsten Text wechseln
               if (currentIndex.get() < messages.size() - 1) {
                 currentIndex.incrementAndGet();
-                Game.entityStream(Set.of(SignComponent.class))
+                Game.levelEntities(Set.of(SignComponent.class))
                     .filter(signEntity -> signEntity.equals(entity))
                     .findFirst()
                     .ifPresent(

--- a/blockly/src/client/Client.java
+++ b/blockly/src/client/Client.java
@@ -202,7 +202,7 @@ public class Client {
    * @throws RuntimeException if an {@link IOException} occurs during hero creation
    */
   public static void createHero() {
-    Game.entityStream(Set.of(PlayerComponent.class)).forEach(e -> Game.remove(e));
+    Game.levelEntities(Set.of(PlayerComponent.class)).forEach(e -> Game.remove(e));
     Entity hero;
     try {
       hero = HeroTankControlledFactory.newTankControlledHero();

--- a/blockly/src/level/LevelManagementUtils.java
+++ b/blockly/src/level/LevelManagementUtils.java
@@ -25,7 +25,7 @@ public class LevelManagementUtils {
    * @param coordinate The coordinate to focus the camera on.
    */
   public static void cameraFocusOn(Coordinate coordinate) {
-    Game.entityStream()
+    Game.levelEntities()
         .filter(e -> e.isPresent(CameraComponent.class))
         .forEach(entity -> entity.remove(CameraComponent.class));
 
@@ -42,7 +42,7 @@ public class LevelManagementUtils {
    * @throws MissingHeroException if the hero entity is not present.
    */
   public static void cameraFocusHero() {
-    Game.entityStream()
+    Game.levelEntities()
         .filter(e -> e.isPresent(CameraComponent.class))
         .forEach(entity -> entity.remove(CameraComponent.class));
     Game.hero().orElseThrow(() -> new MissingHeroException()).add(new CameraComponent());

--- a/blockly/src/level/produs/Level015.java
+++ b/blockly/src/level/produs/Level015.java
@@ -109,7 +109,7 @@ public class Level015 extends BlocklyLevel {
       if (x >= 11) LevelManagementUtils.cameraFocusHero();
     }
 
-    if (Game.entityStream(Set.of(AIComponent.class)).findAny().isPresent()) door.close();
+    if (Game.levelEntities(Set.of(AIComponent.class)).findAny().isPresent()) door.close();
     else door.open();
   }
 }

--- a/blockly/src/utils/BlocklyCommands.java
+++ b/blockly/src/utils/BlocklyCommands.java
@@ -57,7 +57,7 @@ public class BlocklyCommands {
     Entity hero = Game.hero().orElseThrow(MissingHeroException::new);
     Direction viewDirection = EntityUtils.getViewDirection(hero);
     BlocklyCommands.move(viewDirection, hero);
-    Game.entityStream()
+    Game.levelEntities()
         .filter(entity -> entity.name().equals("Blockly Black Knight"))
         .findFirst()
         .ifPresent(
@@ -450,7 +450,7 @@ public class BlocklyCommands {
         distances[i] = comp.pc.position().distance(comp.targetPosition.toCenteredPoint());
 
         if (comp.vc().maxSpeed() > 0
-            && Game.findEntity(entities[i])
+            && Game.existInLevel(entities[i])
             && !(distances[i] <= distanceThreshold || distances[i] > lastDistances[i])) {
           allEntitiesArrived = false;
         }

--- a/devDungeon/src/level/devlevel/BossLevel.java
+++ b/devDungeon/src/level/devlevel/BossLevel.java
@@ -258,7 +258,7 @@ public class BossLevel extends DevDungeonLevel implements IHealthObserver {
    * @return true if any other mobs are alive, false otherwise.
    */
   private boolean anyOtherMobsAlive() {
-    return Game.entityStream().filter(e -> e.isPresent(AIComponent.class)).toList().size()
+    return Game.levelEntities().filter(e -> e.isPresent(AIComponent.class)).toList().size()
         > 1; // 1 is the boss
   }
 

--- a/devDungeon/src/level/devlevel/riddleHandler/TorchRiddleRiddleHandler.java
+++ b/devDungeon/src/level/devlevel/riddleHandler/TorchRiddleRiddleHandler.java
@@ -140,7 +140,7 @@ public class TorchRiddleRiddleHandler {
     this.rewardGiven = true;
 
     // Once the reward is given, all torches are extinguished
-    Game.entityStream()
+    Game.levelEntities()
         .filter(e -> e.isPresent(TorchComponent.class))
         .forEach(
             e -> {

--- a/devDungeon/src/systems/MobSpawnerSystem.java
+++ b/devDungeon/src/systems/MobSpawnerSystem.java
@@ -164,7 +164,7 @@ public class MobSpawnerSystem extends System {
    * @return A list of entities around the given position within the given radius.
    */
   private List<Entity> getEntitiesAround(Point position, int radius) {
-    return Game.entityStream(Collections.singleton(AIComponent.class)) // mobs
+    return Game.levelEntities(Collections.singleton(AIComponent.class)) // mobs
         .filter(
             entity -> {
               PositionComponent entityPosition =

--- a/dungeon/src/contrib/entities/AIFactory.java
+++ b/dungeon/src/contrib/entities/AIFactory.java
@@ -187,7 +187,7 @@ public final class AIFactory {
    */
   private static Optional<Entity> randomMonster() {
     Stream<Entity> monsterStream =
-        Game.entityStream()
+        Game.levelEntities()
             .filter(m -> m.isPresent(HealthComponent.class))
             .filter(m -> m.isPresent(AIComponent.class));
 

--- a/dungeon/src/contrib/entities/HeroFactory.java
+++ b/dungeon/src/contrib/entities/HeroFactory.java
@@ -299,7 +299,7 @@ public final class HeroFactory {
         KeyboardConfig.CLOSE_UI.value(),
         (e) -> {
           var firstUI =
-              Game.entityStream() // would be nice to directly access HudSystems
+              Game.levelEntities() // would be nice to directly access HudSystems
                   // stream (no access to the System object)
                   .filter(x -> x.isPresent(UIComponent.class)) // find all Entities
                   // that have a

--- a/dungeon/src/contrib/hud/inventory/InventoryGUI.java
+++ b/dungeon/src/contrib/hud/inventory/InventoryGUI.java
@@ -110,7 +110,7 @@ public class InventoryGUI extends CombinableGUI {
    */
   public InventoryGUI(InventoryComponent inventoryComponent) {
     this(
-        Game.find(inventoryComponent)
+        Game.findInAll(inventoryComponent)
             .map(Entity::toString)
             .orElse("Inventory")
             .split("_(?=\\d+)")[0]

--- a/dungeon/src/contrib/utils/components/interaction/InteractionTool.java
+++ b/dungeon/src/contrib/utils/components/interaction/InteractionTool.java
@@ -37,7 +37,7 @@ public final class InteractionTool {
         who.fetch(PositionComponent.class)
             .orElseThrow(() -> MissingComponentException.build(who, PositionComponent.class));
     Optional<InteractionData> data =
-        Game.entityStream()
+        Game.levelEntities()
             .filter(x -> x.isPresent(InteractionComponent.class))
             .map(x -> convertToData(x, heroPosition))
             .filter(iReachable::apply)

--- a/dungeon/src/core/Game.java
+++ b/dungeon/src/core/Game.java
@@ -45,7 +45,7 @@ import java.util.stream.Stream;
  * <p>For System management use: {@link #add(System)}, {@link #remove(Class)} or {@link
  * #removeAllSystems()}
  *
- * <p>Get access via: {@link #entityStream()}, {@link #systems()}
+ * <p>Get access via: {@link #levelEntities()}, {@link #systems()}
  *
  * @see PreRunConfiguration
  * @see ECSManagment
@@ -340,12 +340,12 @@ public final class Game {
   }
 
   /**
-   * Use this stream if you want to iterate over all currently active entities.
+   * Use this stream if you want to iterate over all entities in the current level.
    *
-   * @return a stream of all entities currently in the game
+   * @return a stream of all entities currently in the level
    */
-  public static Stream<Entity> entityStream() {
-    return ECSManagment.entityStream();
+  public static Stream<Entity> levelEntities() {
+    return ECSManagment.levelEntities();
   }
 
   /**
@@ -356,8 +356,8 @@ public final class Game {
    * @return a stream of all entities currently in the game that should be processed by the given
    *     system.
    */
-  public static Stream<Entity> entityStream(final System system) {
-    return ECSManagment.entityStream(system);
+  public static Stream<Entity> levelEntities(final System system) {
+    return ECSManagment.levelEntities(system);
   }
 
   /**
@@ -366,14 +366,15 @@ public final class Game {
    * @param filter the components to check.
    * @return a stream of all entities currently in the game that contains the given components.
    */
-  public static Stream<Entity> entityStream(final Set<Class<? extends Component>> filter) {
-    return ECSManagment.entityStream(filter);
+  public static Stream<Entity> levelEntities(final Set<Class<? extends Component>> filter) {
+    return ECSManagment.levelEntities(filter);
   }
 
   /**
-   * Get the player character.
+   * Searches the current level for the player character.
    *
-   * @return the player character, can be null if not initialized
+   * @return an {@link Optional} containing the player character from the current level, or an empty
+   *     {@code Optional} if none is present
    */
   public static Optional<Entity> hero() {
     return ECSManagment.hero();
@@ -402,7 +403,7 @@ public final class Game {
   /**
    * Use this stream if you want to iterate over all active entities.
    *
-   * <p>Use {@link #entityStream()} if you want to iterate over all active entities.
+   * <p>Use {@link #levelEntities()} if you want to iterate over all active entities.
    *
    * @return a stream of all entities currently in the game
    */
@@ -411,13 +412,53 @@ public final class Game {
   }
 
   /**
-   * Find the entity that contains the given component instance.
+   * Finds the entity that contains the given component instance.
    *
-   * @param component Component instance where the entity is searched for.
-   * @return An Optional containing the found Entity, or an empty Optional if not found.
+   * <p>This searches across all entities in the game, not just those in the current level.
+   *
+   * @param component the component instance whose owning entity should be located
+   * @return an {@link Optional} containing the found entity, or an empty {@code Optional} if none
+   *     is found
    */
-  public static Optional<Entity> find(final Component component) {
-    return ECSManagment.find(component);
+  public static Optional<Entity> findInAll(final Component component) {
+    return ECSManagment.findInAll(component);
+  }
+
+  /**
+   * Finds the entity that contains the given component instance.
+   *
+   * <p>This searches across all entities in the current level.
+   *
+   * @param component the component instance whose owning entity should be located
+   * @return an {@link Optional} containing the found entity, or an empty {@code Optional} if none
+   *     is found
+   */
+  public static Optional<Entity> findInLevel(final Component component) {
+    return ECSManagment.findInLevel(component);
+  }
+
+  /**
+   * Tries to find the given entity in the game.
+   *
+   * <p>This searches in the current level.
+   *
+   * @param entity the entity to search for
+   * @return {@code true} if the entity is found, {@code false} otherwise
+   */
+  public static boolean existInLevel(Entity entity) {
+    return ECSManagment.existInLevel(entity);
+  }
+
+  /**
+   * Tries to find the given entity in the game.
+   *
+   * <p>This searches in the current level.
+   *
+   * @param entity the entity to search for
+   * @return {@code true} if the entity is found, {@code false} otherwise
+   */
+  public static boolean existInAll(final Entity entity) {
+    return ECSManagment.existInAll(entity);
   }
 
   /**
@@ -549,7 +590,7 @@ public final class Game {
     Tile tile = Game.tileAT(check.position());
     if (tile == null) return Stream.empty();
 
-    return ECSManagment.entityStream(Set.of(PositionComponent.class))
+    return ECSManagment.levelEntities(Set.of(PositionComponent.class))
         .filter(
             e ->
                 tile.equals(
@@ -719,15 +760,5 @@ public final class Game {
   /** Exits the GDX application. */
   public static void exit() {
     Gdx.app.exit();
-  }
-
-  /**
-   * Checks if the given entity is in {@link core.Game}.
-   *
-   * @param entity Entity to check.
-   * @return True if the entity is in the game, false otherwise.
-   */
-  public static boolean findEntity(final Entity entity) {
-    return ECSManagment.findEntity(entity);
   }
 }

--- a/dungeon/src/core/System.java
+++ b/dungeon/src/core/System.java
@@ -178,7 +178,7 @@ public abstract class System {
    */
   public final Stream<Entity> filteredEntityStream(
       final Set<Class<? extends Component>> filterRules) {
-    return Game.entityStream(filterRules);
+    return Game.levelEntities(filterRules);
   }
 
   /**

--- a/dungeon/test/contrib/systems/HealthSystemTest.java
+++ b/dungeon/test/contrib/systems/HealthSystemTest.java
@@ -46,7 +46,7 @@ public class HealthSystemTest {
 
     system.execute();
     assertTrue(ac.isAnimationQueued(AdditionalAnimations.DIE));
-    assertFalse(Game.entityStream().anyMatch(e -> e == entity));
+    assertFalse(Game.levelEntities().anyMatch(e -> e == entity));
   }
 
   /** WTF? . */
@@ -66,7 +66,7 @@ public class HealthSystemTest {
     component.currentHealthpoints(0);
     system.execute();
     assertFalse(ac.isCurrentAnimation(AdditionalAnimations.DIE));
-    assertTrue(Game.entityStream().anyMatch(e -> e == entity));
+    assertTrue(Game.levelEntities().anyMatch(e -> e == entity));
   }
 
   /** WTF? . */

--- a/dungeon/test/contrib/utils/components/item/ItemTest.java
+++ b/dungeon/test/contrib/utils/components/item/ItemTest.java
@@ -192,8 +192,8 @@ public class ItemTest {
 
     Point point = new Point(3, 3);
     item.drop(point);
-    assertEquals(1, Game.entityStream().count());
-    Entity worldItem = Game.entityStream().findFirst().get();
+    assertEquals(1, Game.levelEntities().count());
+    Entity worldItem = Game.levelEntities().findFirst().get();
     assertTrue(worldItem.isPresent(PositionComponent.class));
     assertTrue(worldItem.fetch(PositionComponent.class).get().position().equals(point));
     assertTrue(worldItem.isPresent(DrawComponent.class));
@@ -203,14 +203,14 @@ public class ItemTest {
   /** Tests if item is present in inventory and removed from Game world after collect. */
   @Test
   public void testCollect() {
-    assertEquals(0, Game.entityStream().count());
+    assertEquals(0, Game.levelEntities().count());
 
     Item item = new Item("Test item", "Test description", defaultAnimation);
     item.drop(new Point(0, 0));
-    assertEquals(1, Game.entityStream().count());
+    assertEquals(1, Game.levelEntities().count());
     Entity collector = new Entity();
     collector.add(new InventoryComponent(3));
-    Entity worldItem = Game.entityStream().findFirst().get();
+    Entity worldItem = Game.levelEntities().findFirst().get();
 
     assertTrue(item.collect(worldItem, collector));
 
@@ -220,38 +220,38 @@ public class ItemTest {
             .map(inventoryComponent -> inventoryComponent.hasItem(item))
             .get());
 
-    assertEquals(0, Game.entityStream().count());
+    assertEquals(0, Game.levelEntities().count());
   }
 
   /** Tests if item can be collected from entity with no InventoryComponent. */
   @Test
   public void testCollectNoInventory() {
-    assertEquals(0, Game.entityStream().count());
+    assertEquals(0, Game.levelEntities().count());
 
     Item item = new Item("Test item", "Test description", defaultAnimation);
     item.drop(new Point(0, 0));
-    assertEquals(1, Game.entityStream().count());
+    assertEquals(1, Game.levelEntities().count());
     Entity collector = new Entity();
-    Entity worldItem = Game.entityStream().findFirst().get();
+    Entity worldItem = Game.levelEntities().findFirst().get();
 
     assertFalse(item.collect(worldItem, collector));
-    assertEquals(1, Game.entityStream().count());
+    assertEquals(1, Game.levelEntities().count());
   }
 
   /** Tests if item can be collected from entity with full inventory. */
   @Test
   public void testCollectFullInventory() {
-    assertEquals(0, Game.entityStream().count());
+    assertEquals(0, Game.levelEntities().count());
 
     Item item = new Item("Test item", "Test description", defaultAnimation);
     item.drop(new Point(0, 0));
-    assertEquals(1, Game.entityStream().count());
+    assertEquals(1, Game.levelEntities().count());
     Entity collector = new Entity();
     collector.add(new InventoryComponent(0));
-    Entity worldItem = Game.entityStream().findFirst().get();
+    Entity worldItem = Game.levelEntities().findFirst().get();
 
     assertFalse(item.collect(worldItem, collector));
-    assertEquals(1, Game.entityStream().count());
+    assertEquals(1, Game.levelEntities().count());
   }
 
   /** Tests if item is removed from inventory after use. */

--- a/dungeon/test/core/GameTest.java
+++ b/dungeon/test/core/GameTest.java
@@ -59,17 +59,17 @@ public class GameTest {
     DummyComponent dc = new DummyComponent();
     e.add(dc);
     Game.add(e);
-    assertEquals(e, Game.find(dc).get());
+    assertEquals(e, Game.findInAll(dc).get());
     // load ne level to check if it still works
     ILevel level = Mockito.mock(ILevel.class);
-    assertEquals(e, Game.find(dc).get());
+    assertEquals(e, Game.findInAll(dc).get());
   }
 
   /** WTF? . */
   @Test
   public void find_nonExisting() {
     DummyComponent dc = new DummyComponent();
-    assertTrue(Game.find(dc).isEmpty());
+    assertTrue(Game.findInAll(dc).isEmpty());
   }
 
   private static class DummyComponent implements Component {}


### PR DESCRIPTION
* In Blockly wurde der Boss immer versucht zu bewegen, auch wenn:
  a) er gar nicht im aktuellen Level ist
  b) seine `maxSpeed` 0 ist
* Das führte dazu, dass die `move`-Funktion in einen Endlosloop geriet.

**Fix:**

* Suche nur noch nach dem Boss **im aktuellen Level**.
* Prüfe `if maxSpeed == 0` → `break`, um die Bewegung zu stoppen.

**Ursache:**

* Die API im `ECSManagement` war undeutlich: Es war nicht klar, ob man alle Entitäten im Spiel oder nur die im aktuellen Level meint.
* Durch bessere Namensgebung und Dokumentation ist der Unterschied jetzt klarer.

* Das Konzept, Entitäten global vs. level-spezifisch zu verwalten, ist etwas suboptimal, aber das ist eine andere Baustelle.

