### PR TITLE
DynamicCompiler: Chamber of Secrets ClassCastException

### DIFF
--- a/advancedDungeon/build.gradle
+++ b/advancedDungeon/build.gradle
@@ -31,3 +31,16 @@ tasks.register('runPathFindingComparison', JavaExec) {
     mainClass = 'aiAdvanced.starter.ComparePathfindingStarter'
     classpath = sourceSets.main.runtimeClasspath
 }
+
+
+tasks.register('demo1', JavaExec) {
+    group 'starter'
+    mainClass = 'chamberofnosecrets.MyMain'
+    classpath = sourceSets.main.runtimeClasspath
+}
+
+tasks.register('demo2', JavaExec) {
+    group 'starter'
+    mainClass = 'chamberofsecrets.MyMain'
+    classpath = sourceSets.main.runtimeClasspath
+}

--- a/advancedDungeon/src/chamberofnosecrets/MyMain.java
+++ b/advancedDungeon/src/chamberofnosecrets/MyMain.java
@@ -1,0 +1,20 @@
+package chamberofnosecrets;
+
+import contrib.utils.DynamicCompiler;
+import core.utils.Tuple;
+import core.utils.components.path.SimpleIPath;
+
+public class MyMain {
+
+  private static final SimpleIPath PATH = new SimpleIPath("src/chamberofnosecrets/ToCode2.java");
+  private static final String CLASSNAME = "chamberofnosecrets.ToCode2";
+
+  public static void main(String[] args) {
+    try {
+      Object o = DynamicCompiler.loadUserInstance(PATH, CLASSNAME, new Tuple<>(Integer.class, 2));
+      System.out.println(((ToCode) o).getInteger());
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/advancedDungeon/src/chamberofnosecrets/ToCode.java
+++ b/advancedDungeon/src/chamberofnosecrets/ToCode.java
@@ -1,0 +1,6 @@
+package chamberofnosecrets;
+
+public abstract class ToCode {
+
+  public abstract int getInteger();
+}

--- a/advancedDungeon/src/chamberofnosecrets/ToCode2.java
+++ b/advancedDungeon/src/chamberofnosecrets/ToCode2.java
@@ -1,0 +1,9 @@
+package chamberofnosecrets;
+
+public class ToCode2 extends ToCode {
+  public ToCode2(Integer a) {}
+
+  public int getInteger() {
+    return 4;
+  }
+}

--- a/advancedDungeon/src/chamberofsecrets/MyMain.java
+++ b/advancedDungeon/src/chamberofsecrets/MyMain.java
@@ -1,0 +1,20 @@
+package chamberofsecrets;
+
+import contrib.utils.DynamicCompiler;
+import core.utils.Tuple;
+import core.utils.components.path.SimpleIPath;
+
+public class MyMain {
+
+  private static final SimpleIPath PATH = new SimpleIPath("src/chamberofsecrets/ToCode2.java");
+  private static final String CLASSNAME = "chamberofsecrets.ToCode2";
+
+  public static void main(String[] args) {
+    try {
+      Object o = DynamicCompiler.loadUserInstance(PATH, CLASSNAME, new Tuple<>(Integer.class, 2));
+      System.out.println(((ToCode) o).getInteger());
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/advancedDungeon/src/chamberofsecrets/ToCode.java
+++ b/advancedDungeon/src/chamberofsecrets/ToCode.java
@@ -1,0 +1,6 @@
+package chamberofsecrets;
+
+public abstract class ToCode {
+
+  public abstract int getInteger();
+}

--- a/advancedDungeon/src/chamberofsecrets/ToCode2.java
+++ b/advancedDungeon/src/chamberofsecrets/ToCode2.java
@@ -1,0 +1,9 @@
+package chamberofsecrets;
+
+public class ToCode2 extends ToCode {
+  public ToCode2(Integer a) {}
+
+  public int getInteger() {
+    return 4;
+  }
+}


### PR DESCRIPTION
Ich kann REPRODUZIEREND eine `java.lang.ClassCastException` im DynamicCompiler fixen, indem ich das Package von `chamberofsecrets` in `chamberofnosecrets` rename.

—

Ich hab mir ein mwe für den `DynamicCompiler` gebaut, weil ich was testen möchte.

Aufbau
Im Package `chamberofsecrets`
`MyMain.java`;  `ToCode.java` und `ToCode2.java`
wobei `ToCode` abstrakt ist und `ToCode2` von `ToCode` ableitet.

MyMain

```
package chamberofsecrets;

import contrib.utils.DynamicCompiler;
import core.utils.Tuple;
import core.utils.components.path.SimpleIPath;

public class MyMain {

  private static final SimpleIPath PATH = new SimpleIPath("src/chamberofsecrets/ToCode2.java");
  private static final String CLASSNAME = "chamberofsecrets.ToCode2";

  public static void main(String[] args) {
    try {
      Object o = DynamicCompiler.loadUserInstance(PATH, CLASSNAME, new Tuple<>(Integer.class, 2));
      System.out.println(((ToCode) o).getInteger());
    } catch (Exception e) {
      throw new RuntimeException(e);
    }
  }
}
 
```
und ich kriege eine

```
Exception in thread "main" java.lang.RuntimeException: java.lang.ClassCastException: class chamberofsecrets.ToCode2 cannot be cast to class chamberofsecrets.ToCode (chamberofsecrets.ToCode2 is in unnamed module of loader contrib.utils.DynamicCompiler$MyClassLoader @3c153a1; chamberofsecrets.ToCode is in unnamed module of loader 'app')
        at chamberofsecrets.MyMain.main(MyMain.java:17)
 
```
Da konflikten die Classloader miteinander.

ABER
wenn ich das package (und die Pfade) in `chamberofnosecrets` rename, dann geht alles.

```
  private static final SimpleIPath PATH = new SimpleIPath("src/chamberofnosecrets/ToCode2.java");
  private static final String CLASSNAME = "chamberofnosecrets.ToCode2"; 
```
Ich hab geguckt, es gibt kein anderes package `chamberofsecrets`

Werd ich bekloppt?


---

Edit: Ich hab mal das gradle target `demo1` und `demo2` gebaut und den Code copy pasted (einmal mit `chamberofsecrets` und einmal mit `chamberofnosecrets`) 
