### PR TITLE
 Dungeon: fix ctor for Bow-Skill

### DIFF
--- a/dungeon/src/contrib/utils/components/skill/projectileSkill/BowSkill.java
+++ b/dungeon/src/contrib/utils/components/skill/projectileSkill/BowSkill.java
@@ -79,8 +79,8 @@ public class BowSkill extends DamageProjectileSkill {
     this(
         targetSelection,
         BOW_COOLDOWN,
-        DEFAULT_PROJECTILE_RANGE,
         DEFAULT_PROJECTILE_SPEED,
+        DEFAULT_PROJECTILE_RANGE,
         DEFAULT_DAMAGE_AMOUNT,
         COST);
   }


### PR DESCRIPTION
Der einfache CTor im Bow Skill hatte den super ctor in falscher Parameter reihenfolge aufgerufen.
Deswegen wurde die Default Speed als Range gesetzt und umgedreht. Ich hab das fix gedreht