### PR TITLE
Dungeon: make `CursorSkill#executeOnCursor` protected

### DIFF
--- a/dungeon/src/contrib/utils/components/skill/cursorSkill/CursorSkill.java
+++ b/dungeon/src/contrib/utils/components/skill/cursorSkill/CursorSkill.java
@@ -54,5 +54,5 @@ public abstract class CursorSkill extends Skill {
    * @param caster The entity using the skill.
    * @param point The current cursor position in the game world.
    */
-  public abstract void executeOnCursor(Entity caster, Point point);
+  protected abstract void executeOnCursor(Entity caster, Point point);
 }

--- a/dungeon/src/contrib/utils/components/skill/cursorSkill/HealTarget.java
+++ b/dungeon/src/contrib/utils/components/skill/cursorSkill/HealTarget.java
@@ -76,7 +76,7 @@ public class HealTarget extends CursorSkill {
    * @param point The cursor position in the game world where the skill is applied.
    */
   @Override
-  public void executeOnCursor(Entity caster, Point point) {
+  protected void executeOnCursor(Entity caster, Point point) {
     Game.entityAtPoint(point).findFirst().ifPresent(this::heal);
   }
 }


### PR DESCRIPTION
Die `CursorSkill#executeOnCurso` war public, sollte aber protected sein.
Der einstiegspunkt fürs Skills ist immer `Skill#execute` 