### PR TITLE
Blockly: apply hotfix for push pull racecondition

### DIFF
--- a/blockly/src/coderunner/BlocklyCommands.java
+++ b/blockly/src/coderunner/BlocklyCommands.java
@@ -280,7 +280,8 @@ public class BlocklyCommands {
     toMove.forEach(entity -> entity.remove(BlockComponent.class));
     // TODO This is a hotfix for https://github.com/Dungeon-CampusMinden/Dungeon/issues/1952 , this
     // will make the hero move AFTER everyone else.
-    BlocklyCommands.turnEntity(hero, viewDirection);
+    BlocklyCommands.move(moveDirection, toMove.toArray(Entity[]::new));
+    BlocklyCommands.move(moveDirection, hero);
     // give BlockComponent back
     toMove.forEach(entity -> entity.add(new BlockComponent()));
     BlocklyCommands.turnEntity(hero, viewDirection);


### PR DESCRIPTION
Ein Hotfix für #1952, der Held wird jetzt explizit nach den Steinen bewegt.
Visuell sieht das etwas Käse aus, aber es verhindert unerwartete Gamestates. 


Vorher:

https://github.com/user-attachments/assets/e76f69d6-76d1-44b3-904f-f996b91df387

Jetzt: 

https://github.com/user-attachments/assets/441af30a-9a67-47a2-b986-3d0bd59cb083

