### PR TITLE
Blockly: dont push or pull if hero is frozen

### DIFF
--- a/blockly/src/coderunner/BlocklyCommands.java
+++ b/blockly/src/coderunner/BlocklyCommands.java
@@ -283,10 +283,10 @@ public class BlocklyCommands {
   private static void movePushable(boolean push) {
     Entity hero = Game.hero().orElseThrow(MissingHeroException::new);
     // do not push or pull if the hero is frozen
-    Optional<VelocityComponent> opt = hero.fetch(VelocityComponent.class);
-    if (opt.isPresent() && opt.get().maxSpeed() == 0) {
-      return; // exits the outer method
-    }
+    if (hero.fetch(VelocityComponent.class)
+        .map(VelocityComponent::maxSpeed)
+        .filter(s -> s == 0)
+        .isPresent()) return;
     DISABLE_SHOOT_ON_HERO = true;
     PositionComponent heroPC =
         hero.fetch(PositionComponent.class)


### PR DESCRIPTION
Wenn der Held gefreezt ist, sollte der Push bzw Pull Command nicht ausgeführt werden. 
Dieser Pr fügt einen entsprechenden Check ein.

Das Problem ist dadurch entsanden, dass ich in #2468 Held und Stein unabhängig voneinander bewege. 