### PR TITLE
Blockly: return false in isNearTile if there is no tile

### DIFF
--- a/blockly/src/coderunner/BlocklyCommands.java
+++ b/blockly/src/coderunner/BlocklyCommands.java
@@ -343,7 +343,7 @@ public class BlocklyCommands {
               .map(pos -> pos.translate(MAGIC_OFFSET))
               .flatMap(Game::tileAt)
               .orElse(null);
-      return checkTile.levelElement() == tileElement;
+      return checkTile != null && checkTile.levelElement() == tileElement;
     }
     return targetTile(direction).map(tile -> tile.levelElement() == tileElement).orElse(false);
   }


### PR DESCRIPTION
Eigentlich ein nicht erreichbarer Case aber ab jetzt wird `false` returnt, wenn der Held auf keinen Tile steht. 