### PR TITLE
Dungeon: Fix DrawSystem cache not properly removing entities

### DIFF
--- a/dungeon/src/core/systems/DrawSystem.java
+++ b/dungeon/src/core/systems/DrawSystem.java
@@ -91,10 +91,10 @@ public final class DrawSystem extends System {
         entitiesAtDepth.add(changed);
         sortedEntities.put(depth, entitiesAtDepth);
       }
-    } else if (!entitiesAtDepth.contains(data) && added) {
+    } else if (!entitiesAtDepth.contains(changed) && added) {
       entitiesAtDepth.add(changed);
     } else if (!added) {
-      entitiesAtDepth.remove(data);
+      entitiesAtDepth.remove(changed);
       if (entitiesAtDepth.isEmpty()) {
         sortedEntities.remove(depth);
       }


### PR DESCRIPTION
Entities mit DrawComponent werden derzeit einfach weitergezeichnet, wenn sie entfernt werden.