### PR TITLE
Blockly: fixes level 022 boss death not detected bug

### DIFF
--- a/blockly/src/entities/monster/BlocklyMonster.java
+++ b/blockly/src/entities/monster/BlocklyMonster.java
@@ -177,7 +177,6 @@ public enum BlocklyMonster {
       return monster;
     }
 
-    // This fixex the bug where the boss death in level 022 was not detected
     private HealthComponent buildHealthComponent() {
       Consumer<Entity> constructedOnDeath =
           entity -> {


### PR DESCRIPTION
Hier der gennante Fix aus #2513, um #2494 zu beheben.

closes #2494