### PR TITLE
Made catapults not solid

### DIFF
--- a/dungeon/src/contrib/entities/MiscFactory.java
+++ b/dungeon/src/contrib/entities/MiscFactory.java
@@ -448,7 +448,7 @@ public final class MiscFactory {
                   });
           catapultFlyEntity(other, spawnPoint, location, speed);
         };
-    catapult.add(new CollideComponent(action, CollideComponent.DEFAULT_COLLIDER));
+    catapult.add(new CollideComponent(action, CollideComponent.DEFAULT_COLLIDER).isSolid(false));
     return catapult;
   }
 


### PR DESCRIPTION
Fixes #2506

Problem war, dass die Katapulte solid waren. Da der Spieler auch solid ist, konnte dieser nicht vorbei kommen, wenn das  Katapult ihn in genau durch das Katapult senden wollte.

Zwei Optionen:
- Katapult wird nicht solid
- Katapult wird temporär nicht solid, solange der Spieler fliegt, und wird danach wieder solid gemacht

Hab jetzt erstmal ersteres genommen.