### PR TITLE
Blockly: Delete old Blocks

### DIFF
--- a/blockly/frontend/src/index.ts
+++ b/blockly/frontend/src/index.ts
@@ -64,6 +64,10 @@ levelSelector.addEventListener("levelChanged", (event) => {
   // Configure blocks and categories based on level restrictions
   blockElementsFromToolbox(toolbox, levelChangedEvent.blockedElements, "Not available in Level");
 
+  // clear the old workspace, so that if the new level has never been played all blocks from the level before are deleted
+  // this has to be done after saving the old game and loading the new game
+  workspace.clear()
+
   // Load new level and initialize workspace
   load(workspace, levelChangedEvent.newLevelName);
   updateCodeDiv();


### PR DESCRIPTION
Sobald ein neues Level begonnen wird, werden die Blöcke aus dem alten Level automatisch gelöscht. Man sieht jetzt nur noch den Start Block.

Ich habe meinen Code nun einige Male getestet und es hat in der Regel auch immer funktioniert. Nur einmal wurden links die Anweisungen nicht richtig erweitert. Ich hatte einmal in Level 4 kein Inventar und keine Skills (schieben, ziehen, benutzen). Kannst du @AMatutat einmal prüfen, ob es bei dir funktioniert? 

Closes #2527 