### PR TITLE
AdvancedDungeon: Fixed bug where portal direction caused a nullpointer

### DIFF
--- a/advancedDungeon/src/produsAdvanced/abstraction/portals/portalSkills/BluePortalSkill.java
+++ b/advancedDungeon/src/produsAdvanced/abstraction/portals/portalSkills/BluePortalSkill.java
@@ -31,10 +31,11 @@ public class BluePortalSkill extends PortalSkill {
   /**
    * Method that creates the blue portal via the PortalFactory class.
    *
-   * @param position Position where the portal will be created
+   * @param portalPosition Position where the portal will be created
+   * @param originalProjectilePosition original position of the projectile, needed for direction
    */
   @Override
-  protected void createPortal(Point position) {
-    PortalFactory.createPortal(position, PortalColor.BLUE);
+  protected void createPortal(Point portalPosition, Point originalProjectilePosition) {
+    PortalFactory.createPortal(portalPosition, originalProjectilePosition, PortalColor.BLUE);
   }
 }

--- a/advancedDungeon/src/produsAdvanced/abstraction/portals/portalSkills/GreenPortalSkill.java
+++ b/advancedDungeon/src/produsAdvanced/abstraction/portals/portalSkills/GreenPortalSkill.java
@@ -31,10 +31,11 @@ public class GreenPortalSkill extends PortalSkill {
   /**
    * Method that creates the green portal via the PortalFactory class.
    *
-   * @param position Position where the portal will be created
+   * @param portalPosition Position where the portal will be created
+   * @param originalProjectilePosition original position of the projectile, needed for direction
    */
   @Override
-  protected void createPortal(Point position) {
-    PortalFactory.createPortal(position, PortalColor.GREEN);
+  protected void createPortal(Point portalPosition, Point originalProjectilePosition) {
+    PortalFactory.createPortal(portalPosition, originalProjectilePosition, PortalColor.GREEN);
   }
 }

--- a/advancedDungeon/src/produsAdvanced/abstraction/portals/portalSkills/PortalSkill.java
+++ b/advancedDungeon/src/produsAdvanced/abstraction/portals/portalSkills/PortalSkill.java
@@ -74,10 +74,9 @@ public abstract class PortalSkill extends ProjectileSkill {
     Vector2 velocity = vc.currentVelocity().normalize();
     Point movedPos = pc.position().translate(velocity);
     Point finalPos = new Point(Math.round(movedPos.x()), Math.round(movedPos.y()));
-
     if (Game.tileAt(finalPos.toCoordinate()).isPresent()
         && Game.tileAt(finalPos.toCoordinate()).get().levelElement() == LevelElement.PORTAL) {
-      createPortal(finalPos.toCoordinate().toPoint());
+      createPortal(finalPos.toCoordinate().toPoint(), pc.position());
     }
     Game.remove(projectile);
   }
@@ -135,7 +134,8 @@ public abstract class PortalSkill extends ProjectileSkill {
    * Method that has to be implemented in the actual skill where the corresponding portal is
    * created.
    *
-   * @param position Position where the portal will be created
+   * @param portalPosition Position where the portal will be created
+   * @param originalProjectilePosition original position of the projectile, needed for direction
    */
-  protected abstract void createPortal(Point position);
+  protected abstract void createPortal(Point portalPosition, Point originalProjectilePosition);
 }


### PR DESCRIPTION
Das Game hatte einen Nullpointer bei der direction berechnung geworfen da nur Floortiles mitberücksichtigt wurden. Heißt wenn es keines gibt(Portal an einer Wand mit einen Pit davor, sieht Bild 1) ist das Game gecrasht da es keine Floortiles finden konnte.
Bild 1
<img width="198" height="148" alt="image" src="https://github.com/user-attachments/assets/0c59e6da-2b3e-4e6f-bce3-3dcc0a348659" />

Das ist nun behoben indem alle Nachbarn mitberücksichtigt werden und die Projektil Position bei der Wall Collision nun als Ausgangspunkt für die Distanzberechnung gilt. 