### PR TITLE
Dungeon: `EntitySystemMapper` iterate over set copy to avoid mce

### DIFF
--- a/dungeon/src/core/utils/EntitySystemMapper.java
+++ b/dungeon/src/core/utils/EntitySystemMapper.java
@@ -80,7 +80,8 @@ public final class EntitySystemMapper {
     writeLock.lock();
     try {
       if (systems.add(system)) {
-        entities.forEach(system::triggerOnAdd);
+        Set<Entity> copy = new HashSet<>(entities);
+        copy.forEach(system::triggerOnAdd);
         return true;
       }
       return false;
@@ -105,7 +106,8 @@ public final class EntitySystemMapper {
     writeLock.lock();
     try {
       if (systems.remove(system)) {
-        entities.forEach(system::triggerOnRemove);
+        Set<Entity> copy = new HashSet<>(entities);
+        copy.forEach(system::triggerOnRemove);
         return true;
       }
       return false;


### PR DESCRIPTION
Es kam beim wechsel eines Level während der Transition Zeit beim Anzeigen eines Images im HUD zu einer CME. 
Das liegt daran, wie das HUD-System das Image aufräumt, dabei wird (ich konnte es nicht pinpointen) auch die Entität und somit das Set im EntitySystemMapper verändert.

Um hier Verantwortung vom User zu nehmen, iteriert der EntitySystemMapper jetzt bei den `add` bzw `remove` Events über eine Copy des Entity Sets. 


@fabianprojects guck mal ob das dein problem löst


Theoretisch könnte man das auch bei den Systemen machen, aber YAGNI. 