### PR TITLE
AdvancedDungeon: adjusted portalhitbox and refactored portal direction

### DIFF
--- a/advancedDungeon/src/produsAdvanced/abstraction/portals/portalSkills/BluePortalSkill.java
+++ b/advancedDungeon/src/produsAdvanced/abstraction/portals/portalSkills/BluePortalSkill.java
@@ -1,6 +1,7 @@
 package produsAdvanced.abstraction.portals.portalSkills;
 
 import contrib.utils.components.skill.Resource;
+import core.utils.Direction;
 import core.utils.Point;
 import core.utils.Tuple;
 import core.utils.components.path.IPath;
@@ -36,6 +37,7 @@ public class BluePortalSkill extends PortalSkill {
    */
   @Override
   protected void createPortal(Point portalPosition, Point originalProjectilePosition) {
-    PortalFactory.createPortal(portalPosition, originalProjectilePosition, PortalColor.BLUE);
+    Direction direction = setPortalDirection(portalPosition, originalProjectilePosition);
+    PortalFactory.createPortal(portalPosition, direction, PortalColor.BLUE);
   }
 }

--- a/advancedDungeon/src/produsAdvanced/abstraction/portals/portalSkills/GreenPortalSkill.java
+++ b/advancedDungeon/src/produsAdvanced/abstraction/portals/portalSkills/GreenPortalSkill.java
@@ -1,6 +1,7 @@
 package produsAdvanced.abstraction.portals.portalSkills;
 
 import contrib.utils.components.skill.Resource;
+import core.utils.Direction;
 import core.utils.Point;
 import core.utils.Tuple;
 import core.utils.components.path.IPath;
@@ -36,6 +37,7 @@ public class GreenPortalSkill extends PortalSkill {
    */
   @Override
   protected void createPortal(Point portalPosition, Point originalProjectilePosition) {
-    PortalFactory.createPortal(portalPosition, originalProjectilePosition, PortalColor.GREEN);
+    Direction direction = setPortalDirection(portalPosition, originalProjectilePosition);
+    PortalFactory.createPortal(portalPosition, direction, PortalColor.GREEN);
   }
 }


### PR DESCRIPTION
In #2577 haben wir herausgefunden das die Collider hitbox der Portale noch zu klein war und somit Probleme versucht hatte. Dies ist hier gefixt indem die Hitboxen weiter nach außen geschoben wurden, siehe Bild 1.
Außerdem ist das Handling wenn man Portale Manuel erstellt nun besser da man nun eine Direction direkt bei `createPortal`  mitgeben kann anstatt das diese in der Methode erst berechnet wird. 

Bild 1: 
<img width="127" height="121" alt="image" src="https://github.com/user-attachments/assets/ff5bd46b-4acf-4dd8-9707-46bd533b5ede" />
