### PR TITLE
AdvancedDungeon: adds option to activate and deactivate the TractorBeam

### DIFF
--- a/advancedDungeon/src/entities/TractorBeamFactory.java
+++ b/advancedDungeon/src/entities/TractorBeamFactory.java
@@ -331,6 +331,11 @@ public class TractorBeamFactory {
    * @param tractorBeamEntities The list of all entities building the tractor beam
    */
   public static void reverseTractorBeam(List<Entity> tractorBeamEntities) {
+    // don't reverse the beam if it is deactivated
+    if (!checkActiveState(tractorBeamEntities)) {
+      return;
+    }
+
     final Direction[] directionHolder = {Direction.NONE};
     for (Entity tractorBeamEntity : tractorBeamEntities) {
       if (tractorBeamEntity.name().equals("tractorBeam")) {
@@ -382,6 +387,103 @@ public class TractorBeamFactory {
                                 });
                       });
                 });
+        tractorBeamEntity
+            .fetch(TractorBeamComponent.class)
+            .ifPresent(TractorBeamComponent::toggleReversed);
+      }
+    }
+  }
+
+  /**
+   * Reverses all tractor beam segments after the first beamEmitter. This ensures that the extended
+   * beam has the correct texture orientation and applies force in the correct direction.
+   *
+   * @param extensionBeamEntities the list of all entities that form the extended tractor beam
+   */
+  public static void reverseExtensionBeam(List<Entity> extensionBeamEntities) {
+    // find index of first beamEmitter
+    int firstEmitterIndex = -1;
+    for (int i = 0; i < extensionBeamEntities.size(); i++) {
+      if (extensionBeamEntities.get(i).name().equals("beamEmitter")) {
+        firstEmitterIndex = i;
+        break;
+      }
+    }
+
+    if (firstEmitterIndex == -1) return;
+
+    // reverse all entities after the first beamEmitter
+    int i = firstEmitterIndex + 1;
+
+    while (i < extensionBeamEntities.size()) {
+
+      final Direction[] directionHolder = {Direction.NONE};
+
+      while (i < extensionBeamEntities.size()
+          && extensionBeamEntities.get(i).name().equals("tractorBeam")) {
+
+        Entity tractorBeamEntity = extensionBeamEntities.get(i);
+
+        tractorBeamEntity
+            .fetch(DrawComponent.class)
+            .ifPresent(
+                dc -> {
+                  String currentState = dc.currentStateName();
+
+                  if (currentState.contains("horizontal")) {
+                    if (currentState.startsWith("blue")) {
+                      dc.sendSignal("reverse_horizontal");
+                      directionHolder[0] = Direction.RIGHT;
+                    } else {
+                      dc.sendSignal("normal_horizontal");
+                      directionHolder[0] = Direction.LEFT;
+                    }
+                  }
+
+                  if (currentState.contains("vertical")) {
+                    if (currentState.startsWith("blue")) {
+                      dc.sendSignal("reverse_vertical");
+                      directionHolder[0] = Direction.DOWN;
+                    } else {
+                      dc.sendSignal("normal_vertical");
+                      directionHolder[0] = Direction.UP;
+                    }
+                  }
+                });
+
+        i++;
+      }
+
+      if (i < extensionBeamEntities.size()
+          && extensionBeamEntities.get(i).name().equals("beamEmitter")) {
+
+        Entity emitter = extensionBeamEntities.get(i);
+        final Direction dir = directionHolder[0];
+
+        emitter
+            .fetch(CollideComponent.class)
+            .ifPresent(
+                cc -> {
+                  cc.onHold(
+                      (you, other, collisionDir) -> {
+                        other
+                            .fetch(VelocityComponent.class)
+                            .ifPresent(
+                                vc -> {
+                                  if (!other.isPresent(FlyComponent.class)) {
+                                    other.add(new FlyComponent());
+                                  }
+                                  Vector2 forceVector =
+                                      Vector2.of(
+                                          -dir.x() * forceMagnitude, -dir.y() * forceMagnitude);
+                                  vc.applyForce("beamEmitter", forceVector);
+                                });
+                      });
+                });
+
+        i++;
+      } else {
+        break;
       }
     }
   }
@@ -419,6 +521,10 @@ public class TractorBeamFactory {
     emitter.remove(DrawComponent.class);
     tractorBeamEntities.add(emitter);
     Game.add(emitter);
+
+    if (tbc.isReversed()) {
+      reverseExtensionBeam(tractorBeamEntities);
+    }
   }
 
   /**
@@ -447,5 +553,23 @@ public class TractorBeamFactory {
       }
       entities.subList(firstEmitterIndex + 1, entities.size()).clear();
     }
+  }
+
+  /**
+   * Checks the active status of a tractor beam by fetching it from the TractorBeamComponent.
+   *
+   * @param tractorBeamEntities The list of all entities building the tractor beam
+   * @return the current status of the "active" status
+   */
+  public static boolean checkActiveState(List<Entity> tractorBeamEntities) {
+    for (Entity entity : tractorBeamEntities) {
+      if (entity.name().equals("beamEmitter")) {
+        TractorBeamComponent tbc = entity.fetch(TractorBeamComponent.class).orElse(null);
+        if (tbc != null) {
+          return tbc.isActive();
+        }
+      }
+    }
+    return false;
   }
 }

--- a/advancedDungeon/src/produsAdvanced/abstraction/portals/components/TractorBeamComponent.java
+++ b/advancedDungeon/src/produsAdvanced/abstraction/portals/components/TractorBeamComponent.java
@@ -18,6 +18,7 @@ public class TractorBeamComponent implements Component {
   private List<Entity> tractorBeamEntities;
   private boolean active = false;
   private List<CollideComponent> collideComponents = new ArrayList<>();
+  private boolean reversed = false;
 
   /**
    * Constructs a TractorBeamComponent so it can be extended and trimmed.
@@ -81,6 +82,11 @@ public class TractorBeamComponent implements Component {
     else activate();
   }
 
+  /** Toggles the reversed status of the TractorBeam. */
+  public void toggleReversed() {
+    reversed = !reversed;
+  }
+
   /**
    * Shows the current status of the "active" status.
    *
@@ -88,6 +94,15 @@ public class TractorBeamComponent implements Component {
    */
   public boolean isActive() {
     return active;
+  }
+
+  /**
+   * Shows the current status of the "reversed" status.
+   *
+   * @return whether the beam is currently reversed or not.
+   */
+  public boolean isReversed() {
+    return reversed;
   }
 
   /**


### PR DESCRIPTION
Fügt die Funktionalität hinzu, dass der TractorBeam wieder Ein- und Ausgeschalten werden kann. Dazu können normale Lever verwendet werden und über das TractorBeamComponent die Aktion durchführen.

Zusätzlich wurde noch ein Bug gefixed, beim die force Richtung des Strahls nicht korrekt durch ein Portal erweitert wurde.

Außerdem kann die Richtung eines Strahls nur noch gewechselt werden, wenn dieser gerade aktiv ist. 