### PR TITLE
Blockly: Fix update of available blocks

### DIFF
--- a/blockly/src/server/Server.java
+++ b/blockly/src/server/Server.java
@@ -180,7 +180,6 @@ public class Server {
       for (int i = 0; i < 5; i++) {
         waitDelta(); // waiting for all systems to update once
       }
-
     }
 
     response.append(DungeonLoader.currentLevel()).append(" ");


### PR DESCRIPTION
Nach dem Wechsel eines Levels kam es vermehrt vor, dass die verfügbaren Blöcke nicht aktualisiert worden sind. Das Problem lag daran, dass der Server die Informationen zum aktuellen Level nicht synchronisiert hat. Der Server ist davon ausgegangen, dass er in einem anderen Level ist und hat daher andere Blöcke herausgegeben. Ich habe die Wartezeit mit einer for-Schleife verlängert.

Bitte prüft bei euch auch nocheinmal, ob das funktioniert. Besonders der Wechsel der Level 12,13,14 hat Probleme gemacht. Bitte einfach ein paar mal ausprobieren. 

closes #2598 
