### PR TITLE
Dungeon: register Items

### DIFF
--- a/dungeon/src/contrib/item/Item.java
+++ b/dungeon/src/contrib/item/Item.java
@@ -64,7 +64,6 @@ public class Item implements CraftingIngredient, CraftingResult {
     registerItem(ItemHammer.class);
     registerItem(ItemHeart.class);
     registerItem(ItemKey.class);
-    registerItem(ItemDefault.class);
   }
 
   private String displayName;


### PR DESCRIPTION
Item Klassen sollen in via `Item#register` registriert werden. Das hängt mit dem Crafting-System zusammen. 
In Short: Der Item Klassenname wird benötigt, um die Items aus den recipe.json Definitionen mit der Klasse zu matchen.
Erst wenn ein Item registriert ist, kann man es für Crafting Rezpete verwenden. Es scheint von @fwatermann damals so gewollt zu sein, dass jedes Item Potenziell als Crating Resource/Output dienen kann.

Wir könnten jetzt lange über diese Entscheidung diskutieren ODER wir machen was sinnvolles mit unserer Zeit. 


Wir hatten einige Items die nicht registriert waren und daher immer ein Warning geprinted haben. Ich hab die jetzt mal registriert.


