### PR TITLE
Dungeon: Fix Game Stretching on Window Resize

### DIFF
--- a/dungeon/src/core/systems/CameraSystem.java
+++ b/dungeon/src/core/systems/CameraSystem.java
@@ -138,9 +138,20 @@ public final class CameraSystem extends System {
     CAMERA.update();
   }
 
+  @Override
+  public void render(final float delta) {
+    // Check if Gdx.graphics is null which happens when the game is run in headless mode (e.g.
+    // in tests)
+    if (Gdx.graphics != null) {
+      float aspectRatio = Game.windowWidth() / (float) Game.windowHeight();
+      CAMERA.viewportWidth = viewportWidth();
+      CAMERA.viewportHeight = viewportWidth() / aspectRatio;
+    }
+  }
+
   private void focus() {
     Point focusPoint;
-    if (Game.currentLevel() == null) focusPoint = new Point(0, 0);
+    if (Game.currentLevel().isEmpty()) focusPoint = new Point(0, 0);
     else focusPoint = Game.startTile().map(Tile::position).orElse(new Point(0, 0));
 
     focus(focusPoint);


### PR DESCRIPTION
Dieser PR behebt das Stretching des Games beim Resizen des Fensters

Es wurde im Commit a6ccb47884cda81ecd780195a3882280dd82996c wichtige Logik dafür gelöscht, dieser PR steht diesen Code wieder her. 