### PR TITLE
Dungeon: fix MacOS bug where DebugDrawSystem not render correct

### DIFF
--- a/dungeon/src/contrib/systems/DebugDrawSystem.java
+++ b/dungeon/src/contrib/systems/DebugDrawSystem.java
@@ -70,7 +70,7 @@ public class DebugDrawSystem extends System {
   /** Creates a new DebugDrawSystem. */
   public DebugDrawSystem() {
     super(PositionComponent.class);
-
+    DEBUG_CAM.setToOrtho(false, Game.windowWidth(), Game.windowHeight());
     WindowEventManager.registerWindowRefreshListener(
         () -> DEBUG_CAM.setToOrtho(false, Game.windowWidth(), Game.windowHeight()));
   }


### PR DESCRIPTION
Auf MacOS wird beim Starten der Anwendung nicht das Fenster aktualisiert, deswegen hat der callback hier nicht gegriffen und daher wurde der setup erst ausgeführt, wenn man das Fenster verändert hat.

Dieser PR führt beim start auch ein setup aus


Jetzt werden Debug Ausgaben, wie z.B das LevelEditor Menü wieder korrekt gerendert