### PR TITLE
dungeon: Revert "Dungeon: remove SkipTile and use PitTile (#2655)

### DIFF
--- a/dungeon/src/core/level/elements/tile/SkipTile.java
+++ b/dungeon/src/core/level/elements/tile/SkipTile.java
@@ -6,13 +6,7 @@ import core.level.utils.DesignLabel;
 import core.level.utils.LevelElement;
 import core.utils.components.path.IPath;
 
-/**
- * Represents an empty void in the dungeon.
- *
- * @deprecated This tile type is no longer supported. Use {@link PitTile} instead for representing
- *     empty or falling-space areas.
- */
-@Deprecated
+/** Represents an empty void in the dungeon. */
 public class SkipTile extends Tile {
 
   /**

--- a/dungeon/src/core/level/elements/tile/TileFactory.java
+++ b/dungeon/src/core/level/elements/tile/TileFactory.java
@@ -29,8 +29,8 @@ public class TileFactory {
       case HOLE -> new HoleTile(texturePath, coordinate, designLabel);
       case DOOR -> new DoorTile(texturePath, coordinate, designLabel);
       case EXIT -> new ExitTile(texturePath, coordinate, designLabel);
-      // SKIPS are outdated and should not be used, this case is for backwards compatibility.
-      case SKIP, PIT -> new PitTile(texturePath, coordinate, designLabel);
+      case SKIP -> new SkipTile(texturePath, coordinate, designLabel);
+      case PIT -> new PitTile(texturePath, coordinate, designLabel);
     };
   }
 }

--- a/dungeon/src/core/level/utils/LevelElement.java
+++ b/dungeon/src/core/level/utils/LevelElement.java
@@ -2,13 +2,7 @@ package core.level.utils;
 
 /** Each type of field in a level can be represented by an integer value. */
 public enum LevelElement {
-  /**
-   * This field is a blank.
-   *
-   * @deprecated This tile type is no longer supported. Use PIT instead for representing empty or
-   *     falling-space areas.
-   */
-  @Deprecated
+  /** This field is a blank. */
   SKIP(false, false),
   /** This field is a floor-field. */
   FLOOR(true, true),

--- a/dungeon/test/core/level/TileTest.java
+++ b/dungeon/test/core/level/TileTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import core.level.elements.tile.ExitTile;
 import core.level.elements.tile.FloorTile;
+import core.level.elements.tile.SkipTile;
 import core.level.elements.tile.WallTile;
 import core.level.utils.Coordinate;
 import core.level.utils.DesignLabel;
@@ -21,10 +22,12 @@ public class TileTest {
     Tile floor = new FloorTile(new SimpleIPath(""), dummyCoordinate, DesignLabel.DEFAULT);
     Tile exit = new ExitTile(new SimpleIPath(""), dummyCoordinate, DesignLabel.DEFAULT);
     Tile start = new FloorTile(new SimpleIPath(""), dummyCoordinate, DesignLabel.DEFAULT);
+    Tile skip = new SkipTile(new SimpleIPath(""), dummyCoordinate, DesignLabel.DEFAULT);
     assertTrue(floor.isAccessible());
     assertTrue(exit.isAccessible());
     assertTrue(start.isAccessible());
     assertFalse(wall.isAccessible());
+    assertFalse(skip.isAccessible());
   }
 
   /** WTF? . */

--- a/dungeon/test/core/level/elements/tile/TileFactoryTest.java
+++ b/dungeon/test/core/level/elements/tile/TileFactoryTest.java
@@ -13,6 +13,20 @@ import org.junit.jupiter.api.Test;
 /** Tests for {@link TileFactory} class. */
 public class TileFactoryTest {
 
+  /** Checks if Tile of type SKIP can be generated. */
+  @Test
+  public void createSKIPTile() {
+    Tile t =
+        TileFactory.createTile(
+            new SimpleIPath(""), new Coordinate(0, 0), LevelElement.SKIP, DesignLabel.DEFAULT);
+    assertEquals(SkipTile.class, t.getClass());
+    assertEquals(0, t.coordinate().x());
+    assertEquals(0, t.coordinate().y());
+    assertEquals(LevelElement.SKIP, t.levelElement());
+    assertEquals(DesignLabel.DEFAULT, t.designLabel());
+    assertNull(t.level());
+  }
+
   /** Checks if Tile of type FLOOR can be generated. */
   @Test
   public void createFLOORTile() {


### PR DESCRIPTION
This reverts commit 8089c93cd0c004a9127d0d792a872ebb110df33f.


Das betrachten von SkipTiles als Pit hat starke Performance Probleme da für Tiles die Out-Of-Player-Range sind, Texturen berechnet werden müssen. 

Beim mappen der Texturen sind laut @davidv0312 auch ein paar unschöne Nebeneffekte entstanden, die alternativ durch überarbeitung aller Level gefixt werden müssten. 