### PR TITLE
Dungeon: Fix bugs in TileTextureFactory

### DIFF
--- a/dungeon/src/core/level/utils/TileTextureFactory.java
+++ b/dungeon/src/core/level/utils/TileTextureFactory.java
@@ -2155,6 +2155,7 @@ public class TileTextureFactory {
    *
    * @param p the coordinate of the tile to test
    * @param layout the level grid
+   * @param visited layout of already visited tiles
    * @return {@code true} if {@code p} is {@code SKIP} and at least one orthogonal neighbor is a
    *     base floor; otherwise {@code false}
    */


### PR DESCRIPTION
In diesem Pull Request wurden zwei Bugs in der ``TileTextureFactory`` behoben:

1. Wenn man zwischen zwei SKIP-Tiles eine Wall platziert hat, kam es durch eine unendliche Rekursion zu einem Stackoverflow. Das wurde behoben.

2. Bisher war es so, dass SKIP-Tiles für die Nachbarschaftschecks immer als WALL-Tile behandelt wurden. Das hat zu zu dem unschönen Effekt geführt, dass Walls ins schwarze "Nichts" abgezweigt sind wenn ein einzelnes SKIP neben einer WALL war. Mit diesen Änderungen verhalten sich SKIP-Tiles wie folgt:

* Ein SKIP wird als FLOOR-Tile bzw. floorlike behandelt wenn direkt oben, unten, links oder rechts neben der SKIP-Tile ein Tile liegt das floorlike ist. Ansonsten wird ein SKIP-Tile immer als WALL bzw. walllike behandelt. Dies behebt den genannten Fehler.

**Wichtiger Hinweis dazu:** Das ``LevelEditorSystem`` sollte bei Beidarf für die neuen SKIP-Tiles angepasst werden. Das ``LevelEditorSystem`` ändert aktuell nur immer eine bestimme Tile, ohne dabei umliegende Tiles neu zu berechnen. Ändert man nämlich beispielsweise eine WALL-Tile direkt neben einer SKIP-Tile zu einer FLOOR-Tile, so ändert sich die die SKIP-Tile von walllike zu floorlike, was wiederrum andere Tiles beeinflusst die natürlich auch wieder andere Tiles beeinflussen können. Dieses "Rekursive beeinflussen" von Tiles ist momentan im ``LevelEditorSystem`` nicht gegeben.

Siehe #2676 