### PR TITLE
Blockly: stop Coderunner on game close

### DIFF
--- a/blockly/src/client/Client.java
+++ b/blockly/src/client/Client.java
@@ -83,6 +83,7 @@ public class Client {
       if (httpServer != null) {
         httpServer.stop(0);
       }
+      BlocklyCodeRunner.instance().stopCode();
     }
   }
 


### PR DESCRIPTION
fixes #2623 

Ruft `  BlocklyCodeRunner#stopCode;` auf, wenn der Client beendet wird. 