### PR TITLE
Dungeon: update neighbour textures on tile change

### DIFF
--- a/dungeon/src/core/level/DungeonLevel.java
+++ b/dungeon/src/core/level/DungeonLevel.java
@@ -230,6 +230,7 @@ public class DungeonLevel implements ILevel, ITickable {
       case PIT -> pitTiles.remove((PitTile) tile);
     }
     this.removeFromPathfinding(tile);
+    layout[tile.coordinate().y()][tile.coordinate().x()] = null;
   }
 
   /**
@@ -287,6 +288,7 @@ public class DungeonLevel implements ILevel, ITickable {
       case PIT -> pitTiles.add((PitTile) tile);
     }
     this.addToPathfinding(tile);
+    layout[tile.coordinate().y()][tile.coordinate().x()] = tile;
     tile.level(this);
   }
 

--- a/dungeon/src/core/level/Tile.java
+++ b/dungeon/src/core/level/Tile.java
@@ -7,6 +7,7 @@ import core.level.elements.astar.TileConnection;
 import core.level.utils.Coordinate;
 import core.level.utils.DesignLabel;
 import core.level.utils.LevelElement;
+import core.level.utils.TileTextureFactory;
 import core.utils.Direction;
 import core.utils.Point;
 import core.utils.components.path.IPath;
@@ -275,6 +276,11 @@ public abstract class Tile {
    */
   public int tintColor() {
     return this.tintColor;
+  }
+
+  /** Refreshes the texture of this tile. */
+  public void refreshTexture() {
+    this.texturePath(TileTextureFactory.findTexturePath(this, level.layout(), levelElement));
   }
 
   @Override

--- a/dungeon/src/core/level/elements/ILevel.java
+++ b/dungeon/src/core/level/elements/ILevel.java
@@ -16,9 +16,9 @@ import core.level.elements.tile.*;
 import core.level.utils.Coordinate;
 import core.level.utils.DesignLabel;
 import core.level.utils.LevelElement;
-import core.level.utils.TileTextureFactory;
 import core.utils.Point;
 import core.utils.Tuple;
+import core.utils.Vector2;
 import java.util.*;
 import java.util.Optional;
 import java.util.function.Function;
@@ -364,17 +364,26 @@ public interface ILevel extends IndexedGraph<Tile> {
       return;
     }
     level.removeTile(tile);
-    Tile newTile =
-        TileFactory.createTile(
-            TileTextureFactory.findTexturePath(tile, layout(), changeInto),
-            tile.coordinate(),
-            changeInto,
-            tile.designLabel());
+    Tile newTile = TileFactory.createTile(null, tile.coordinate(), changeInto, tile.designLabel());
     level.layout()[tile.coordinate().y()][tile.coordinate().x()] = newTile;
     newTile.index(tile.index());
     newTile.tintColor(tile.tintColor());
     newTile.visible(tile.visible());
     level.addTile(newTile);
+    newTile.refreshTexture();
+    refreshNeighbourTexture(newTile.coordinate());
+  }
+
+  private void refreshNeighbourTexture(Coordinate coordinate) {
+
+    int[][] offsets = {
+      {0, -1}, {0, 1}, {-1, 0}, {1, 0},
+      {1, 1}, {-1, 1}, {-1, -1}, {1, -1}
+    };
+
+    for (int[] o : offsets) {
+      tileAt(coordinate.translate(Vector2.of(o[0], o[1]))).ifPresent(Tile::refreshTexture);
+    }
   }
 
   /**

--- a/dungeon/src/core/level/elements/tile/PitTile.java
+++ b/dungeon/src/core/level/elements/tile/PitTile.java
@@ -117,6 +117,7 @@ public class PitTile extends Tile {
   }
 
   /** Refreshes the texture of this pit and the pit below (if there is one). */
+  @Override
   public void refreshTexture() {
     this.texturePath(TileTextureFactory.findTexturePath(this, level.layout(), levelElement));
     if (coordinate().y() == 0) return;


### PR DESCRIPTION
fixes #2676 

Wenn ein Tile verändert wird, werden jetzt die Nachbar-Tiles gebeten ihre Textur zu überprüfen und ggf upzudaten.

Außerdem passe ich jetzt auch das layout Array an. Da stand früher noch das alte Tile drinen

Before: 

https://github.com/user-attachments/assets/1dc58701-58be-43f0-96f9-a20031d518d7

After: 


https://github.com/user-attachments/assets/abaf4f26-6da5-49e4-911c-b09be31c6368







