### PR TITLE
Core: Add multiplayer inventory synchronization

### DIFF
--- a/advancedDungeon/src/produsAdvanced/abstraction/Hero.java
+++ b/advancedDungeon/src/produsAdvanced/abstraction/Hero.java
@@ -155,7 +155,7 @@ public class Hero {
         .ifPresentOrElse(
             uiComponent -> {
               if (uiComponent.dialog() instanceof GUICombination
-                  && !InventoryGUI.inPlayerInventory()) {
+                  && !InventoryGUI.inPlayerInventory(hero)) {
                 hero.remove(UIComponent.class);
               }
             },

--- a/dungeon/src/contrib/entities/HeroBuilder.java
+++ b/dungeon/src/contrib/entities/HeroBuilder.java
@@ -377,7 +377,6 @@ public final class HeroBuilder {
         false);
 
     // UI controls
-    // TODO: make UI controls work for multiplayer (currently only local)
     inputComp.registerCallback(
         KeyboardConfig.INVENTORY_OPEN.value(), HeroController::toggleInventory, false, true);
     inputComp.registerCallback(

--- a/dungeon/src/contrib/entities/MiscFactory.java
+++ b/dungeon/src/contrib/entities/MiscFactory.java
@@ -316,6 +316,8 @@ public final class MiscFactory {
     DrawComponent dc = new DrawComponent(new SimpleIPath("objects/cauldron"));
     dc.depth(DepthLayer.Player.depth());
     cauldron.add(dc);
+    InventoryComponent invComp = new InventoryComponent();
+    cauldron.add(invComp);
     cauldron.add(
         new InteractionComponent(
             () ->
@@ -324,7 +326,7 @@ public final class MiscFactory {
                         who.fetch(InventoryComponent.class)
                             .ifPresent(
                                 ic -> {
-                                  CraftingGUI craftingGUI = new CraftingGUI(ic);
+                                  CraftingGUI craftingGUI = new CraftingGUI(invComp, ic);
                                   UIComponent component =
                                       new UIComponent(
                                           new GUICombination(new InventoryGUI(ic), craftingGUI),

--- a/dungeon/src/contrib/hud/IInventoryHolder.java
+++ b/dungeon/src/contrib/hud/IInventoryHolder.java
@@ -1,0 +1,18 @@
+package contrib.hud;
+
+import contrib.components.InventoryComponent;
+
+/**
+ * An interface for dialogs that hold an inventory.
+ *
+ * @see contrib.hud.inventory.InventoryGUI
+ * @see contrib.hud.crafting.CraftingGUI
+ */
+public interface IInventoryHolder {
+  /**
+   * Gets the inventory component associated with this holder.
+   *
+   * @return the inventory component
+   */
+  InventoryComponent inventoryComponent();
+}

--- a/dungeon/src/contrib/hud/UIUtils.java
+++ b/dungeon/src/contrib/hud/UIUtils.java
@@ -4,7 +4,9 @@ import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.scenes.scene2d.Actor;
 import com.badlogic.gdx.scenes.scene2d.ui.Dialog;
 import com.badlogic.gdx.scenes.scene2d.ui.Skin;
+import contrib.components.InventoryComponent;
 import contrib.components.UIComponent;
+import contrib.hud.elements.GUICombination;
 import core.Entity;
 import core.Game;
 import core.components.PlayerComponent;
@@ -12,6 +14,7 @@ import core.utils.IVoidFunction;
 import core.utils.components.path.IPath;
 import core.utils.components.path.SimpleIPath;
 import java.util.function.Supplier;
+import java.util.stream.Stream;
 
 /** UI utility functions, such as a formatter for the window or dialog. */
 public final class UIUtils {
@@ -184,5 +187,21 @@ public final class UIUtils {
     }
 
     return sb.toString();
+  }
+
+  /**
+   * Retrieves all {@link InventoryComponent}s from the given {@link UIComponent}'s dialog, if it is
+   * a {@link GUICombination}.
+   *
+   * @param ui the UIComponent whose dialog to check for inventories
+   * @return a stream of InventoryComponents found in the dialog's combinable GUIs
+   */
+  public static Stream<InventoryComponent> getInventoriesFromUI(UIComponent ui) {
+    return (ui.dialog() instanceof GUICombination guiCombination)
+        ? guiCombination.combinableGuis().stream()
+            .filter(IInventoryHolder.class::isInstance)
+            .map(IInventoryHolder.class::cast)
+            .map(IInventoryHolder::inventoryComponent)
+        : Stream.empty();
   }
 }

--- a/dungeon/src/contrib/hud/elements/CombinableGUI.java
+++ b/dungeon/src/contrib/hud/elements/CombinableGUI.java
@@ -152,8 +152,12 @@ public abstract class CombinableGUI {
    * Set the width of the element.
    *
    * @param width the width.
+   * @throws IllegalArgumentException if the width is negative.
    */
   public void width(int width) {
+    if (width < 0) {
+      throw new IllegalArgumentException("Width cannot be negative");
+    }
     this.actor.setSize(width, this.height);
     this.width = width;
   }
@@ -171,8 +175,12 @@ public abstract class CombinableGUI {
    * Set the height of the element.
    *
    * @param height the height.
+   * @throws IllegalArgumentException if the height is negative.
    */
   public void height(int height) {
+    if (height < 0) {
+      throw new IllegalArgumentException("Height cannot be negative");
+    }
     this.actor.setSize(this.width, height);
     this.height = height;
   }

--- a/dungeon/src/contrib/hud/elements/GUICombination.java
+++ b/dungeon/src/contrib/hud/elements/GUICombination.java
@@ -38,10 +38,16 @@ public final class GUICombination extends Group {
    */
   public GUICombination(int guisPerRow, final CombinableGUI... combinableGuis) {
     this.guisPerRow = guisPerRow;
-    this.dragAndDrop = new DragAndDrop();
-    this.setSize(Game.stage().orElseThrow().getWidth(), Game.stage().orElseThrow().getHeight());
     this.setPosition(0, 0);
     this.combinableGuis = new ArrayList<>(Arrays.asList(combinableGuis));
+
+    if (Game.isHeadless()) {
+      this.dragAndDrop = null;
+      return;
+    }
+    this.dragAndDrop = new DragAndDrop();
+    this.setSize(Game.stage().orElseThrow().getWidth(), Game.stage().orElseThrow().getHeight());
+
     this.combinableGuis.forEach(
         combinableGUI -> {
           combinableGUI.dragAndDrop(this.dragAndDrop);

--- a/dungeon/src/contrib/hud/inventory/ItemDragPayload.java
+++ b/dungeon/src/contrib/hud/inventory/ItemDragPayload.java
@@ -7,7 +7,9 @@ import contrib.item.Item;
  * This class represents an item dragged from and to an inventory.
  *
  * @param inventoryComponent The inventory the item was dragged from.
+ * @param wasHeroInv Whether the inventory is the local hero's inventory.
  * @param slot The slot the item was dragged from.
  * @param item The item that was dragged.
  */
-public record ItemDragPayload(InventoryComponent inventoryComponent, int slot, Item item) {}
+public record ItemDragPayload(
+    InventoryComponent inventoryComponent, boolean wasHeroInv, int slot, Item item) {}

--- a/dungeon/src/contrib/item/Item.java
+++ b/dungeon/src/contrib/item/Item.java
@@ -13,6 +13,8 @@ import core.level.elements.tile.FloorTile;
 import core.utils.Point;
 import core.utils.components.draw.animation.Animation;
 import core.utils.logging.DungeonLogger;
+import java.io.Serial;
+import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -33,7 +35,8 @@ import java.util.Random;
  * max stack size is 1 and the default stack size is 1. The values can be changed via the {@link
  * #stackSize()} and {@link #maxStackSize()} methods.
  */
-public class Item implements CraftingIngredient, CraftingResult {
+public class Item implements CraftingIngredient, CraftingResult, Serializable {
+  @Serial private static final long serialVersionUID = 1L;
   private static final DungeonLogger LOGGER = DungeonLogger.getLogger(Item.class);
 
   /** Random object used to generate random numbers for item related things. */

--- a/dungeon/src/core/Game.java
+++ b/dungeon/src/core/Game.java
@@ -4,6 +4,7 @@ import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Graphics;
 import com.badlogic.gdx.ai.pfa.GraphPath;
 import com.badlogic.gdx.scenes.scene2d.Stage;
+import contrib.utils.EntityUtils;
 import core.components.PlayerComponent;
 import core.components.PositionComponent;
 import core.game.ECSManagement;
@@ -643,19 +644,14 @@ public final class Game {
   public static Stream<Entity> entityAtTile(final Tile check) {
     return Game.tileAt(check.position())
         .map(
-            target -> {
-              Set<Class<? extends Component>> filter = new HashSet<>();
-              filter.add(PositionComponent.class);
-
-              return ECSManagement.levelEntities(filter)
-                  .filter(
-                      e ->
-                          e.fetch(PositionComponent.class)
-                              .map(PositionComponent::position)
-                              .flatMap(Game::tileAt)
-                              .map(target::equals)
-                              .orElse(false));
-            })
+            target ->
+                ECSManagement.levelEntities()
+                    .filter(e -> e.isPresent(PositionComponent.class))
+                    .filter(
+                        e ->
+                            Game.tileAt(EntityUtils.getPosition(e))
+                                .map(target::equals)
+                                .orElse(false)))
         .orElseGet(Stream::empty);
   }
 

--- a/dungeon/src/core/network/MessageDispatcher.java
+++ b/dungeon/src/core/network/MessageDispatcher.java
@@ -77,7 +77,7 @@ public final class MessageDispatcher {
         @SuppressWarnings("unchecked")
         BiConsumer<Session, Object> c = (BiConsumer<Session, Object>) handler;
         c.accept(session, message);
-      } catch (Exception e) {
+      } catch (Throwable e) {
         LOGGER.error(
             "Error in message handler for message {}: {}",
             message.getClass().getSimpleName(),

--- a/dungeon/src/core/network/messages/c2s/InputMessage.java
+++ b/dungeon/src/core/network/messages/c2s/InputMessage.java
@@ -110,7 +110,26 @@ public record InputMessage(
     /** Switch to the next skill in the player's skill set. */
     NEXT_SKILL(3),
     /** Switch to the previous skill in the player's skill set. */
-    PREV_SKILL(4);
+    PREV_SKILL(4),
+    /**
+     * Drop a specified item from the inventory.
+     *
+     * <p>The point x coordinate represents the inventory slot index of the item to be dropped.
+     */
+    INV_DROP(5),
+    /**
+     * Move an item within the inventory.
+     *
+     * <p>The point x coordinate represents the source inventory slot index, and the point y
+     * coordinate represents the destination inventory slot index.
+     */
+    INV_MOVE(6),
+    /**
+     * Uses the item in the specified inventory slot.
+     *
+     * <p>The point x coordinate represents the inventory slot index of the item to be used.
+     */
+    INV_USE(7);
 
     private final byte value;
 

--- a/dungeon/src/core/network/messages/c2s/InventoryUIMessage.java
+++ b/dungeon/src/core/network/messages/c2s/InventoryUIMessage.java
@@ -1,0 +1,18 @@
+package core.network.messages.c2s;
+
+import core.network.messages.NetworkMessage;
+import java.io.Serial;
+
+/**
+ * Client→server: Open/close inventory UI.
+ *
+ * <p>This message is sent from the client to the server to indicate whether the player has opened
+ * or closed the inventory user interface (UI). The server can use this information to manage game
+ * state, such as pausing certain actions while the inventory is open or updating the player's
+ * inventory data.
+ *
+ * @param open true if the inventory UI is opened, false if closed
+ */
+public record InventoryUIMessage(boolean open) implements NetworkMessage {
+  @Serial private static final long serialVersionUID = 1L;
+}

--- a/dungeon/src/core/network/messages/s2c/EntityState.java
+++ b/dungeon/src/core/network/messages/s2c/EntityState.java
@@ -1,5 +1,6 @@
 package core.network.messages.s2c;
 
+import contrib.item.Item;
 import core.network.messages.NetworkMessage;
 import core.sound.SoundSpec;
 import core.utils.Direction;
@@ -32,6 +33,7 @@ public class EntityState implements NetworkMessage {
   private final String stateName;
   private final Integer tintColor;
   private final List<SoundSpec> sounds;
+  private final Item[] inventory;
 
   /**
    * Constructs an EntityState object using the provided Builder.
@@ -51,6 +53,7 @@ public class EntityState implements NetworkMessage {
     this.stateName = builder.stateName;
     this.tintColor = builder.tintColor;
     this.sounds = builder.sounds;
+    this.inventory = builder.inventory;
   }
 
   /**
@@ -170,6 +173,15 @@ public class EntityState implements NetworkMessage {
     return new Builder();
   }
 
+  /**
+   * Gets the optional inventory of the entity.
+   *
+   * @return an Optional containing the inventory if present, otherwise an empty Optional
+   */
+  public Optional<Item[]> inventory() {
+    return Optional.ofNullable(inventory);
+  }
+
   /** Builder class for constructing EntityState objects. */
   public static class Builder {
     private int entityId;
@@ -184,6 +196,7 @@ public class EntityState implements NetworkMessage {
     private String stateName;
     private Integer tintColor;
     private List<SoundSpec> sounds;
+    private Item[] inventory;
 
     /**
      * Sets the unique identifier for the entity.
@@ -325,6 +338,17 @@ public class EntityState implements NetworkMessage {
      */
     public Builder sounds(List<SoundSpec> sounds) {
       this.sounds = sounds;
+      return this;
+    }
+
+    /**
+     * Sets the inventory items for the entity.
+     *
+     * @param inventory the array of Item instances
+     * @return the Builder instance
+     */
+    public Builder inventory(Item[] inventory) {
+      this.inventory = inventory;
       return this;
     }
 

--- a/dungeon/test/contrib/components/InventoryComponentTest.java
+++ b/dungeon/test/contrib/components/InventoryComponentTest.java
@@ -80,7 +80,7 @@ public class InventoryComponentTest {
     e.add(ic);
     Item itemData = new Item("Test item", "Test description", new Animation(MISSING_TEXTURE));
     ic.add(itemData);
-    assertTrue(ic.remove(itemData));
+    assertTrue(ic.remove(itemData).isPresent());
 
     assertEquals(0, ic.count());
   }
@@ -94,7 +94,7 @@ public class InventoryComponentTest {
     Item itemData = new Item("Test item", "Test description", new Animation(MISSING_TEXTURE));
     ic.add(itemData);
     ic.remove(itemData);
-    assertFalse(ic.remove(itemData));
+    assertTrue(ic.remove(itemData).isEmpty());
 
     assertEquals(0, ic.count());
   }
@@ -107,7 +107,7 @@ public class InventoryComponentTest {
     e.add(ic);
     Item itemData = new Item("Test item", "Test description", new Animation(MISSING_TEXTURE));
     ic.add(itemData);
-    assertFalse(ic.remove(null));
+    assertTrue(ic.remove(null).isEmpty());
 
     assertEquals(1, ic.count());
   }


### PR DESCRIPTION
Multiplayer-Unterstützung für Inventar; Hero-Inventar vollständig synchronisiert, Item-Verschiebung, Austausch, Quick-Transfer und Drop funktionieren zwischen Spielern.

Wesentliche Änderungen:
* Inventory-API:
  * Neue Callbacks `onAddItem` und `onRemoveItem` zur Benachrichtigung über Änderungen.
* Inventar-Operationen:
  * Transfer (schnelles Verschieben zwischen Containern) nutzt nun gleiche Logik wie Drag-and-Drop-Verschiebung.
  * Alle Inventar-Steuerungen zentralisiert in `HeroController`.
  * Unterstützte Operationen: Items verschieben, austauschen, Quick-Transfer, droppen.
* Fehlerbehandlung und Logging:
  * Verbessertes Error-Handling und Logging auf UI- und Multiplayer-Seite.
* Bekannte Einschränkungen:
  * Kisten und andere Container-Typen funktionieren noch nicht; benötigen UI-Support in separatem PR (siehe #2690)

Funktionaler Status:
* Hero-Inventar vollständig spielbar im Multiplayer.

closes #2689