### PR TITLE
Dungeon: Only update endPointSupplier if no cursor

### DIFF
--- a/dungeon/src/contrib/entities/HeroController.java
+++ b/dungeon/src/contrib/entities/HeroController.java
@@ -92,7 +92,11 @@ public class HeroController {
               if (skill instanceof CursorSkill cursorSkill) {
                 cursorSkill.cursorPositionSupplier(() -> target);
               } else if (skill instanceof ProjectileSkill projSkill) {
-                projSkill.endPointSupplier(() -> target);
+                try {
+                  projSkill.endPointSupplier().get(); // test if supplier wants cursor position
+                } catch (IllegalStateException ignored) {
+                  projSkill.endPointSupplier(() -> target);
+                }
               }
               skill.execute(hero);
             });


### PR DESCRIPTION
Jetzt wird erst der EndPoint Supplier überschrieben, wenn der Server/Client kein Cursor finden konnte.