### PR TITLE
AdvancedDungeon: optimize anitMaterialBarrier CollideComponent

### DIFF
--- a/advancedDungeon/src/entities/AdvancedFactory.java
+++ b/advancedDungeon/src/entities/AdvancedFactory.java
@@ -19,6 +19,7 @@ import core.Component;
 import core.Entity;
 import core.Game;
 import core.components.DrawComponent;
+import core.components.PlayerComponent;
 import core.components.PositionComponent;
 import core.components.VelocityComponent;
 import core.level.utils.LevelElement;
@@ -35,6 +36,8 @@ import core.utils.components.path.SimpleIPath;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import produsAdvanced.abstraction.portals.components.PortalExtendComponent;
+import produsAdvanced.abstraction.portals.components.TractorBeamComponent;
 import skills.EnergyPelletSkill;
 
 /**
@@ -125,8 +128,6 @@ public class AdvancedFactory {
     barrier.add(new PositionComponent(spawnPoint));
     barrier.add(new AntiMaterialBarrierComponent(true));
 
-    // this action needs to be the same as the one applied in applyBarrierLogic() in the
-    // antiMaterialBarrierSystem
     CollideComponent colComp = getCollideComponent();
     barrier.add(colComp);
 
@@ -155,22 +156,22 @@ public class AdvancedFactory {
     return barrier;
   }
 
-  private static CollideComponent getCollideComponent() {
+  /**
+   * Creates the CollideComponent for the AntiMaterialBarrier.
+   *
+   * @return the new CollideComponent.
+   */
+  public static CollideComponent getCollideComponent() {
     TriConsumer<Entity, Entity, Direction> action =
         (self, other, direction) -> {
-          String name = other.name();
-
-          switch (name) {
-            case "hero":
-              // TODO: clearAllPortals() aufrufen, sobald es wieder funktioniert
-              // PortalFactory.clearAllPortals();
-              break;
-            case "lightWallCollider", "beamEmitter":
-              // do nothing
-              break;
-            default:
-              Game.remove(other);
-              break;
+          if (other.isPresent(PlayerComponent.class)) {
+            // TODO: clearAllPortals() aufrufen, sobald es wieder funktioniert
+            // PortalFactory.clearAllPortals();
+          } else if (other.isPresent(TractorBeamComponent.class)
+              || other.isPresent(PortalExtendComponent.class)) {
+            // do nothing
+          } else {
+            Game.remove(other);
           }
         };
 

--- a/advancedDungeon/src/starter/PortalStarter.java
+++ b/advancedDungeon/src/starter/PortalStarter.java
@@ -64,8 +64,10 @@ public class PortalStarter {
         .fetch(SkillComponent.class)
         .ifPresent(
             skillComponent -> {
-              skillComponent.addSkill(new PortalSkill(PortalColor.BLUE, new Tuple<>(Resource.MANA, 0)));
-              skillComponent.addSkill(new PortalSkill(PortalColor.GREEN, new Tuple<>(Resource.MANA, 0)));
+              skillComponent.addSkill(
+                  new PortalSkill(PortalColor.BLUE, new Tuple<>(Resource.MANA, 0)));
+              skillComponent.addSkill(
+                  new PortalSkill(PortalColor.GREEN, new Tuple<>(Resource.MANA, 0)));
               skillComponent.removeSkill(FireballSkill.class);
               skillComponent.removeSkill(SelfHealSkill.class);
             });
@@ -105,6 +107,7 @@ public class PortalStarter {
     Game.add(new PortalExtendSystem());
     Game.add(new AntiMaterialBarrierSystem());
     Game.add(new LasergridSystem());
+    Game.add(new AttachmentSystem());
     if (DEBUG_MODE) Game.add(new Debugger());
   }
 

--- a/advancedDungeon/src/systems/AntiMaterialBarrierSystem.java
+++ b/advancedDungeon/src/systems/AntiMaterialBarrierSystem.java
@@ -3,12 +3,10 @@ package systems;
 import components.AntiMaterialBarrierComponent;
 import contrib.components.CollideComponent;
 import core.Entity;
-import core.Game;
 import core.System;
 import core.components.DrawComponent;
-import core.utils.Direction;
-import core.utils.TriConsumer;
 import core.utils.components.MissingComponentException;
+import entities.AdvancedFactory;
 
 /**
  * The AntiMaterialBarrierSystem manages the activation and deactivation of anti-material barriers.
@@ -89,28 +87,7 @@ public class AntiMaterialBarrierSystem extends System {
       if (currentState.equals("horizontal_off") || currentState.equals("vertical_off")) {
         data.draw().sendSignal("activate_anti_barrier");
 
-        // this action needs to be the same as the one applied in antiMaterialBarrier() in the
-        // AdvancedFactory
-        TriConsumer<Entity, Entity, Direction> action =
-            (self, other, direction) -> {
-              String name = other.name();
-
-              switch (name) {
-                case "hero":
-                  // TODO: clearAllPortals() aufrufen, sobald es wieder funktioniert
-                  // PortalFactory.clearAllPortals();
-                  break;
-                case "lightWallCollider", "beamEmitter":
-                  // do nothing
-                  break;
-                default:
-                  Game.remove(other);
-                  break;
-              }
-            };
-
-        CollideComponent colComp = new CollideComponent(action, CollideComponent.DEFAULT_COLLIDER);
-        colComp.isSolid(false);
+        CollideComponent colComp = AdvancedFactory.getCollideComponent();
         data.entity().add(colComp);
       }
     } else {


### PR DESCRIPTION
fixt einen Bug, bei dem der Held entfernt wurde, wenn er durch das antiMaterialBarrier durch gegangen ist. Und verschönert der Code etwas, sodass das antiMaterialBarrierSystem auch die getCollideComponent Methode aus der AdvancedFactory benutzt.

Fügt außerdem dem PortalStarter das AttachmentSysem hinzu, damit der Würfel und die Kugel aufgehoben werden können.