### PR TITLE
Fixes for LightBridge and LightWall + added PortalIgnoreComponent

### DIFF
--- a/advancedDungeon/src/entities/LightBridgeFactory.java
+++ b/advancedDungeon/src/entities/LightBridgeFactory.java
@@ -8,9 +8,8 @@ import core.Game;
 import core.components.DrawComponent;
 import core.components.PositionComponent;
 import core.level.Tile;
-import core.level.elements.tile.GlasswandTile;
 import core.level.elements.tile.PitTile;
-import core.level.elements.tile.WallTile;
+import core.level.utils.LevelElement;
 import core.utils.Direction;
 import core.utils.Point;
 import core.utils.Vector2;
@@ -20,12 +19,10 @@ import core.utils.components.draw.animation.AnimationConfig;
 import core.utils.components.draw.state.State;
 import core.utils.components.draw.state.StateMachine;
 import core.utils.components.path.SimpleIPath;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import produsAdvanced.abstraction.portals.components.PortalExtendComponent;
+import produsAdvanced.abstraction.portals.components.PortalIgnoreComponent;
 
 /**
  * Factory for creating and managing light bridges and their emitters. A light bridge consists of
@@ -46,6 +43,10 @@ public class LightBridgeFactory {
 
   /** Number of tiles by which the extended start point is offset in front of the emitter. */
   public static int spawnOffset = 1;
+
+  private static final LevelElement[] stoppingTiles = {
+    LevelElement.WALL, LevelElement.PORTAL, LevelElement.GLASSWALL
+  };
 
   /**
    * Creates a new light bridge emitter at the given position and direction. Can be spawned active
@@ -124,6 +125,7 @@ public class LightBridgeFactory {
               CollideComponent.DEFAULT_COLLIDER,
               (a, b, c) -> {}));
       beams.add(new BeamComponent(emitter, start, direction, true));
+      emitter.add(new PortalIgnoreComponent());
       if (active) activate();
     }
 
@@ -408,21 +410,24 @@ public class LightBridgeFactory {
     }
 
     /**
-     * Calculates the end point by stepping from the start in the beam's direction until a WallTile
-     * is reached or no tile exists. Returns the last traversable point.
+     * Calculates the end point by stepping from the start in the beam's direction until a WallTile,
+     * PortalTile, or Glass Wand Tile is reached or no tile exists. Returns the last traversable
+     * point.
      *
-     * @param beamDirection Direction of the beam
      * @param from Starting point
+     * @param beamDirection Direction of the beam
      * @return Returns the calculated end point of the beam.
      */
     private Point calculateEndPoint(Point from, Direction beamDirection) {
       Point lastPoint = from;
       Point currentPoint = from;
+
       while (true) {
         Tile currentTile = Game.tileAt(currentPoint).orElse(null);
         if (currentTile == null) break;
-        boolean isWall = currentTile instanceof WallTile || currentTile instanceof GlasswandTile;
-        if (isWall) break;
+
+        if (Arrays.asList(stoppingTiles).contains(currentTile.levelElement())) break;
+
         lastPoint = currentPoint;
         currentPoint = currentPoint.translate(beamDirection);
       }

--- a/advancedDungeon/src/produsAdvanced/abstraction/portals/PortalFactory.java
+++ b/advancedDungeon/src/produsAdvanced/abstraction/portals/PortalFactory.java
@@ -16,6 +16,7 @@ import core.utils.components.path.SimpleIPath;
 import java.util.*;
 import produsAdvanced.abstraction.portals.components.PortalComponent;
 import produsAdvanced.abstraction.portals.components.PortalExtendComponent;
+import produsAdvanced.abstraction.portals.components.PortalIgnoreComponent;
 
 /**
  * A factory class for creating and managing portals in the game.
@@ -243,6 +244,10 @@ public class PortalFactory {
    * @param dir the direction of collision
    */
   public static void onGreenCollideEnter(Entity portal, Entity other, Direction dir) {
+    if (other.fetch(PortalIgnoreComponent.class).isPresent()) {
+      return;
+    }
+
     PositionComponent otherPositionComponent = other.fetch(PositionComponent.class).get();
     PositionComponent portalPositionComponent = portal.fetch(PositionComponent.class).get();
 
@@ -293,6 +298,10 @@ public class PortalFactory {
    * @param dir the direction of collision
    */
   public static void onBlueCollideEnter(Entity portal, Entity other, Direction dir) {
+    if (other.fetch(PortalIgnoreComponent.class).isPresent()) {
+      return;
+    }
+
     PositionComponent otherPositionComponent = other.fetch(PositionComponent.class).get();
     PositionComponent portalPositionComponent = portal.fetch(PositionComponent.class).get();
 

--- a/advancedDungeon/src/produsAdvanced/abstraction/portals/components/PortalIgnoreComponent.java
+++ b/advancedDungeon/src/produsAdvanced/abstraction/portals/components/PortalIgnoreComponent.java
@@ -1,0 +1,6 @@
+package produsAdvanced.abstraction.portals.components;
+
+import core.Component;
+
+/** Holder class for all entities that should be ignored by the Portal. */
+public class PortalIgnoreComponent implements Component {}

--- a/advancedDungeon/src/produsAdvanced/abstraction/portals/systems/PortalExtendSystem.java
+++ b/advancedDungeon/src/produsAdvanced/abstraction/portals/systems/PortalExtendSystem.java
@@ -5,6 +5,7 @@ import core.System;
 import core.components.PositionComponent;
 import core.utils.components.MissingComponentException;
 import produsAdvanced.abstraction.portals.PortalFactory;
+import produsAdvanced.abstraction.portals.components.PortalComponent;
 import produsAdvanced.abstraction.portals.components.PortalExtendComponent;
 
 /**
@@ -60,6 +61,20 @@ public class PortalExtendSystem extends System {
       PortalFactory.getGreenPortal()
           .ifPresent(
               portal -> {
+                portal
+                    .fetch(PortalComponent.class)
+                    .ifPresent(
+                        pc -> {
+                          Entity other =
+                              PortalFactory.getBluePortal()
+                                  .get()
+                                  .fetch(PortalComponent.class)
+                                  .get()
+                                  .getExtendedEntityThrough();
+                          if (pc.getExtendedEntityThrough() == null) {
+                            pc.setExtendedEntityThrough(other);
+                          }
+                        });
                 PositionComponent greenPortalPosition = portal.fetch(PositionComponent.class).get();
                 pec.onExtend.accept(
                     greenPortalPosition.viewDirection(), greenPortalPosition.position(), pec);
@@ -69,6 +84,20 @@ public class PortalExtendSystem extends System {
       PortalFactory.getBluePortal()
           .ifPresent(
               portal -> {
+                portal
+                    .fetch(PortalComponent.class)
+                    .ifPresent(
+                        pc -> {
+                          Entity other =
+                              PortalFactory.getGreenPortal()
+                                  .get()
+                                  .fetch(PortalComponent.class)
+                                  .get()
+                                  .getExtendedEntityThrough();
+                          if (pc.getExtendedEntityThrough() == null) {
+                            pc.setExtendedEntityThrough(other);
+                          }
+                        });
                 PositionComponent bluePortalPosition = portal.fetch(PositionComponent.class).get();
                 pec.onExtend.accept(
                     bluePortalPosition.viewDirection(), bluePortalPosition.position(), pec);


### PR DESCRIPTION
Fixed Erros der LightBridgeFactory und LightWallFactory, die in Pull Request #2633 genannt wurden.

Gefixte Probleme
- Portale können deine Emitter teleportieren
- Lichtbrücke kann noch durch die Portalwände durchgehen
- Fehler beim aktivieren der Lichtbrücke
- Fehler mit Portalinteraktion

Zusätzlich die `PortalExtendComponent ` hinzugefügt, die das Teleportieren des Emitters verhindert.