### PR TITLE
AdvancedDungeon: antiMaterialBarrirer clearsAllPortals and wont block energyPellet

### DIFF
--- a/advancedDungeon/src/components/ai/PelletLauncherBehaviour.java
+++ b/advancedDungeon/src/components/ai/PelletLauncherBehaviour.java
@@ -48,6 +48,9 @@ public class PelletLauncherBehaviour implements Consumer<Entity>, ISkillUser {
 
     if (skill instanceof DamageProjectileSkill dps) {
       this.projectileSkill = dps;
+      Game.allEntities()
+          .filter(e -> "antiMaterialBarrier".equals(e.name()))
+          .forEach(e -> projectileSkill.ignoreEntity(e));
     } else {
       throw new IllegalArgumentException(
           "Skill for PelletLauncher must be a DamageProjectileSkill");

--- a/advancedDungeon/src/entities/AdvancedFactory.java
+++ b/advancedDungeon/src/entities/AdvancedFactory.java
@@ -36,6 +36,7 @@ import core.utils.components.path.SimpleIPath;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import produsAdvanced.abstraction.portals.PortalFactory;
 import produsAdvanced.abstraction.portals.components.PortalExtendComponent;
 import produsAdvanced.abstraction.portals.components.TractorBeamComponent;
 import skills.EnergyPelletSkill;
@@ -164,11 +165,13 @@ public class AdvancedFactory {
   public static CollideComponent getCollideComponent() {
     TriConsumer<Entity, Entity, Direction> action =
         (self, other, direction) -> {
+          String otherEntityName = other.name();
           if (other.isPresent(PlayerComponent.class)) {
-            // TODO: clearAllPortals() aufrufen, sobald es wieder funktioniert
-            // PortalFactory.clearAllPortals();
+            PortalFactory.clearAllPortals();
           } else if (other.isPresent(TractorBeamComponent.class)
-              || other.isPresent(PortalExtendComponent.class)) {
+              || other.isPresent(PortalExtendComponent.class)
+              || (otherEntityName.contains("energyPelletLauncher")
+                  && otherEntityName.contains("skill_projectile"))) {
             // do nothing
           } else {
             Game.remove(other);


### PR DESCRIPTION
Die antiMaterialBarrier entfernt jetzt alle Portale sobald der Held hinduch geht und das energyPellet wird nicht mehr blockiert und kann durch fliegen.