### PR TITLE
Dungeon: Workaround for diagonal movement problem

### DIFF
--- a/dungeon/src/contrib/entities/HeroController.java
+++ b/dungeon/src/contrib/entities/HeroController.java
@@ -77,6 +77,7 @@ public class HeroController {
       // When moving diagonally, this function is called once per axis. On the first call, only the
       // force for one axis might be present, so we need to ensure we only scale by the speed of the
       // moving axes.
+      // TODO: Inputs should be batched and calculated together (explanation in PR #2724)
       Vector2 unitSpeed =
           Vector2.of(direction.x() != 0 ? speed.x() : 0, direction.y() != 0 ? speed.y() : 0);
       updatedForce = updatedForce.normalize().scale(unitSpeed.length());


### PR DESCRIPTION
Fixes #2667

Problem: Die Eingabe wird derzeit so verarbeitet, dass der Held 4 Callbacks für die verschiedenen Bewegungsrichtungen hat. Wenn der Spieler zwei Richtungen gleichzeitig drückt, werden 2 Move Aktionen gesendet, die sequentiell abgearbeitet werden. Dann tritt z.B. dieser Fall ein (speed der CharacterClass: (5, 5)):
- Spieler drückt (RECHTS, OBEN)
- Zuerst wird RECHTS verarbeitet
  - Der HeroController berechnet die force für die Direction: (5, 0)
  - Es existiert noch keine force mit dem key `MOVEMENT`, also ist die gesamt Force = (5, 0)
  - Normalisiert mit der speed der Character Klasse (5, 5) -> (7.071, 0)
- Danach wird OBEN verarbeitet
  - Der HeroController berechnet die force für die Direction: (0, 5)
  - Die force wird auf die existierende force addiert: (7.071, 5)
  - Normalisiert mit speed -> (5.773, 4.082)

Ich habe mir einige Lösungsmöglichkeiten angeschaut:
- Inputs batchen vorm Auslösen des Signals
  - Sauberste Lösung, benötigt aber ein umschreiben des Input Systems fürs Movement. Callbacks können dann nicht mehr funktionieren, sondern es muss der KeyPressed state gepolled werden
  - Der HeroController bekommt dann eine Richtung (1, 1), und kann diese dann perfekt weiterverwenden
- Inputs batchen, nach dem Auslösen des Signals
  - Mehrere Move Aktionen werden seitens des Servers zusammengruppiert, bevor die Berechnung ausgeführt wird
  - Bin mir nicht sicher, wie technisch möglich das ist, muss @Flamtky sagen
- Stumpf bei dem ersten call der Berechnung nicht gegen die gesamte speed normalisieren, sondern nur gegen die speed in der betroffenen Rechnung.
  - (Dieser PR)
  - Sollte funktionieren, solange die `MOVEMENT` force tatsächlich jeden Frame zurückgesetzt und nur vom HeroController neu berechnet wird.