### PR TITLE
Revert "Dungeon: Only update endPointSupplier if no cursor"

### DIFF
--- a/dungeon/src/contrib/entities/HeroController.java
+++ b/dungeon/src/contrib/entities/HeroController.java
@@ -96,11 +96,7 @@ public class HeroController {
               if (skill instanceof CursorSkill cursorSkill) {
                 cursorSkill.cursorPositionSupplier(() -> target);
               } else if (skill instanceof ProjectileSkill projSkill) {
-                try {
-                  projSkill.endPointSupplier().get(); // test if supplier wants cursor position
-                } catch (IllegalStateException ignored) {
-                  projSkill.endPointSupplier(() -> target);
-                }
+                projSkill.endPointSupplier(() -> target);
               }
               skill.execute(hero);
             });


### PR DESCRIPTION
Reverts Dungeon-CampusMinden/Dungeon#2697

Haben damit das Schießen im Multiplayer kaputt gemacht. Ich weiß auch nicht warum wir überhaupt das "gefixt" haben?