### PR TITLE
Level Editor: Crash on Door placement Fix

### DIFF
--- a/dungeon/src/core/level/elements/tile/DoorTile.java
+++ b/dungeon/src/core/level/elements/tile/DoorTile.java
@@ -16,7 +16,6 @@ import core.utils.components.path.SimpleIPath;
  */
 public class DoorTile extends Tile {
 
-  private final IPath closedTexturePath;
   private DoorTile otherDoor;
   private Tile doorstep;
   private boolean open;
@@ -33,8 +32,6 @@ public class DoorTile extends Tile {
   public DoorTile(
       final IPath texturePath, final Coordinate globalPosition, final DesignLabel designLabel) {
     super(texturePath, globalPosition, designLabel);
-    String[] splitPath = texturePath.pathString().split("\\.");
-    closedTexturePath = new SimpleIPath(splitPath[0] + "_closed." + splitPath[1]);
     levelElement = LevelElement.DOOR;
     open = true;
   }
@@ -114,7 +111,7 @@ public class DoorTile extends Tile {
   @Override
   public IPath texturePath() {
     if (open && (otherDoor == null || otherDoor.isOpen())) return texturePath;
-    else return closedTexturePath;
+    else return closedTexturePath();
   }
 
   @Override
@@ -123,9 +120,11 @@ public class DoorTile extends Tile {
     tileStr = tileStr.replace("Tile", "DoorTile").replace("}", "");
     String doorStepStr = this.doorstep == null ? "null" : this.doorstep.coordinate().toString();
     String otherDoorStr = this.otherDoor == null ? "null" : this.otherDoor.coordinate().toString();
+    String closedTexturePathStr =
+        closedTexturePath() == null ? "null" : closedTexturePath().pathString();
     return tileStr
         + ", closedTexturePath="
-        + this.closedTexturePath.pathString()
+        + closedTexturePathStr
         + ", open="
         + this.open
         + ", Doorstep="
@@ -133,5 +132,14 @@ public class DoorTile extends Tile {
         + ", OtherDoor="
         + otherDoorStr
         + "}";
+  }
+
+  private IPath closedTexturePath() {
+    if (texturePath != null) {
+      String[] splitPath = texturePath.pathString().split("\\.");
+      return new SimpleIPath(splitPath[0] + "_closed." + splitPath[1]);
+    } else {
+      return null;
+    }
   }
 }


### PR DESCRIPTION
Wenn man im Leveleditor versucht hat ein DoorTile zu platzieren, ist das Programm abgestürzt mit NullPointerExeption. Dies liegt daran, dass beim platzieren eines Tiles dieses zuerst ohne Texturpfad erzeugt wird und dieser erst später geladen wird. Beim Erstellen des DoorTiles wird allerdings schon auf den Texturpfad zugegriffen, um daraus den Pfad für die geschlossene Tür zu generieren.
Jetzt wird der Pfad nicht mehr direkt generiert, sondern nur beim Zugriff aus dem normalen Texturpfad generiert und ein null Check hinzugefügt.