### PR TITLE
Blockly: Add script to delete LocalStorage

### DIFF
--- a/blockly/tooling/deleteLocalStorage.sh
+++ b/blockly/tooling/deleteLocalStorage.sh
@@ -1,0 +1,5 @@
+# 1. Beende Chromium (WICHTIG: Sonst werden die Daten beim Schließen wieder erstellt)
+pkill -f chromium
+
+# 2. Lösche den Inhalt des leveldb Ordners
+rm -rf ~/.config/chromium/Default/Local\ Storage/leveldb/*


### PR DESCRIPTION
Ein Bash script zum Löschen des LocalStorages in Chromium. Bitte nocheinmal überprüfen, ob der Pfad richtig ist. Ich konnte jz nicht konkret auf den Pis testen, sondern nur bei mir im WSL.