### PR TITLE
Dungeon: Corner Correction Bug Fixes

### DIFF
--- a/dungeon/src/core/systems/MoveSystem.java
+++ b/dungeon/src/core/systems/MoveSystem.java
@@ -95,8 +95,7 @@ public class MoveSystem extends System {
     boolean canCornerCorrect = cornerCorrectTimers.getOrDefault(data.e, 0f) <= 0;
 
     // Dont allow corner correction when moving too fast diagonally. This allows the hero to enter
-    // 1-tile
-    // wide tunnels when easily by walking diagonally into them.
+    // 1-tile wide tunnels when easily by walking diagonally into them.
     canCornerCorrect &= absVelocity.x() < 0.5f || absVelocity.y() < 0.5f;
 
     // First: move only in X direction


### PR DESCRIPTION
Kleiner Nachtrag zum corner correction PR:
- Diagonal in Ecken moven schlackert jetzt nicht mehr hin und her
- Diagonal in 1-tile-Tunnel zu bewegen klappt jetzt ohne Probleme
- Man wird nicht mehr ab und zu für einen frame in einer Wand platziert durch corner correction

Ich muss schon sagen, jetzt fühlt es sich wirklich gut an, sich einfach durch ein Level mit vielen Wänden zu bewegen.