### PR TITLE
Dungeon: Fix double calling of onClose on UI callback

### DIFF
--- a/dungeon/src/contrib/hud/UIUtils.java
+++ b/dungeon/src/contrib/hud/UIUtils.java
@@ -209,10 +209,12 @@ public final class UIUtils {
    *
    * @param uiComponent the UIComponent whose dialog is to be closed
    * @param deleteOwner whether to remove the owner entity from the game after closing the dialog
-   * @param callDefaultClose whether to call the onClose (default close behavior) callback of the UIComponent
+   * @param callDefaultClose whether to call the onClose (default close behavior) callback of the
+   *     UIComponent
    */
-  public static void closeDialog(UIComponent uiComponent, boolean deleteOwner, boolean callDefaultClose) {
-    if(callDefaultClose){
+  public static void closeDialog(
+      UIComponent uiComponent, boolean deleteOwner, boolean callDefaultClose) {
+    if (callDefaultClose) {
       uiComponent.onClose().accept(uiComponent); // onClose callback
     }
 

--- a/dungeon/src/contrib/hud/dialogs/DialogFactory.java
+++ b/dungeon/src/contrib/hud/dialogs/DialogFactory.java
@@ -209,9 +209,7 @@ public class DialogFactory {
     UIComponent ui = show(ctx, targetIds);
 
     // Register callback
-    ui.registerCallback(
-        DialogContextKeys.ON_CONFIRM,
-        data -> UIUtils.closeDialog(ui, true, true));
+    ui.registerCallback(DialogContextKeys.ON_CONFIRM, data -> UIUtils.closeDialog(ui, true, true));
 
     // Default onClose behavior (e.g. when pressing ESC)
     ui.onClose(uic -> onConfirm.execute());
@@ -247,9 +245,7 @@ public class DialogFactory {
           onYes.execute();
           UIUtils.closeDialog(ui, true, false);
         });
-    ui.registerCallback(
-        DialogContextKeys.ON_NO,
-        data -> UIUtils.closeDialog(ui, true, true));
+    ui.registerCallback(DialogContextKeys.ON_NO, data -> UIUtils.closeDialog(ui, true, true));
 
     // Default onClose behavior (e.g. when pressing ESC)
     ui.onClose(uic -> onNo.execute());


### PR DESCRIPTION
Fixes #2758

- Neuer Parameter in `UIUtils.closeDialog`: `boolean callDefaultClose` (default: true, um bestehendes Verhalten von nicht-Standarddialogen beizubehalten)

Beim Schließen von Dialogen via ein UI Element callback wurde bisher immer der callback manuell aufgerufen und danach UIUtils.closeDialog um die UIComponent zu löschen, was den hinterlegten `onClose` immer ausgeführt hat. Mit dem neuen Parameter kann man nur die UIComponent löschen, ohne den `onClose` nochmal auszuführen.