### PR TITLE
Dungeon: trigger `onLeave` in `CollisionSystem` on entity remove

### DIFF
--- a/dungeon/src/core/System.java
+++ b/dungeon/src/core/System.java
@@ -49,6 +49,8 @@ public abstract class System {
    * <p>Use this in your own system to implement logic that should be executed after an entity was
    * added.
    *
+   * <p>This will also be triggered, if a new level was loaded or the System was added to the ECS.
+   *
    * <p>The default implementation is just empty.
    */
   protected Consumer<Entity> onEntityAdd = (e) -> {};
@@ -58,6 +60,9 @@ public abstract class System {
    *
    * <p>Use this in your own system to implement logic that should be executed after an entity was
    * removed.
+   *
+   * <p>This will also be triggered, if a new level was loaded or the System was removed from the
+   * ECS.
    *
    * <p>The default implementation is just empty.
    */


### PR DESCRIPTION
fixes #2788 

Implementiert die `System#onEntityRemove` für `CollisionSystem`

Wenn eine Entität aus dem Spiel entfernt wird **oder** die für das System wichtige Components verliert, werden jetzt alle aktuellen Collisions aufgelöst (die `onLeave` wird getriggert).

Dies passiert jetzt auch, wenn ein neues Level geladen wird (dann werden die Collisions aus dem letzten Level aufgelöst und nicht weiter verrechnet). Vorher wurden die tatsächlich weiterbetrachtet, da sie nie aufgeräumt wurden.
Das ECS triggert dies automatisch beim Wechseln der Level.

Die Direction der `onLeave` ist auf `None` eingestellt... Hielt ich für den besten Kompromiss, da es in dem Sinne keine Auflösungsdirection gibt.

Bisschen nervig finde ich es, dass ich tatsächlich über die ganze Map iterieren muss, um zu gucken, in welchen Kollisionen meine Entität mitspielt, aber mir fehlt auch eine bessere Lösung.