### PR TITLE
 Core: Add support for empty levels and centralize initial level loading

### DIFF
--- a/advancedDungeon/src/aiAdvanced/starter/PathfinderStarter.java
+++ b/advancedDungeon/src/aiAdvanced/starter/PathfinderStarter.java
@@ -67,7 +67,6 @@ public class PathfinderStarter {
             throw new RuntimeException(e);
           }
           Game.system(LevelSystem.class, ls -> ls.onEndTile(DungeonLoader::loadNextLevel));
-          DungeonLoader.loadLevel(0);
         });
   }
 

--- a/blockly/src/client/Client.java
+++ b/blockly/src/client/Client.java
@@ -123,8 +123,6 @@ public class Client {
           createSystems();
 
           startServer();
-
-          DungeonLoader.loadLevel(0);
         });
   }
 

--- a/dungeon/src/contrib/systems/EventScheduler.java
+++ b/dungeon/src/contrib/systems/EventScheduler.java
@@ -26,6 +26,17 @@ public class EventScheduler extends System {
   private static boolean pausable = true;
 
   /**
+   * Creates a new EventScheduler.
+   *
+   * <p>The EventScheduler is initialized to operate on both the client and server sides.
+   *
+   * @see System
+   */
+  public EventScheduler() {
+    super(AuthoritativeSide.BOTH);
+  }
+
+  /**
    * Schedules a new action to be executed after a specified delay.
    *
    * <p>This method creates a new ScheduledAction with the provided action and execution time, and

--- a/dungeon/src/contrib/systems/LevelTickSystem.java
+++ b/dungeon/src/contrib/systems/LevelTickSystem.java
@@ -17,7 +17,7 @@ public class LevelTickSystem extends System {
 
   /** Creates a new LevelTickSystem. */
   public LevelTickSystem() {
-    super(AuthoritativeSide.SERVER);
+    super(AuthoritativeSide.BOTH);
   }
 
   /** The current level of the game. */

--- a/dungeon/src/core/game/GameLoop.java
+++ b/dungeon/src/core/game/GameLoop.java
@@ -5,6 +5,7 @@ import static com.badlogic.gdx.graphics.GL20.GL_COLOR_BUFFER_BIT;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.ScreenAdapter;
 import com.badlogic.gdx.assets.AssetManager;
+import com.badlogic.gdx.backends.headless.HeadlessFiles;
 import com.badlogic.gdx.backends.lwjgl3.Lwjgl3Application;
 import com.badlogic.gdx.backends.lwjgl3.Lwjgl3ApplicationConfiguration;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
@@ -308,16 +309,20 @@ public final class GameLoop extends ScreenAdapter {
     doSetup = false;
     if (!PreRunConfiguration.multiplayerEnabled() || !PreRunConfiguration.isNetworkServer()) {
       setupClient();
+    } else {
+      Gdx.files = new HeadlessFiles();
     }
+
+    Crafting.loadRecipes();
 
     PreRunConfiguration.userOnSetup().execute();
     Game.network().start();
 
     if (!Game.isHeadless()) InputManager.init();
 
-    Crafting.loadRecipes();
-
-    Game.system(LevelSystem.class, LevelSystem::execute); // load initial level
+    if (!DungeonLoader.levelOrder().isEmpty()) {
+      if (Game.currentLevel().isEmpty()) DungeonLoader.loadLevel(0); // load the first level
+    } else LOGGER.warn("No levels found to load!");
   }
 
   private void setupMessageHandlers() {

--- a/dungeon/src/core/network/server/AuthoritativeServerLoop.java
+++ b/dungeon/src/core/network/server/AuthoritativeServerLoop.java
@@ -3,8 +3,6 @@ package core.network.server;
 import static core.network.config.NetworkConfig.SERVER_SNAPSHOT_HZ;
 import static core.network.config.NetworkConfig.SERVER_TICK_HZ;
 
-import com.badlogic.gdx.Gdx;
-import com.badlogic.gdx.backends.headless.HeadlessFiles;
 import contrib.entities.HeroBuilder;
 import contrib.entities.HeroController;
 import core.Entity;
@@ -71,21 +69,13 @@ public final class AuthoritativeServerLoop {
    * tasks.
    */
   public void start() {
-    Gdx.files = new HeadlessFiles();
-
     PreRunConfiguration.frameRate(SERVER_TICK_HZ);
-    PreRunConfiguration.userOnSetup().execute();
 
-    try {
-      DungeonLoader.afterAllLevels(
-          () -> {
-            Game.network().broadcast(new GameOverEvent("All levels completed"), true);
-            Game.exit("Game Over");
-          });
-      DungeonLoader.loadLevel(0);
-    } catch (Exception e) {
-      LOGGER.warn("Failed to load initial level on server", e);
-    }
+    DungeonLoader.afterAllLevels(
+        () -> {
+          Game.network().broadcast(new GameOverEvent("All levels completed"), true);
+          Game.exit("Game Over");
+        });
 
     long tickPeriodMs = 1000L / SERVER_TICK_HZ;
     long snapshotPeriodMs = 1000L / SERVER_SNAPSHOT_HZ;

--- a/dungeon/src/core/network/server/ServerTransport.java
+++ b/dungeon/src/core/network/server/ServerTransport.java
@@ -769,6 +769,11 @@ public final class ServerTransport {
   }
 
   private void sendInitialLevel(ChannelHandlerContext ctx, int clientId) {
+    if (Game.currentLevel().isEmpty()) {
+      LOGGER.warn("No current level to send to clientId={}", clientId);
+      return;
+    }
+
     try {
       LevelChangeEvent ev = LevelChangeEvent.currentLevel();
       sendTcpObject(ctx, ev);

--- a/dungeon/src/core/systems/LevelSystem.java
+++ b/dungeon/src/core/systems/LevelSystem.java
@@ -136,38 +136,32 @@ public final class LevelSystem extends System {
   /**
    * Execute the system logic.
    *
-   * <p>Will load a new level if no level exists or one of the managed entities are on the end tile.
-   *
-   * <p>Will draw the level.
+   * <p>If no level exists yet, the system will do nothing. If all players are on the end tile, the
+   * onEndTile callback will be executed. If all players are on the same open door, the level behind
+   * that door will be loaded. Otherwise, the system will check if any pits should be opened.
    */
   @Override
   public void execute() {
     if (currentLevel == null) {
-      try {
-        DungeonLoader.loadLevel(0);
-        execute();
-      } catch (IndexOutOfBoundsException e) {
-        LOGGER.warn("Can´t load level 0, because no level is added to the DungeonLoader.");
-      }
-    } else {
-      if (Game.allPlayers().findAny().isEmpty()) return;
-
-      // Load next level if all heroes are on the end tile
-      if (Game.allPlayers().allMatch(this::isOnOpenEndTile)) {
-        onEndTile.execute();
-        return;
-      }
-
-      // Check if all heroes are on the same open door and load that level
-      List<ILevel> doorLevels =
-          Game.allPlayers().map(this::isOnDoor).flatMap(Optional::stream).distinct().toList();
-
-      if (doorLevels.size() == 1) {
-        loadLevel(doorLevels.get(0));
-        playSound();
-      }
+      return;
     }
 
+    if (Game.allPlayers().findAny().isEmpty()) return;
+
+    // Load next level if all heroes are on the end tile
+    if (Game.allPlayers().allMatch(this::isOnOpenEndTile)) {
+      onEndTile.execute();
+      return;
+    }
+
+    // Check if all heroes are on the same open door and load that level
+    List<ILevel> doorLevels =
+        Game.allPlayers().map(this::isOnDoor).flatMap(Optional::stream).distinct().toList();
+
+    if (doorLevels.size() == 1) {
+      loadLevel(doorLevels.get(0));
+      playSound();
+    }
     openPits();
   }
 

--- a/dungeon/src/core/systems/PositionSystem.java
+++ b/dungeon/src/core/systems/PositionSystem.java
@@ -4,9 +4,7 @@ import core.Entity;
 import core.Game;
 import core.System;
 import core.components.PositionComponent;
-import core.utils.Point;
 import core.utils.components.MissingComponentException;
-import java.util.NoSuchElementException;
 
 /**
  * The {@link PositionSystem} checks if an entity has an illegal position and then changes the
@@ -30,7 +28,7 @@ public final class PositionSystem extends System {
 
   @Override
   public void execute() {
-    filteredEntityStream(PositionComponent.class)
+    filteredEntityStream()
         .map(this::buildDataObject)
         .filter(data -> data.pc.position().equals(PositionComponent.ILLEGAL_POSITION))
         .forEach(this::randomPosition);
@@ -43,13 +41,7 @@ public final class PositionSystem extends System {
    * @param data The PSData object containing entity and position component information.
    */
   private void randomPosition(final PSData data) {
-    Point position =
-        Game.freePosition()
-            .orElseThrow(
-                () ->
-                    new NoSuchElementException(
-                        "There is no free tile in the level; the entity can't be placed."));
-    data.pc().position(position);
+    Game.freePosition().ifPresent(newPos -> data.pc().position(newPos));
   }
 
   private PSData buildDataObject(final Entity e) {


### PR DESCRIPTION
Unterstützung für leere/keine Level implementiert sowie initialer Level-Ladevorgang nun in Game-Loop.

* Level-Management:
  * `GameLoop` lädt automatisch Level 0, wenn `levelOrder` nicht leer ist; Warnung bei fehlenden Levels.
  * `DungeonLoader.loadLevel(0)` Aufrufe aus Startern (`PathfinderStarter`, `Client`) entfernt.
  * `LevelSystem` bricht bei `currentLevel == null` ab, statt automatischen Nachladen zu versuchen.
  * `ServerTransport.sendInitialLevel` prüft auf Existenz des aktuellen Levels vor Versand.

* System-Konfiguration:
  * `EventScheduler` und `LevelTickSystem` auf `AuthoritativeSide.BOTH` gesetzt.

* Server-Setup:
  * Initialisierung von `HeadlessFiles` in `GameLoop` verschoben, um File-Zugriff im Server-Modus sicherzustellen.

* PositionSystem:
  * Wirft keine `NoSuchElementException` mehr bei leeren Level/Positionen