### PR TITLE
Dungeon: Add protobuf custom value codec for dialogs

### DIFF
--- a/dungeon/proto/c2s/dialog.proto
+++ b/dungeon/proto/c2s/dialog.proto
@@ -29,6 +29,6 @@ message DialogResponseMessage {
     bool bool_value = 15;
     dungeon.common.StringList string_list = 16;
     dungeon.common.IntList int_list = 17;
+    dungeon.common.CustomValue custom_value = 18;
   }
 }
-

--- a/dungeon/proto/common/common_types.proto
+++ b/dungeon/proto/common/common_types.proto
@@ -102,3 +102,14 @@ message StringList {
 message IntList {
     repeated int32 values = 1;
 }
+
+// Type-discriminated binary value for custom/extension types.
+// Used by dialog attributes and response payloads to carry
+// subproject-defined types through the codec registry.
+message CustomValue {
+    // Unique type discriminator (e.g. "TransitionSpeed", "ComputerStateComponent").
+    string type_id = 1;
+
+    // Encoded payload produced by DialogValueCodec.encode().
+    bytes data = 2;
+}

--- a/dungeon/proto/s2c/dialog.proto
+++ b/dungeon/proto/s2c/dialog.proto
@@ -41,6 +41,7 @@ message DialogAttribute {
     bool bool_value = 7;
     dungeon.common.StringList string_list = 8;
     dungeon.common.IntList int_list = 9;
+    dungeon.common.CustomValue custom_value = 10;
   }
 }
 

--- a/dungeon/src/core/network/codec/DialogValueCodec.java
+++ b/dungeon/src/core/network/codec/DialogValueCodec.java
@@ -1,0 +1,52 @@
+package core.network.codec;
+
+import java.io.Serializable;
+
+/**
+ * Codec for encoding and decoding custom dialog attribute and payload types to bytes.
+ *
+ * <p>Subprojects implement this interface for each custom {@link Serializable} type they need to
+ * send through dialog context attributes ({@link
+ * core.network.codec.converters.s2c.DialogShowConverter}) or dialog response payloads ({@link
+ * core.network.codec.converters.c2s.DialogResponseConverter}).
+ *
+ * <p>Register implementations via {@link DialogValueCodecRegistry#register(DialogValueCodec)}.
+ *
+ * @param <T> the custom type, must be {@link Serializable}
+ */
+public interface DialogValueCodec<T extends Serializable> {
+
+  /**
+   * Unique string discriminator written to the protobuf {@code CustomValue.type_id} field.
+   *
+   * <p>Must be stable across versions; changing it breaks wire compatibility.
+   *
+   * @return the type identifier
+   */
+  String typeId();
+
+  /**
+   * The concrete Java class this codec handles.
+   *
+   * <p>Used for encode-side dispatch with exact-class matching.
+   *
+   * @return the handled class
+   */
+  Class<T> type();
+
+  /**
+   * Encodes a value to a byte array for protobuf transport.
+   *
+   * @param value the value to encode
+   * @return the encoded bytes
+   */
+  byte[] encode(T value);
+
+  /**
+   * Decodes a value from a byte array received over protobuf.
+   *
+   * @param data the encoded bytes
+   * @return the decoded value
+   */
+  T decode(byte[] data);
+}

--- a/dungeon/src/core/network/codec/DialogValueCodecRegistry.java
+++ b/dungeon/src/core/network/codec/DialogValueCodecRegistry.java
@@ -1,0 +1,102 @@
+package core.network.codec;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Central registry for {@link DialogValueCodec} instances.
+ *
+ * <p>Provides encode-side lookup by Java class and decode-side lookup by type ID string. Access the
+ * shared instance via {@link #global()}.
+ */
+public final class DialogValueCodecRegistry {
+  private static volatile DialogValueCodecRegistry globalInstance;
+
+  private final Map<Class<?>, DialogValueCodec<?>> byType = new ConcurrentHashMap<>();
+  private final Map<String, DialogValueCodec<?>> byTypeId = new ConcurrentHashMap<>();
+
+  /** Creates an empty registry. */
+  public DialogValueCodecRegistry() {}
+
+  /**
+   * Returns the shared global registry instance.
+   *
+   * <p>Built-in codecs are registered automatically during first initialization.
+   *
+   * @return the global registry
+   */
+  public static DialogValueCodecRegistry global() {
+    DialogValueCodecRegistry instance = globalInstance;
+    if (instance != null) {
+      return instance;
+    }
+    synchronized (DialogValueCodecRegistry.class) {
+      instance = globalInstance;
+      if (instance == null) {
+        instance = new DialogValueCodecRegistry();
+        instance.registerDefaults();
+        globalInstance = instance;
+      }
+    }
+    return instance;
+  }
+
+  /**
+   * Registers a codec.
+   *
+   * @param codec the codec to register
+   * @throws IllegalStateException if a codec for the same type or type ID is already registered
+   */
+  public void register(DialogValueCodec<?> codec) {
+    Objects.requireNonNull(codec, "codec");
+    Objects.requireNonNull(codec.typeId(), "codec.typeId()");
+    Objects.requireNonNull(codec.type(), "codec.type()");
+
+    DialogValueCodec<?> existingType = byType.putIfAbsent(codec.type(), codec);
+    if (existingType != null) {
+      throw new IllegalStateException(
+          "Duplicate DialogValueCodec for type "
+              + codec.type().getName()
+              + " (existing: "
+              + existingType.getClass().getName()
+              + ")");
+    }
+
+    DialogValueCodec<?> existingTypeId = byTypeId.putIfAbsent(codec.typeId(), codec);
+    if (existingTypeId != null) {
+      byType.remove(codec.type(), codec);
+      throw new IllegalStateException(
+          "Duplicate DialogValueCodec for typeId '"
+              + codec.typeId()
+              + "' (existing: "
+              + existingTypeId.getClass().getName()
+              + ")");
+    }
+  }
+
+  /**
+   * Looks up a codec by exact Java class.
+   *
+   * @param type the class to look up
+   * @return the codec if one is registered for the class
+   */
+  public Optional<DialogValueCodec<?>> byType(Class<?> type) {
+    return Optional.ofNullable(byType.get(type));
+  }
+
+  /**
+   * Looks up a codec by type ID string.
+   *
+   * @param typeId the type discriminator
+   * @return the codec if one is registered for the type ID
+   */
+  public Optional<DialogValueCodec<?>> byTypeId(String typeId) {
+    return Optional.ofNullable(byTypeId.get(typeId));
+  }
+
+  private void registerDefaults() {
+    register(new core.network.codec.codecs.TransitionSpeedCodec());
+  }
+}

--- a/dungeon/src/core/network/codec/codecs/TransitionSpeedCodec.java
+++ b/dungeon/src/core/network/codec/codecs/TransitionSpeedCodec.java
@@ -1,0 +1,29 @@
+package core.network.codec.codecs;
+
+import contrib.utils.components.showImage.TransitionSpeed;
+import core.network.codec.DialogValueCodec;
+import java.nio.charset.StandardCharsets;
+
+/** Built-in codec for {@link TransitionSpeed}. */
+public final class TransitionSpeedCodec implements DialogValueCodec<TransitionSpeed> {
+
+  @Override
+  public String typeId() {
+    return "TransitionSpeed";
+  }
+
+  @Override
+  public Class<TransitionSpeed> type() {
+    return TransitionSpeed.class;
+  }
+
+  @Override
+  public byte[] encode(TransitionSpeed value) {
+    return value.name().getBytes(StandardCharsets.UTF_8);
+  }
+
+  @Override
+  public TransitionSpeed decode(byte[] data) {
+    return TransitionSpeed.valueOf(new String(data, StandardCharsets.UTF_8));
+  }
+}

--- a/dungeon/src/core/network/codec/converters/s2c/DialogShowConverter.java
+++ b/dungeon/src/core/network/codec/converters/s2c/DialogShowConverter.java
@@ -1,13 +1,15 @@
 package core.network.codec.converters.s2c;
 
+import com.google.protobuf.ByteString;
 import com.google.protobuf.Parser;
 import contrib.hud.dialogs.DialogContext;
-import contrib.hud.dialogs.DialogContextKeys;
 import contrib.hud.dialogs.DialogFactory;
 import contrib.hud.dialogs.DialogType;
-import contrib.utils.components.showImage.TransitionSpeed;
+import core.network.codec.DialogValueCodec;
+import core.network.codec.DialogValueCodecRegistry;
 import core.network.codec.MessageConverter;
 import core.network.messages.s2c.DialogShowMessage;
+import core.network.proto.common.CustomValue;
 import core.network.proto.common.IntList;
 import core.network.proto.common.StringList;
 import core.network.proto.s2c.DialogAttribute;
@@ -114,14 +116,25 @@ public final class DialogShowConverter
         }
         builder.setIntList(intList);
       }
-      case TransitionSpeed speed when DialogContextKeys.IMAGE_TRANSITION_SPEED.equals(key) ->
-          builder.setStringValue(speed.name());
-      default ->
-          throw new IllegalArgumentException(
-              "Unsupported dialog attribute type for key '"
-                  + key
-                  + "': "
-                  + value.getClass().getName());
+      default -> {
+        @SuppressWarnings("unchecked")
+        DialogValueCodec<Serializable> codec =
+            (DialogValueCodec<Serializable>)
+                DialogValueCodecRegistry.global()
+                    .byType(value.getClass())
+                    .orElseThrow(
+                        () ->
+                            new IllegalArgumentException(
+                                "Unsupported dialog attribute type for key '"
+                                    + key
+                                    + "': "
+                                    + value.getClass().getName()
+                                    + ". Register a DialogValueCodec for this type."));
+        builder.setCustomValue(
+            CustomValue.newBuilder()
+                .setTypeId(codec.typeId())
+                .setData(ByteString.copyFrom(codec.encode(value))));
+      }
     }
 
     return builder.build();
@@ -129,7 +142,7 @@ public final class DialogShowConverter
 
   private static Serializable fromAttribute(String key, DialogAttribute attribute) {
     return switch (attribute.getValueCase()) {
-      case STRING_VALUE -> transitionSpeedOrString(key, attribute.getStringValue());
+      case STRING_VALUE -> attribute.getStringValue();
       case INT_VALUE -> attribute.getIntValue();
       case LONG_VALUE -> attribute.getLongValue();
       case FLOAT_VALUE -> attribute.getFloatValue();
@@ -137,19 +150,23 @@ public final class DialogShowConverter
       case BOOL_VALUE -> attribute.getBoolValue();
       case STRING_LIST -> attribute.getStringList().getValuesList().toArray(new String[0]);
       case INT_LIST -> attribute.getIntList().getValuesList().stream().mapToInt(i -> i).toArray();
+      case CUSTOM_VALUE -> {
+        CustomValue custom = attribute.getCustomValue();
+        DialogValueCodec<?> codec =
+            DialogValueCodecRegistry.global()
+                .byTypeId(custom.getTypeId())
+                .orElseThrow(
+                    () ->
+                        new IllegalArgumentException(
+                            "No DialogValueCodec registered for typeId '"
+                                + custom.getTypeId()
+                                + "' (attribute key: '"
+                                + key
+                                + "')"));
+        yield codec.decode(custom.getData().toByteArray());
+      }
       case VALUE_NOT_SET -> null;
     };
-  }
-
-  private static Serializable transitionSpeedOrString(String key, String value) {
-    if (!DialogContextKeys.IMAGE_TRANSITION_SPEED.equals(key)) {
-      return value;
-    }
-    try {
-      return TransitionSpeed.valueOf(value);
-    } catch (IllegalArgumentException ignored) {
-      return value;
-    }
   }
 
   private static DialogType resolveDialogType(String typeString) {

--- a/dungeon/src/core/network/messages/c2s/DialogResponseMessage.java
+++ b/dungeon/src/core/network/messages/c2s/DialogResponseMessage.java
@@ -1,6 +1,7 @@
 package core.network.messages.c2s;
 
 import core.network.messages.NetworkMessage;
+import java.io.Serializable;
 import java.util.Objects;
 
 /**
@@ -72,7 +73,7 @@ public record DialogResponseMessage(String dialogId, String callbackKey, Payload
    *
    * @see DialogResponseMessage
    */
-  public interface Payload {}
+  public interface Payload extends Serializable {}
 
   /**
    * Represents a string payload for dialog responses.
@@ -179,6 +180,26 @@ public record DialogResponseMessage(String dialogId, String callbackKey, Payload
      */
     public IntList {
       Objects.requireNonNull(values, "values");
+    }
+  }
+
+  /**
+   * Wraps a custom value decoded by a {@link core.network.codec.DialogValueCodec} that does not
+   * directly implement {@link Payload}.
+   *
+   * <p>Use {@link #value()} and cast to the expected type.
+   *
+   * @param value the decoded value
+   */
+  public record CustomPayload(Serializable value) implements Payload {
+    /**
+     * Creates a custom payload wrapper with a required value.
+     *
+     * @param value the decoded value
+     * @throws NullPointerException if {@code value} is {@code null}
+     */
+    public CustomPayload {
+      Objects.requireNonNull(value, "value");
     }
   }
 }


### PR DESCRIPTION
Protobuf CustomValue für Dialog-Oneofs hinzugefügt und Codec-API für Custom Values implementiert.

* Codec-API:
  * `DialogValueCodec`, `DialogValueCodecRegistry`, `TransitionSpeedCodec` hinzugefügt.

* Refactoring:
  * `DialogShowConverter` nutzt Registry/Custom Wire Type (hardcoded TransitionSpeed-Logik entfernt).
  * `DialogResponseConverter` encode/decode Custom Payloads via Registry.

* API-Änderungen:
  * `DialogResponseMessage.Payload` erweitert `Serializable`.
  * `DialogResponseMessage.CustomPayload` für dekodierte Custom Values hinzugefügt.

* Tests:
  * Tests für Custom Codec Roundtrips und Wrapper-Pfad: `DialogShowConverterTest`, `C2SConverterTest`.