### PR TITLE
Blockly: create temp folder manually

### DIFF
--- a/blockly/src/client/Client.java
+++ b/blockly/src/client/Client.java
@@ -67,7 +67,7 @@ public class Client {
    * @param args CLI arguments
    * @throws IOException if textures can not be loaded.
    */
-  public static void main(String[] args) throws IOException {
+  public static void main(String[] args) throws Exception {
     try {
       Properties props = new Properties();
       // loads the file that sets the web mode (incase jar was created with jardesktop or jarweb)
@@ -80,6 +80,18 @@ public class Client {
           runInWeb = true;
         }
       }
+    }
+
+    String path =
+        String.valueOf(Client.class.getProtectionDomain().getCodeSource().getLocation().toURI());
+
+    String operatingSystem = java.lang.System.getProperty("os.name");
+
+    // extract the folder for the windows operatin system
+    // prevents the creation of temporary folders
+    if (path.endsWith(".jar") && operatingSystem.contains("Windows")) {
+      java.lang.System.out.println("Extracting folders");
+      FolderExtractor.prepareCompilerResources();
     }
 
     if (runInWeb) {
@@ -105,6 +117,7 @@ public class Client {
       }
       BlocklyCodeRunner.instance().stopCode();
       FrontendServer.stopServer();
+      FolderExtractor.deleteCompilerResources();
     }
   }
 

--- a/blockly/src/client/FolderExtractor.java
+++ b/blockly/src/client/FolderExtractor.java
@@ -1,0 +1,110 @@
+package client;
+
+import coderunner.BlocklyCodeRunner;
+import core.utils.logging.DungeonLogger;
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.*;
+import java.util.Comparator;
+import java.util.Map;
+
+/**
+ * This class has functions for managing a temporary folder that the blockly code is saved in. In
+ * addition, there are also function for creating a copy of the jar file in case the windows
+ * operating system is used. Otherwise a loft of temporary folders would be created because the
+ * blocklyCodeRunner and libgdx access the jar file at the same time.
+ */
+public class FolderExtractor {
+
+  private static final DungeonLogger LOGGER = DungeonLogger.getLogger(BlocklyCodeRunner.class);
+
+  /**
+   * The name of the temporary folder where the compiled code will be stored. This folder is created
+   * in the system's temporary directory. (default: "blockly")
+   */
+  public static String TEMP_FOLDER_NAME = "blockly";
+
+  /**
+   * Returns the path to the BlocklyCodeRunner's temporary folder.
+   *
+   * <p>If no temporary folder is found it will generate a new one in the system's temporary
+   * directory.
+   *
+   * @return Path to the temporary folder. If no folder is found or cannot be created, returns null.
+   */
+  public static Path tempFolder() {
+    File tempDir = new File(System.getProperty("java.io.tmpdir"));
+    System.out.println("Found temp file: " + tempDir.getAbsolutePath());
+    File[] tempFiles = tempDir.listFiles();
+    if (tempFiles != null) {
+      for (File file : tempFiles) {
+
+        if (file.isDirectory() && file.getName().equals(TEMP_FOLDER_NAME)) {
+          return file.toPath();
+        }
+      }
+    }
+
+    // If no temp folder found, create a new one
+    try {
+      tempDir = Files.createDirectory(Paths.get(tempDir.getPath(), TEMP_FOLDER_NAME)).toFile();
+    } catch (IOException e) {
+      LOGGER.error("Error creating temp folder: " + e.getMessage());
+      return null;
+    }
+    return tempDir.toPath();
+  }
+
+  /** Creates a copy of the jar file and stores it in the temp directory. */
+  public static void prepareCompilerResources() throws Exception {
+    // create directory
+    Path tempDir = tempFolder();
+    Path libFolder = Files.createDirectories(tempDir.resolve("unpacked_libs"));
+    URI jarUri = FolderExtractor.class.getProtectionDomain().getCodeSource().getLocation().toURI();
+
+    try (FileSystem zipFs = FileSystems.newFileSystem(URI.create("jar:" + jarUri), Map.of())) {
+      Path root = zipFs.getPath("/");
+
+      // go through the jar and process each file
+      Files.walk(root)
+          .filter(Files::isRegularFile) // only files
+          .forEach(source -> copyToTemp(source, root, libFolder));
+    }
+  }
+
+  /** Deletes the copy of the jar file. */
+  public static void deleteCompilerResources() throws Exception {
+
+    System.out.println("Deleting temp folder");
+
+    Path tempDir = tempFolder();
+    Path libFolder = tempDir.resolve("unpacked_libs");
+
+    if (Files.exists(libFolder)) {
+      Files.walk(libFolder)
+          .sorted(Comparator.reverseOrder())
+          .forEach(
+              path -> {
+                try {
+                  Files.delete(path);
+                } catch (IOException e) {
+                  // Fehlerbehandlung, falls eine Datei gesperrt ist
+                  System.err.println("Could not delete: " + path + " - " + e.getMessage());
+                }
+              });
+    }
+  }
+
+  private static void copyToTemp(Path source, Path root, Path targetDir) {
+    try {
+      // path relativ to jar file
+      Path target = targetDir.resolve(root.relativize(source).toString());
+
+      Files.createDirectories(target.getParent());
+      Files.copy(source, target, StandardCopyOption.REPLACE_EXISTING);
+    } catch (IOException e) {
+      System.err.println("Skip: " + source + " (" + e.getMessage() + ")");
+    }
+  }
+}

--- a/blockly/src/coderunner/BlocklyCodeRunner.java
+++ b/blockly/src/coderunner/BlocklyCodeRunner.java
@@ -5,13 +5,11 @@ import core.utils.logging.DungeonLogger;
 import java.io.*;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.net.MalformedURLException;
-import java.net.URISyntaxException;
-import java.net.URL;
-import java.net.URLClassLoader;
+import java.net.*;
 import java.nio.file.*;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -131,54 +129,36 @@ public class BlocklyCodeRunner {
    * @param code Java code that should be executed.
    * @throws RuntimeException If an error occurs during execution.
    */
-  public void executeJavaCode(String code) throws RuntimeException, URISyntaxException {
+  public void executeJavaCode(String code) throws Exception {
     executeJavaCode(code, DEFAULT_SLEEP_AFTER_EACH_LINE);
   }
 
 
-  public void prepareCompilerResources(Path tempDir) {
-    Path libFolder = tempDir.resolve("unpacked_libs");
+  private void prepareCompilerResources(Path tempDir) throws Exception {
+    // create directory
+    Path libFolder = Files.createDirectories(tempDir.resolve("unpacked_libs"));
+    URI jarUri = getClass().getProtectionDomain().getCodeSource().getLocation().toURI();
 
-      try {
-        Files.createDirectories(libFolder);
-        File jarFile = new File(getClass().getProtectionDomain().getCodeSource().getLocation().toURI());
+    try (FileSystem zipFs = FileSystems.newFileSystem(URI.create("jar:" + jarUri), Map.of())) {
+      Path root = zipFs.getPath("/");
 
-        try (java.util.zip.ZipFile zip = new java.util.zip.ZipFile(jarFile)) {
-          java.util.Enumeration<? extends java.util.zip.ZipEntry> entries = zip.entries();
+      // go through the jar and process each file
+      Files.walk(root)
+        .filter(Files::isRegularFile) // only files
+        .forEach(source -> copyToTemp(source, root, libFolder));
+    }
+  }
 
-          while (entries.hasMoreElements()) {
-            java.util.zip.ZipEntry entry = entries.nextElement();
-            Path entryPath = libFolder.resolve(entry.getName());
+  private void copyToTemp(Path source, Path root, Path targetDir) {
+    try {
+      // path relativ to jar file
+      Path target = targetDir.resolve(root.relativize(source).toString());
 
-            if (entry.isDirectory()) {
-              // create folder if it does not exist
-              if (!Files.exists(entryPath)) {
-                Files.createDirectories(entryPath);
-              }
-            } else {
-              // make sure the parent folder exists
-              Path parent = entryPath.getParent();
-              if (parent != null && !Files.exists(parent)) {
-                Files.createDirectories(parent);
-              }
-
-              // extract file
-              try (InputStream is = zip.getInputStream(entry)) {
-                // check if there is a folder with the same name
-                if (Files.exists(entryPath) && Files.isDirectory(entryPath)) {
-                } else {
-                  Files.copy(is, entryPath, StandardCopyOption.REPLACE_EXISTING);
-                }
-              } catch (IOException e) {
-                // Case-Sensitivity Konflikte (LICENSE vs license) abfangen
-                 System.out.println("Could not extract files: " + entry.getName());
-              }
-            }
-          } // Ende while
-        } // Ende try-with-resources (zip)
-      } catch (Exception e) {
-        e.printStackTrace();
-      }
+      Files.createDirectories(target.getParent());
+      Files.copy(source, target, StandardCopyOption.REPLACE_EXISTING);
+    } catch (IOException e) {
+      System.err.println("Skip: " + source + " (" + e.getMessage() + ")");
+    }
   }
 
 
@@ -189,7 +169,7 @@ public class BlocklyCodeRunner {
    * @param sleepAfterEachLine The time to sleep after each line of code execution, in milliseconds.
    * @throws RuntimeException If an error occurs during execution.
    */
-  public void executeJavaCode(String code, int sleepAfterEachLine) throws RuntimeException, URISyntaxException {
+  public void executeJavaCode(String code, int sleepAfterEachLine) throws Exception {
 
     if (sleepAfterEachLine > 0) code = addSleepCalls(code); // no sleep if time is 0
     codeRunning.set(true);

--- a/blockly/src/coderunner/BlocklyCodeRunner.java
+++ b/blockly/src/coderunner/BlocklyCodeRunner.java
@@ -6,6 +6,7 @@ import java.io.*;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.MalformedURLException;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.*;
@@ -130,15 +131,13 @@ public class BlocklyCodeRunner {
    * @param code Java code that should be executed.
    * @throws RuntimeException If an error occurs during execution.
    */
-  public void executeJavaCode(String code) throws RuntimeException {
+  public void executeJavaCode(String code) throws RuntimeException, URISyntaxException {
     executeJavaCode(code, DEFAULT_SLEEP_AFTER_EACH_LINE);
   }
 
 
   public void prepareCompilerResources(Path tempDir) {
     Path libFolder = tempDir.resolve("unpacked_libs");
-
-    // Nur entpacken, wenn der Ordner noch nicht da ist
 
       try {
         Files.createDirectories(libFolder);
@@ -152,28 +151,27 @@ public class BlocklyCodeRunner {
             Path entryPath = libFolder.resolve(entry.getName());
 
             if (entry.isDirectory()) {
-              // Ordner erstellen, falls er nicht existiert
+              // create folder if it does not exist
               if (!Files.exists(entryPath)) {
                 Files.createDirectories(entryPath);
               }
             } else {
-              // Sicherstellen, dass der Eltern-Ordner existiert
+              // make sure the parent folder exists
               Path parent = entryPath.getParent();
               if (parent != null && !Files.exists(parent)) {
                 Files.createDirectories(parent);
               }
 
-              // Datei entpacken
+              // extract file
               try (InputStream is = zip.getInputStream(entry)) {
-                // Wir prüfen, ob ein Ordner mit dem gleichen Namen den Weg versperrt
+                // check if there is a folder with the same name
                 if (Files.exists(entryPath) && Files.isDirectory(entryPath)) {
-                  // System.out.println("Überspringe: Ordner blockiert Datei " + entry.getName());
                 } else {
                   Files.copy(is, entryPath, StandardCopyOption.REPLACE_EXISTING);
                 }
               } catch (IOException e) {
                 // Case-Sensitivity Konflikte (LICENSE vs license) abfangen
-                 System.out.println("Konnte Datei nicht entpacken: " + entry.getName());
+                 System.out.println("Could not extract files: " + entry.getName());
               }
             }
           } // Ende while
@@ -181,9 +179,6 @@ public class BlocklyCodeRunner {
       } catch (Exception e) {
         e.printStackTrace();
       }
-
-      System.out.println("fertig mit dem entpacken der dateien");
-
   }
 
 
@@ -194,7 +189,7 @@ public class BlocklyCodeRunner {
    * @param sleepAfterEachLine The time to sleep after each line of code execution, in milliseconds.
    * @throws RuntimeException If an error occurs during execution.
    */
-  public void executeJavaCode(String code, int sleepAfterEachLine) throws RuntimeException {
+  public void executeJavaCode(String code, int sleepAfterEachLine) throws RuntimeException, URISyntaxException {
 
     if (sleepAfterEachLine > 0) code = addSleepCalls(code); // no sleep if time is 0
     codeRunning.set(true);
@@ -204,8 +199,8 @@ public class BlocklyCodeRunner {
     Path tempDir = tempFolder();
     Path libFolder = tempDir.resolve("unpacked_libs");
 
-    if (!folderTransfered) {
-      System.out.println("transfering folders once");
+    String path = String.valueOf(getClass().getProtectionDomain().getCodeSource().getLocation().toURI());
+    if (!folderTransfered && path.endsWith(".jar")) {
       prepareCompilerResources(tempDir);
       folderTransfered = true;
     }
@@ -331,7 +326,6 @@ public class BlocklyCodeRunner {
    * @return Path to the temporary folder. If no folder is found or cannot be created, returns null.
    */
   private Path tempFolder() {
-    System.out.println("temp folder under " + System.getProperty("java.io.tmpdir"));
     File tempDir = new File(System.getProperty("java.io.tmpdir"));
     File[] tempFiles = tempDir.listFiles();
     if (tempFiles != null) {

--- a/blockly/src/coderunner/BlocklyCodeRunner.java
+++ b/blockly/src/coderunner/BlocklyCodeRunner.java
@@ -8,9 +8,8 @@ import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
+import java.nio.file.*;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -18,6 +17,8 @@ import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Pattern;
 import javax.tools.JavaCompiler;
+import javax.tools.JavaFileObject;
+import javax.tools.StandardJavaFileManager;
 import javax.tools.ToolProvider;
 import systems.BlocklyCommandExecuteSystem;
 
@@ -37,6 +38,7 @@ public class BlocklyCodeRunner {
 
   private static final DungeonLogger LOGGER = DungeonLogger.getLogger(BlocklyCodeRunner.class);
   private static BlocklyCodeRunner instance;
+
 
   /** List of whitelisted Blockly command method names without the trailing (); or parameters. */
   private static final List<String> WHITELIST =
@@ -106,6 +108,7 @@ public class BlocklyCodeRunner {
   private final AtomicBoolean codeRunning = new AtomicBoolean(false);
   private ExecutorService executor;
   private Future<?> currentExecution;
+  private boolean folderTransfered = false;
 
   private BlocklyCodeRunner() {} // private constructor for singleton
 
@@ -131,6 +134,59 @@ public class BlocklyCodeRunner {
     executeJavaCode(code, DEFAULT_SLEEP_AFTER_EACH_LINE);
   }
 
+
+  public void prepareCompilerResources(Path tempDir) {
+    Path libFolder = tempDir.resolve("unpacked_libs");
+
+    // Nur entpacken, wenn der Ordner noch nicht da ist
+
+      try {
+        Files.createDirectories(libFolder);
+        File jarFile = new File(getClass().getProtectionDomain().getCodeSource().getLocation().toURI());
+
+        try (java.util.zip.ZipFile zip = new java.util.zip.ZipFile(jarFile)) {
+          java.util.Enumeration<? extends java.util.zip.ZipEntry> entries = zip.entries();
+
+          while (entries.hasMoreElements()) {
+            java.util.zip.ZipEntry entry = entries.nextElement();
+            Path entryPath = libFolder.resolve(entry.getName());
+
+            if (entry.isDirectory()) {
+              // Ordner erstellen, falls er nicht existiert
+              if (!Files.exists(entryPath)) {
+                Files.createDirectories(entryPath);
+              }
+            } else {
+              // Sicherstellen, dass der Eltern-Ordner existiert
+              Path parent = entryPath.getParent();
+              if (parent != null && !Files.exists(parent)) {
+                Files.createDirectories(parent);
+              }
+
+              // Datei entpacken
+              try (InputStream is = zip.getInputStream(entry)) {
+                // Wir prüfen, ob ein Ordner mit dem gleichen Namen den Weg versperrt
+                if (Files.exists(entryPath) && Files.isDirectory(entryPath)) {
+                  // System.out.println("Überspringe: Ordner blockiert Datei " + entry.getName());
+                } else {
+                  Files.copy(is, entryPath, StandardCopyOption.REPLACE_EXISTING);
+                }
+              } catch (IOException e) {
+                // Case-Sensitivity Konflikte (LICENSE vs license) abfangen
+                 System.out.println("Konnte Datei nicht entpacken: " + entry.getName());
+              }
+            }
+          } // Ende while
+        } // Ende try-with-resources (zip)
+      } catch (Exception e) {
+        e.printStackTrace();
+      }
+
+      System.out.println("fertig mit dem entpacken der dateien");
+
+  }
+
+
   /**
    * Executes the given Java code.
    *
@@ -139,12 +195,21 @@ public class BlocklyCodeRunner {
    * @throws RuntimeException If an error occurs during execution.
    */
   public void executeJavaCode(String code, int sleepAfterEachLine) throws RuntimeException {
+
     if (sleepAfterEachLine > 0) code = addSleepCalls(code); // no sleep if time is 0
     codeRunning.set(true);
     code = String.format(CodeWrapper, code, sleepAfterEachLine);
 
     // In system temp directory
     Path tempDir = tempFolder();
+    Path libFolder = tempDir.resolve("unpacked_libs");
+
+    if (!folderTransfered) {
+      System.out.println("transfering folders once");
+      prepareCompilerResources(tempDir);
+      folderTransfered = true;
+    }
+
     Path tempFile;
     if (tempDir == null) {
       return;
@@ -159,7 +224,12 @@ public class BlocklyCodeRunner {
     JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
     ByteArrayOutputStream errorStream = new ByteArrayOutputStream();
 
-    int compilationResult = compiler.run(null, null, errorStream, tempFile.toFile().toString());
+    String[] compilerArgs = {
+      "-classpath", libFolder.toAbsolutePath().toString(),
+      tempFile.toFile().toString()
+    };
+
+    int compilationResult = compiler.run(null, null, errorStream, compilerArgs);
 
     if (compilationResult != 0) {
       String errors = errorStream.toString();
@@ -183,25 +253,25 @@ public class BlocklyCodeRunner {
 
     executor = Executors.newSingleThreadExecutor();
     currentExecution =
-        executor.submit(
-            () -> {
-              try {
-                method.invoke(null, new BlocklyCommands());
-                // Code executed successfully
-                codeRunning.set(false);
-              } catch (InvocationTargetException | IllegalAccessException e) {
-                codeRunning.set(false);
-                if (e.getCause() instanceof InterruptedException) {
-                  return; // ignore interruption exception
-                }
+      executor.submit(
+        () -> {
+          try {
+            method.invoke(null, new BlocklyCommands());
+            // Code executed successfully
+            codeRunning.set(false);
+          } catch (InvocationTargetException | IllegalAccessException e) {
+            codeRunning.set(false);
+            if (e.getCause() instanceof InterruptedException) {
+              return; // ignore interruption exception
+            }
 
-                String causeMessage =
-                    e.getCause() != null ? e.getCause().getMessage() : e.getMessage();
-                causeMessage = causeMessage != null ? causeMessage : e.toString();
-                LOGGER.warn(String.format("Error executing code: %s", causeMessage), e);
-                throw new RuntimeException("Execution error: " + causeMessage);
-              }
-            });
+            String causeMessage =
+              e.getCause() != null ? e.getCause().getMessage() : e.getMessage();
+            causeMessage = causeMessage != null ? causeMessage : e.toString();
+            LOGGER.warn(String.format("Error executing code: %s", causeMessage), e);
+            throw new RuntimeException("Execution error: " + causeMessage);
+          }
+        });
   }
 
   /**
@@ -261,6 +331,7 @@ public class BlocklyCodeRunner {
    * @return Path to the temporary folder. If no folder is found or cannot be created, returns null.
    */
   private Path tempFolder() {
+    System.out.println("temp folder under " + System.getProperty("java.io.tmpdir"));
     File tempDir = new File(System.getProperty("java.io.tmpdir"));
     File[] tempFiles = tempDir.listFiles();
     if (tempFiles != null) {

--- a/blockly/src/coderunner/BlocklyCodeRunner.java
+++ b/blockly/src/coderunner/BlocklyCodeRunner.java
@@ -178,7 +178,6 @@ public class BlocklyCodeRunner {
 
     String path = String.valueOf(getClass().getProtectionDomain().getCodeSource().getLocation().toURI());
     if (!folderTransfered && path.endsWith(".jar")) {
-      System.out.println("transferring folders");
       prepareCompilerResources(tempDir);
       folderTransfered = true;
     }

--- a/blockly/src/coderunner/BlocklyCodeRunner.java
+++ b/blockly/src/coderunner/BlocklyCodeRunner.java
@@ -181,6 +181,7 @@ public class BlocklyCodeRunner {
 
     String path = String.valueOf(getClass().getProtectionDomain().getCodeSource().getLocation().toURI());
     if (!folderTransfered && path.endsWith(".jar")) {
+      System.out.println("transferring folders");
       prepareCompilerResources(tempDir);
       folderTransfered = true;
     }
@@ -199,12 +200,16 @@ public class BlocklyCodeRunner {
     JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
     ByteArrayOutputStream errorStream = new ByteArrayOutputStream();
 
-    String[] compilerArgs = {
-      "-classpath", libFolder.toAbsolutePath().toString(),
-      tempFile.toFile().toString()
-    };
-
-    int compilationResult = compiler.run(null, null, errorStream, compilerArgs);
+    int compilationResult;
+    if (path.endsWith(".jar")) {
+      String[] compilerArgs = {
+        "-classpath", libFolder.toAbsolutePath().toString(),
+        tempFile.toFile().toString()
+      };
+      compilationResult = compiler.run(null, null, errorStream, compilerArgs);
+    } else {
+      compilationResult = compiler.run(null, null, errorStream, tempFile.toFile().toString());
+    }
 
     if (compilationResult != 0) {
       String errors = errorStream.toString();
@@ -311,6 +316,7 @@ public class BlocklyCodeRunner {
     if (tempFiles != null) {
       for (File file : tempFiles) {
         if (file.isDirectory() && file.getName().equals(TEMP_FOLDER_NAME)) {
+          System.out.println(file.getAbsolutePath());
           return file.toPath();
         }
       }

--- a/blockly/src/coderunner/BlocklyCodeRunner.java
+++ b/blockly/src/coderunner/BlocklyCodeRunner.java
@@ -7,7 +7,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.*;
 import java.nio.file.*;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
@@ -16,8 +15,6 @@ import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Pattern;
 import javax.tools.JavaCompiler;
-import javax.tools.JavaFileObject;
-import javax.tools.StandardJavaFileManager;
 import javax.tools.ToolProvider;
 import systems.BlocklyCommandExecuteSystem;
 
@@ -37,7 +34,6 @@ public class BlocklyCodeRunner {
 
   private static final DungeonLogger LOGGER = DungeonLogger.getLogger(BlocklyCodeRunner.class);
   private static BlocklyCodeRunner instance;
-
 
   /** List of whitelisted Blockly command method names without the trailing (); or parameters. */
   private static final List<String> WHITELIST =
@@ -133,7 +129,6 @@ public class BlocklyCodeRunner {
     executeJavaCode(code, DEFAULT_SLEEP_AFTER_EACH_LINE);
   }
 
-
   private void prepareCompilerResources(Path tempDir) throws Exception {
     // create directory
     Path libFolder = Files.createDirectories(tempDir.resolve("unpacked_libs"));
@@ -144,8 +139,8 @@ public class BlocklyCodeRunner {
 
       // go through the jar and process each file
       Files.walk(root)
-        .filter(Files::isRegularFile) // only files
-        .forEach(source -> copyToTemp(source, root, libFolder));
+          .filter(Files::isRegularFile) // only files
+          .forEach(source -> copyToTemp(source, root, libFolder));
     }
   }
 
@@ -160,6 +155,7 @@ public class BlocklyCodeRunner {
       System.err.println("Skip: " + source + " (" + e.getMessage() + ")");
     }
   }
+
   /**
    * Executes the given Java code.
    *
@@ -176,7 +172,8 @@ public class BlocklyCodeRunner {
     Path tempDir = tempFolder();
     Path libFolder = tempDir.resolve("unpacked_libs");
 
-    String path = String.valueOf(getClass().getProtectionDomain().getCodeSource().getLocation().toURI());
+    String path =
+        String.valueOf(getClass().getProtectionDomain().getCodeSource().getLocation().toURI());
     if (!folderTransfered && path.endsWith(".jar")) {
       prepareCompilerResources(tempDir);
       folderTransfered = true;
@@ -199,8 +196,7 @@ public class BlocklyCodeRunner {
     int compilationResult;
     if (path.endsWith(".jar")) {
       String[] compilerArgs = {
-        "-classpath", libFolder.toAbsolutePath().toString(),
-        tempFile.toFile().toString()
+        "-classpath", libFolder.toAbsolutePath().toString(), tempFile.toFile().toString()
       };
       compilationResult = compiler.run(null, null, errorStream, compilerArgs);
     } else {
@@ -229,25 +225,25 @@ public class BlocklyCodeRunner {
 
     executor = Executors.newSingleThreadExecutor();
     currentExecution =
-      executor.submit(
-        () -> {
-          try {
-            method.invoke(null, new BlocklyCommands());
-            // Code executed successfully
-            codeRunning.set(false);
-          } catch (InvocationTargetException | IllegalAccessException e) {
-            codeRunning.set(false);
-            if (e.getCause() instanceof InterruptedException) {
-              return; // ignore interruption exception
-            }
+        executor.submit(
+            () -> {
+              try {
+                method.invoke(null, new BlocklyCommands());
+                // Code executed successfully
+                codeRunning.set(false);
+              } catch (InvocationTargetException | IllegalAccessException e) {
+                codeRunning.set(false);
+                if (e.getCause() instanceof InterruptedException) {
+                  return; // ignore interruption exception
+                }
 
-            String causeMessage =
-              e.getCause() != null ? e.getCause().getMessage() : e.getMessage();
-            causeMessage = causeMessage != null ? causeMessage : e.toString();
-            LOGGER.warn(String.format("Error executing code: %s", causeMessage), e);
-            throw new RuntimeException("Execution error: " + causeMessage);
-          }
-        });
+                String causeMessage =
+                    e.getCause() != null ? e.getCause().getMessage() : e.getMessage();
+                causeMessage = causeMessage != null ? causeMessage : e.toString();
+                LOGGER.warn(String.format("Error executing code: %s", causeMessage), e);
+                throw new RuntimeException("Execution error: " + causeMessage);
+              }
+            });
   }
 
   /**

--- a/blockly/src/coderunner/BlocklyCodeRunner.java
+++ b/blockly/src/coderunner/BlocklyCodeRunner.java
@@ -160,8 +160,6 @@ public class BlocklyCodeRunner {
       System.err.println("Skip: " + source + " (" + e.getMessage() + ")");
     }
   }
-
-
   /**
    * Executes the given Java code.
    *
@@ -170,7 +168,6 @@ public class BlocklyCodeRunner {
    * @throws RuntimeException If an error occurs during execution.
    */
   public void executeJavaCode(String code, int sleepAfterEachLine) throws Exception {
-
     if (sleepAfterEachLine > 0) code = addSleepCalls(code); // no sleep if time is 0
     codeRunning.set(true);
     code = String.format(CodeWrapper, code, sleepAfterEachLine);
@@ -316,7 +313,6 @@ public class BlocklyCodeRunner {
     if (tempFiles != null) {
       for (File file : tempFiles) {
         if (file.isDirectory() && file.getName().equals(TEMP_FOLDER_NAME)) {
-          System.out.println(file.getAbsolutePath());
           return file.toPath();
         }
       }

--- a/blockly/src/coderunner/BlocklyCodeRunner.java
+++ b/blockly/src/coderunner/BlocklyCodeRunner.java
@@ -1,5 +1,6 @@
 package coderunner;
 
+import client.FolderExtractor;
 import core.Game;
 import core.utils.logging.DungeonLogger;
 import java.io.*;
@@ -8,7 +9,6 @@ import java.lang.reflect.Method;
 import java.net.*;
 import java.nio.file.*;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -55,12 +55,6 @@ public class BlocklyCodeRunner {
           "loadLevel",
           "loadNextLevel");
 
-  /**
-   * The name of the temporary folder where the compiled code will be stored. This folder is created
-   * in the system's temporary directory. (default: "blockly")
-   */
-  public static String TEMP_FOLDER_NAME = "blockly";
-
   private static final int DEFAULT_SLEEP_AFTER_EACH_LINE = 0; // milliseconds
 
   private static final String CodeWrapper =
@@ -103,7 +97,6 @@ public class BlocklyCodeRunner {
   private final AtomicBoolean codeRunning = new AtomicBoolean(false);
   private ExecutorService executor;
   private Future<?> currentExecution;
-  private boolean folderTransfered = false;
 
   private BlocklyCodeRunner() {} // private constructor for singleton
 
@@ -129,33 +122,6 @@ public class BlocklyCodeRunner {
     executeJavaCode(code, DEFAULT_SLEEP_AFTER_EACH_LINE);
   }
 
-  private void prepareCompilerResources(Path tempDir) throws Exception {
-    // create directory
-    Path libFolder = Files.createDirectories(tempDir.resolve("unpacked_libs"));
-    URI jarUri = getClass().getProtectionDomain().getCodeSource().getLocation().toURI();
-
-    try (FileSystem zipFs = FileSystems.newFileSystem(URI.create("jar:" + jarUri), Map.of())) {
-      Path root = zipFs.getPath("/");
-
-      // go through the jar and process each file
-      Files.walk(root)
-          .filter(Files::isRegularFile) // only files
-          .forEach(source -> copyToTemp(source, root, libFolder));
-    }
-  }
-
-  private void copyToTemp(Path source, Path root, Path targetDir) {
-    try {
-      // path relativ to jar file
-      Path target = targetDir.resolve(root.relativize(source).toString());
-
-      Files.createDirectories(target.getParent());
-      Files.copy(source, target, StandardCopyOption.REPLACE_EXISTING);
-    } catch (IOException e) {
-      System.err.println("Skip: " + source + " (" + e.getMessage() + ")");
-    }
-  }
-
   /**
    * Executes the given Java code.
    *
@@ -169,15 +135,11 @@ public class BlocklyCodeRunner {
     code = String.format(CodeWrapper, code, sleepAfterEachLine);
 
     // In system temp directory
-    Path tempDir = tempFolder();
+    Path tempDir = FolderExtractor.tempFolder();
     Path libFolder = tempDir.resolve("unpacked_libs");
 
     String path =
         String.valueOf(getClass().getProtectionDomain().getCodeSource().getLocation().toURI());
-    if (!folderTransfered && path.endsWith(".jar")) {
-      prepareCompilerResources(tempDir);
-      folderTransfered = true;
-    }
 
     Path tempFile;
     if (tempDir == null) {
@@ -194,7 +156,10 @@ public class BlocklyCodeRunner {
     ByteArrayOutputStream errorStream = new ByteArrayOutputStream();
 
     int compilationResult;
-    if (path.endsWith(".jar")) {
+
+    String operatingSystem = java.lang.System.getProperty("os.name");
+
+    if (path.endsWith(".jar") && operatingSystem.contains("Windows")) {
       String[] compilerArgs = {
         "-classpath", libFolder.toAbsolutePath().toString(), tempFile.toFile().toString()
       };
@@ -292,34 +257,5 @@ public class BlocklyCodeRunner {
       code = code.replaceAll(regex, "$0 sleep();");
     }
     return code;
-  }
-
-  /**
-   * Returns the path to the BlocklyCodeRunner's temporary folder.
-   *
-   * <p>If no temporary folder is found it will generate a new one in the system's temporary
-   * directory.
-   *
-   * @return Path to the temporary folder. If no folder is found or cannot be created, returns null.
-   */
-  private Path tempFolder() {
-    File tempDir = new File(System.getProperty("java.io.tmpdir"));
-    File[] tempFiles = tempDir.listFiles();
-    if (tempFiles != null) {
-      for (File file : tempFiles) {
-        if (file.isDirectory() && file.getName().equals(TEMP_FOLDER_NAME)) {
-          return file.toPath();
-        }
-      }
-    }
-
-    // If no temp folder found, create a new one
-    try {
-      tempDir = Files.createDirectory(Paths.get(tempDir.getPath(), TEMP_FOLDER_NAME)).toFile();
-    } catch (IOException e) {
-      LOGGER.error("Error creating temp folder: " + e.getMessage());
-      return null;
-    }
-    return tempDir.toPath();
   }
 }

--- a/blockly/src/server/Server.java
+++ b/blockly/src/server/Server.java
@@ -211,7 +211,6 @@ public class Server {
    * @throws IOException If an error occurs while sending the response
    */
   private void handleCodeRequest(HttpExchange exchange) throws IOException {
-    System.out.println("test");
     // Check if this is a stop request
     String query = exchange.getRequestURI().getQuery();
     boolean isStopRequest = query != null && query.contains("stop=1");
@@ -228,13 +227,13 @@ public class Server {
         }
       }
     }
-////
+
     if (isStopRequest) {
       handleStopCodeExecution(exchange);
       return;
     }
-////
-//    // Handle normal code execution request
+
+    // Handle normal code execution request
     if (BlocklyCodeRunner.instance().isCodeRunning()) {
       String response = "Another code execution is already running. Please stop it first.";
       exchange.getResponseHeaders().add("Access-Control-Allow-Origin", "*");
@@ -252,7 +251,6 @@ public class Server {
     interruptExecution = false;
     try {
       if (sleepAfterEachLine >= 0) {
-        // hier wird die datei erzeugt
         BlocklyCodeRunner.instance().executeJavaCode(text, sleepAfterEachLine);
       } else {
         BlocklyCodeRunner.instance().executeJavaCode(text);
@@ -267,7 +265,7 @@ public class Server {
 
       String response;
       int statusCode;
-//
+
       if (interruptExecution) {
         response = errorMsg.isEmpty() ? "Code execution interrupted" : "Error: " + errorMsg;
         statusCode = 400;
@@ -288,15 +286,15 @@ public class Server {
       os.write(response.getBytes());
       os.close();
     } catch (Exception e) {
-//      LOGGER.error("Error executing code: " + e);
-//      setError(e.getMessage());
-//      String response = errorMsg;
-//      exchange.getResponseHeaders().add("Access-Control-Allow-Origin", "*");
-//      exchange.sendResponseHeaders(400, response.getBytes().length);
-//      OutputStream os = exchange.getResponseBody();
-//      os.write(response.getBytes());
-//      os.close();
-//      BlocklyCodeRunner.instance().stopCode();
+      LOGGER.error("Error executing code: " + e);
+      setError(e.getMessage());
+      String response = errorMsg;
+      exchange.getResponseHeaders().add("Access-Control-Allow-Origin", "*");
+      exchange.sendResponseHeaders(400, response.getBytes().length);
+      OutputStream os = exchange.getResponseBody();
+      os.write(response.getBytes());
+      os.close();
+      BlocklyCodeRunner.instance().stopCode();
     }
   }
 

--- a/blockly/src/server/Server.java
+++ b/blockly/src/server/Server.java
@@ -211,6 +211,7 @@ public class Server {
    * @throws IOException If an error occurs while sending the response
    */
   private void handleCodeRequest(HttpExchange exchange) throws IOException {
+    System.out.println("test");
     // Check if this is a stop request
     String query = exchange.getRequestURI().getQuery();
     boolean isStopRequest = query != null && query.contains("stop=1");
@@ -227,13 +228,13 @@ public class Server {
         }
       }
     }
-
+////
     if (isStopRequest) {
       handleStopCodeExecution(exchange);
       return;
     }
-
-    // Handle normal code execution request
+////
+//    // Handle normal code execution request
     if (BlocklyCodeRunner.instance().isCodeRunning()) {
       String response = "Another code execution is already running. Please stop it first.";
       exchange.getResponseHeaders().add("Access-Control-Allow-Origin", "*");
@@ -251,6 +252,7 @@ public class Server {
     interruptExecution = false;
     try {
       if (sleepAfterEachLine >= 0) {
+        // hier wird die datei erzeugt
         BlocklyCodeRunner.instance().executeJavaCode(text, sleepAfterEachLine);
       } else {
         BlocklyCodeRunner.instance().executeJavaCode(text);
@@ -265,7 +267,7 @@ public class Server {
 
       String response;
       int statusCode;
-
+//
       if (interruptExecution) {
         response = errorMsg.isEmpty() ? "Code execution interrupted" : "Error: " + errorMsg;
         statusCode = 400;
@@ -286,15 +288,15 @@ public class Server {
       os.write(response.getBytes());
       os.close();
     } catch (Exception e) {
-      LOGGER.error("Error executing code: " + e);
-      setError(e.getMessage());
-      String response = errorMsg;
-      exchange.getResponseHeaders().add("Access-Control-Allow-Origin", "*");
-      exchange.sendResponseHeaders(400, response.getBytes().length);
-      OutputStream os = exchange.getResponseBody();
-      os.write(response.getBytes());
-      os.close();
-      BlocklyCodeRunner.instance().stopCode();
+//      LOGGER.error("Error executing code: " + e);
+//      setError(e.getMessage());
+//      String response = errorMsg;
+//      exchange.getResponseHeaders().add("Access-Control-Allow-Origin", "*");
+//      exchange.sendResponseHeaders(400, response.getBytes().length);
+//      OutputStream os = exchange.getResponseBody();
+//      os.write(response.getBytes());
+//      os.close();
+//      BlocklyCodeRunner.instance().stopCode();
     }
   }
 


### PR DESCRIPTION
closes #2830

Dieser Pull Request soll das Problem mit den temporären Ordnern lösen. Dafür wird beim Start der Jar extra ein eigenständiger Ordner erstellt, auf den der Compiler zugreift, um den Blockly Code zu übersetzten. Der Ordner wird direkt beim Aufruf erstellt und auch nur unter dem Betriebssystem Windows. Nach dem Schließen des Blockly Fensters wird der Ordner automatisch wieder entfernt. 

Ich habe für die Funktion die Klasse FolderExtractor angelegt. Ich bin mir unsicher ob das der richtige Name dafür ist und ob ich die Klasse im richtigen Package abgelegt habe. 