### PR TITLE
Tooling: Add vs code extension

### DIFF
--- a/.github/workflows/buildjar.yml
+++ b/.github/workflows/buildjar.yml
@@ -67,7 +67,7 @@ jobs:
             contents: write
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v3
+              uses: actions/checkout@v6
               with:
                   fetch-depth: 0
 


### PR DESCRIPTION
Fügt die VS Code Extension zu dem Release hinzu.

closes #2912
