### PR TITLE
Dungeon: Fix error when starting a jar with spaces in the filename

### DIFF
--- a/dungeon/src/contrib/crafting/Crafting.java
+++ b/dungeon/src/contrib/crafting/Crafting.java
@@ -93,12 +93,14 @@ public final class Crafting {
   private static void loadFromJar() {
     try {
       String path =
-          new File(Objects.requireNonNull(Game.class.getResource("")).getPath())
-              .getParent()
-              // for windows
-              .replaceAll("(!|file:\\\\)", "")
-              // for unix/macos
-              .replaceAll("(!|file:)", "");
+        new File(Objects.requireNonNull(Game.class.getResource("")).getPath())
+          .getParent()
+          // Erst die Protokolle entfernen
+          .replaceAll("(!|file:\\\\)", "")
+          .replaceAll("(!|file:)", "")
+          // JETZT die URL-Kodierung für Leerzeichen fixen
+          .replace("%20", " ");
+
       JarFile jar = new JarFile(path);
       Enumeration<JarEntry> entries = jar.entries();
       while (entries.hasMoreElements()) {

--- a/dungeon/src/contrib/crafting/Crafting.java
+++ b/dungeon/src/contrib/crafting/Crafting.java
@@ -93,13 +93,13 @@ public final class Crafting {
   private static void loadFromJar() {
     try {
       String path =
-        new File(Objects.requireNonNull(Game.class.getResource("")).getPath())
-          .getParent()
-          // replace protocols
-          .replaceAll("(!|file:\\\\)", "")
-          .replaceAll("(!|file:)", "")
-          // replace the url whitespaces with real whitespaces
-          .replace("%20", " ");
+          new File(Objects.requireNonNull(Game.class.getResource("")).getPath())
+              .getParent()
+              // replace protocols
+              .replaceAll("(!|file:\\\\)", "")
+              .replaceAll("(!|file:)", "")
+              // replace the url whitespaces with real whitespaces
+              .replace("%20", " ");
 
       JarFile jar = new JarFile(path);
       Enumeration<JarEntry> entries = jar.entries();

--- a/dungeon/src/contrib/crafting/Crafting.java
+++ b/dungeon/src/contrib/crafting/Crafting.java
@@ -95,10 +95,10 @@ public final class Crafting {
       String path =
         new File(Objects.requireNonNull(Game.class.getResource("")).getPath())
           .getParent()
-          // Erst die Protokolle entfernen
+          // replace protocols
           .replaceAll("(!|file:\\\\)", "")
           .replaceAll("(!|file:)", "")
-          // JETZT die URL-Kodierung für Leerzeichen fixen
+          // replace the url whitespaces with real whitespaces
           .replace("%20", " ");
 
       JarFile jar = new JarFile(path);

--- a/dungeon/src/contrib/crafting/Crafting.java
+++ b/dungeon/src/contrib/crafting/Crafting.java
@@ -95,8 +95,9 @@ public final class Crafting {
       String path =
           new File(Objects.requireNonNull(Game.class.getResource("")).getPath())
               .getParent()
-              // replace protocols
+              // replace protocols for windows
               .replaceAll("(!|file:\\\\)", "")
+              // replace protocols for unix/macos
               .replaceAll("(!|file:)", "")
               // replace the url whitespaces with real whitespaces
               .replace("%20", " ");


### PR DESCRIPTION
Bisher gab es immer einen Fehler, wenn man eine Jar gestartet hat, die ein Leerzeichen im Pfad hatte. Das Problem war, dass dieser Pfad intern in eine URL übersetzt worden ist und Leerzeichen dann mit %20 angezeigt worden sind. Das habe ich jz herausgefiltert und mit einem richtigen Leerzeichen ersetzt. 

closes #2921 