### PR TITLE
Dungeon: Handle stale queued input without server crash

### DIFF
--- a/dungeon/src/contrib/entities/HeroController.java
+++ b/dungeon/src/contrib/entities/HeroController.java
@@ -696,12 +696,19 @@ public class HeroController {
       var hudSys = Game.systems().get(HudSystem.class);
       boolean paused =
           hudSys instanceof HudSystem hudSystem && hudSystem.hasOpenPausingUI(playerEntity);
+      if (!clientState.advanceProcessedSeq(msg.sequence())) {
+        LOGGER.debug(
+            "Ignoring stale or duplicate input sequence {} for client {}",
+            msg.sequence(),
+            clientState);
+        clientState.updateLastActivity();
+        continue;
+      }
       try {
         applyInput(clientState, msg, playerEntity, paused);
       } catch (Exception e) {
         LOGGER.warn("Failed to apply input for client {}: {}", clientState, e.getMessage(), e);
       }
-      clientState.updateProcessedSeq(msg.sequence());
       clientState.updateLastActivity();
     }
   }

--- a/dungeon/src/core/network/server/ClientState.java
+++ b/dungeon/src/core/network/server/ClientState.java
@@ -150,20 +150,22 @@ public class ClientState {
   }
 
   /**
-   * Updates the last processed sequence after successfully applying an input. Ensures monotonic
-   * progress; throws if seq is not the expected next.
+   * Advances the processed input sequence if the provided sequence is newer than the current one.
    *
-   * @param seq The sequence number that was just processed (must be > lastProcessedSeq).
-   * @throws IllegalArgumentException If seq <= lastProcessedSeq (stale or duplicate).
+   * <p>Stale or duplicate inputs are expected under real network conditions, so they are reported
+   * via the return value instead of an exception.
+   *
+   * @param seq The sequence number that was just dequeued for processing.
+   * @return true when the sequence was accepted, false when it was stale or duplicated.
    */
-  public synchronized void updateProcessedSeq(int seq) {
+  public synchronized boolean advanceProcessedSeq(int seq) {
     if (seq <= this.lastProcessedSeq) {
-      throw new IllegalArgumentException(
-          "Cannot update to stale or duplicate seq: " + seq + " <= " + lastProcessedSeq);
+      return false;
     }
     this.lastProcessedSeq = seq;
     this.expectedSeq = seq + 1;
     this.lastActivityTimeMs = System.currentTimeMillis();
+    return true;
   }
 
   /**


### PR DESCRIPTION
Stale oder doppelte Eingaben konnten den Server trotz Vorvalidierung zum Absturz bringen, weil die Sequenz erst beim Dequeue erneut geprüft und dort per Exception behandelt wurde. Die Sequenzprüfung ist jetzt idempotent und behandelt veraltete Inputs als erwarteten Netzwerkfall.
* ClientState:
	* `advanceProcessedSeq(...)` gibt jetzt ein boolean zurück statt bei stale/duplicate Sequenzen eine `IllegalArgumentException` zu werfen.
* Monotone Sequenzfortschreibung bleibt erhalten, veraltete oder doppelte Inputs werden explizit verworfen.
* HeroController:
	* Prüft die Eingabesequenz direkt beim Drain der Queue vor der eigentlichen Verarbeitung.
* Stale oder doppelte Nachrichten werden geloggt und übersprungen, statt den Server-Loop zu unterbrechen.
	* Akzeptierte Sequenzen werden weiterhin auch dann verbraucht, wenn die eigentliche Command-Ausführung fehlschlägt.
