### PR TITLE
documentation: link to java installer on oracle.com

### DIFF
--- a/.github/workflows/releaseInstructions.md
+++ b/.github/workflows/releaseInstructions.md
@@ -15,7 +15,7 @@ First, you need to decide whether you want to play the web version with a block-
 
 ### Web Version
 
-* Install [Java 21](https://jdk.java.net/21/) on your system
+* Install [Java 21](https://www.oracle.com/de/java/technologies/downloads/#java21) on your system
 * Download the `Blockly-web.jar` file below
 * Start the dungeon by double-clicking the JAR file
     * or run `java -jar Blockly-web.jar` in your terminal
@@ -25,7 +25,7 @@ First, you need to decide whether you want to play the web version with a block-
 
 ### Desktop Version
 
-* Install [Java 21](https://jdk.java.net/21/) on your system
+* Install [Java 21](https://www.oracle.com/de/java/technologies/downloads/#java21) on your system
 * Download the `Blockly-desktop.jar` file below
 * Start the dungeon by double-clicking the JAR file
     * or run `java -jar Blockly-desktop.jar` in your terminal

--- a/doc/produs_unterlagen/readme.md
+++ b/doc/produs_unterlagen/readme.md
@@ -38,7 +38,7 @@ You only need **Java 21** on your computer. Nothing else.
 
 **Installing Java 21:**
 
-- **Windows / Mac / Linux:** Download Java 21 from [https://jdk.java.net/21/](https://jdk.java.net/21/). Choose the version matching your operating system (Windows, macOS or Linux). Extract the archive and add the `bin` folder to your system's `PATH` variable - or alternatively use an installer like [Adoptium Temurin 21](https://adoptium.net/temurin/releases/?version=21), which handles this automatically.
+- **Windows / Mac / Linux:** Download Java 21 from [https://www.oracle.com/de/java/technologies/downloads/#java21). Choose the version matching your operating system (Windows, macOS or Linux) and install it. Restart your device. 
 
 **Tip:** To verify that Java is installed correctly, open a terminal (Windows: `cmd` or PowerShell; Mac/Linux: Terminal) and type:
 

--- a/doc/produs_unterlagen/readme_de.md
+++ b/doc/produs_unterlagen/readme_de.md
@@ -38,7 +38,7 @@ Man braucht nur **Java 21** auf dem Computer. Sonst nichts.
 
 **Java 21 installieren:**
 
-- **Windows / Mac / Linux:** Lade Java 21 von [https://jdk.java.net/21/](https://jdk.java.net/21/) herunter. Wähle dort die passende Version für dein Betriebssystem (Windows, macOS oder Linux). Entpacke das Archiv und füge den `bin`-Ordner zur Systemvariable `PATH` hinzu - oder verwende alternativ einen Installer wie [Adoptium Temurin 21](https://adoptium.net/temurin/releases/?version=21), der das automatisch erledigt.
+- **Windows / Mac / Linux:** Lade Java 21 von [https://www.oracle.com/de/java/technologies/downloads/#java21) herunter. Wähle dort die passende Version für dein Betriebssystem (Windows, macOS oder Linux) und installiere es. Starte dein Gerät neu.
 
 **Tipp:** Um zu prüfen, ob Java korrekt installiert ist, öffne ein Terminal (Windows: `cmd` oder PowerShell; Mac/Linux: Terminal) und tippe:
 


### PR DESCRIPTION
In den Userzentrierten Dokumenten habe ich den Donwload Link zu den Java Bins durch Links zu dem Installer auf Oracle ersetzt. Jetzt muss auch niemand den PATH selber setzen. 

