### PR TITLE
Blockly: Start-Block in der Auswahl ergänzen

### DIFF
--- a/blockly/frontend/src/index.ts
+++ b/blockly/frontend/src/index.ts
@@ -187,7 +187,6 @@ workspace.addChangeListener(async (e: Blockly.Events.Abstract) => {
 
   // check that the two blocks are not the same
   if (newBlock && startBlock.id !== newBlock.id) {
-
     // get the connection tot the next blocks
     const nextConn = startBlock.nextConnection;
 
@@ -198,7 +197,6 @@ workspace.addChangeListener(async (e: Blockly.Events.Abstract) => {
       // disconnect() sorgt dafür, dass die Kinder im Workspace liegen bleiben
       nextConn.disconnect();
     }
-
     // deletes the start block
     startBlock.dispose(false);
   }

--- a/blockly/frontend/src/index.ts
+++ b/blockly/frontend/src/index.ts
@@ -183,10 +183,24 @@ workspace.addChangeListener(async (e: Blockly.Events.Abstract) => {
     extraStartBlocks.forEach(block => block?.dispose());
     return;
   }
+  const newBlock = newStartBlocks[0];
 
-  if (extraStartBlocks.length === 1) { // delete the old start block, so we can restore the new one
-    workspace.removeBlockById(startBlock.id);
-    startBlock.dispose();
+  // check that the two blocks are not the same
+  if (newBlock && startBlock.id !== newBlock.id) {
+
+    // get the connection tot the next blocks
+    const nextConn = startBlock.nextConnection;
+
+    // if there is a connection to other blocks, then disconnect it
+    // this is important because the start block should be deleted but
+    // the other blocks that are attached to them should not be deleted
+    if (nextConn && nextConn.isConnected()) {
+      // disconnect() sorgt dafür, dass die Kinder im Workspace liegen bleiben
+      nextConn.disconnect();
+    }
+
+    // deletes the start block
+    startBlock.dispose(false);
   }
 });
 

--- a/blockly/frontend/src/index.ts
+++ b/blockly/frontend/src/index.ts
@@ -194,7 +194,6 @@ workspace.addChangeListener(async (e: Blockly.Events.Abstract) => {
     // this is important because the start block should be deleted but
     // the other blocks that are attached to them should not be deleted
     if (nextConn && nextConn.isConnected()) {
-      // disconnect() sorgt dafür, dass die Kinder im Workspace liegen bleiben
       nextConn.disconnect();
     }
     // deletes the start block

--- a/blockly/frontend/src/toolbox.ts
+++ b/blockly/frontend/src/toolbox.ts
@@ -5,9 +5,22 @@ export const toolbox: Blockly.utils.toolbox.ToolboxDefinition = {
   contents: [
     {
       kind: "category",
+      name: "Start",
+      colour: "160",
+      contents: [
+        {
+          kind: "block",
+          type: "start",
+        },
+      ]
+    },
+
+    {
+      kind: "category",
       name: "Bewegung",
       colour: "180",
       contents: [
+
         {
           kind: "block",
           type: "move",

--- a/blockly/frontend/src/toolbox.ts
+++ b/blockly/frontend/src/toolbox.ts
@@ -14,13 +14,11 @@ export const toolbox: Blockly.utils.toolbox.ToolboxDefinition = {
         },
       ]
     },
-
     {
       kind: "category",
       name: "Bewegung",
       colour: "180",
       contents: [
-
         {
           kind: "block",
           type: "move",


### PR DESCRIPTION
Erlaubt es einen neuen Startblock zu erstellen. Der alte Startblock wird entfernt und die Blöcke, die vorher mit diesem Startblock verbunden waren, bleiben erhalten. 
Für den Startblock wurde eine neue Kategorie in der Toolbox erstellt. In dieser Kategorie befindet sich nur der Startblock. Vielleicht kann man den Startblock noch in einer anderen Kategorie unterbringen? 

closes #2974
