### PR TITLE
Blockly: Fix hero velocity readout in onTick

### DIFF
--- a/blockly/src/client/Client.java
+++ b/blockly/src/client/Client.java
@@ -244,6 +244,9 @@ public class Client {
     Game.add(new SpikeSystem());
     Game.add(new IdleSoundSystem());
     Game.add(new PathSystem());
+    // remove LevelTickSystem before adding to force it to run after the VelocitySystem and before
+    // the BlocklyCommandExecuteSystem.
+    Game.remove(LevelTickSystem.class);
     Game.add(new LevelTickSystem());
     Game.add(new LeverSystem());
     Game.add(new BlockSystem());


### PR DESCRIPTION
closes #2952

In der onTick-Methode eines Levels wurde die currentVelocity des Heros immer als Null-Vektor zurückgegeben. Dies wurde durch die Reihenfolge in welcher die folgenden Systeme ausgeführt werden verursacht:
- **LevelTickSystem:** Führt onTick-Methode des Levels aus (wird als Essential System hinzugefügt, somit zu Anfang)
- **VelocitySystem:** Berechnet die currentVelocity
- **BlocklyCommandExecuteSystem:** Führt die Blockly-Blöcke aus, setzt am Ende die Velocity auf 0

Dadurch, dass **LevelTickSystem** als erstes läuft, danach **VelocitySystem** und zum Schluss **BlocklyCommandExecuteSystem**, wird in der onTick-Methode nur die zurückgesetzte Velocity des letzten Durchgangs ausgegeben.

Dies wurde Behoben, indem die Reihenfolge so angepasst wurde, dass das **LevelTickSystem** nach dem **VelocitySystem**, aber vor dem **BlocklyCommandExecuteSystem** lauft.

Alle Blockly Level funktionieren wie gewohnt und in Level 20 kann der Boss den Hero wieder fangen.