### PR TITLE
Tooling: Bump Java version to 25

### DIFF
--- a/.github/workflows/buildjar.yml
+++ b/.github/workflows/buildjar.yml
@@ -27,10 +27,10 @@ jobs:
                   npm run build
 
             # 3. Java Setup
-            - name: Set up JDK 21
+            - name: Set up JDK 25
               uses: actions/setup-java@v5
               with:
-                  java-version: '21'
+                  java-version: '25'
                   distribution: 'temurin'
                   cache: 'gradle'
 
@@ -91,4 +91,3 @@ jobs:
                   --prerelease=false
               env:
                 GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-

--- a/.github/workflows/github_ci.yml
+++ b/.github/workflows/github_ci.yml
@@ -14,10 +14,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@v5
         with:
-          java-version: '21'
+          java-version: '25'
           distribution: 'temurin'
       - name: Build with Gradle
         run: ./gradlew assemble
@@ -31,10 +31,10 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@v5
         with:
-          java-version: '21'
+          java-version: '25'
           distribution: 'temurin'
       - name: Run Gradle License Report
         run: ./gradlew generateLicenseReport
@@ -84,10 +84,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@v5
         with:
-          java-version: '21'
+          java-version: '25'
           distribution: 'temurin'
       - name: JUnit
         run: ./gradlew test
@@ -99,10 +99,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@v5
         with:
-          java-version: '21'
+          java-version: '25'
           distribution: 'temurin'
       - name: JUnit
         run: ./gradlew test
@@ -114,10 +114,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@v5
         with:
-          java-version: '21'
+          java-version: '25'
           distribution: 'temurin'
       - name: Spotless
         run: ./gradlew spotlessJavaCheck
@@ -129,10 +129,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@v5
         with:
-          java-version: '21'
+          java-version: '25'
           distribution: 'temurin'
       - name: Checkstyle
         run: ./gradlew checkstyleMain checkstyleTest

--- a/.github/workflows/releaseInstructions.md
+++ b/.github/workflows/releaseInstructions.md
@@ -15,7 +15,7 @@ First, you need to decide whether you want to play the web version with a block-
 
 ### Web Version
 
-* Install [Java 21](https://www.oracle.com/de/java/technologies/downloads/#java21) on your system
+* Install [Java 25 LTS](https://www.oracle.com/de/java/technologies/downloads/#java25) on your system
 * Download the `Blockly-web.jar` file below
 * Start the dungeon by double-clicking the JAR file
     * or run `java -jar Blockly-web.jar` in your terminal
@@ -25,7 +25,7 @@ First, you need to decide whether you want to play the web version with a block-
 
 ### Desktop Version
 
-* Install [Java 21](https://www.oracle.com/de/java/technologies/downloads/#java21) on your system
+* Install [Java 25 LTS](https://www.oracle.com/de/java/technologies/downloads/#java25) on your system
 * Download the `Blockly-desktop.jar` file below
 * Start the dungeon by double-clicking the JAR file
     * or run `java -jar Blockly-desktop.jar` in your terminal

--- a/.github/workflows/spotless.yml
+++ b/.github/workflows/spotless.yml
@@ -56,11 +56,11 @@ jobs:
                   ref: ${{ steps.pr.outputs.branch }}
                   token: ${{ secrets.GITHUB_TOKEN }}
 
-            - name: Set up JDK 21
+            - name: Set up JDK 25
               uses: actions/setup-java@v5
               with:
                   distribution: 'temurin'
-                  java-version: '21'
+                  java-version: '25'
 
             - name: Apply Spotless
               run: ./gradlew spotlessApply
@@ -76,4 +76,3 @@ jobs:
                   else
                       echo "No changes to commit."
                   fi
-

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Bielefeld University of Applied Sciences website.
 
 ## Requirements
 
-[Java SE Development Kit 21 LTS] installed.
+[Java SE Development Kit 25] installed.
 
 ## Known Limitations
 
@@ -184,7 +184,7 @@ All files in [`doc/publication/`] are licensed under [CC BY-SA 4.0].
   [PRODUS project]: #programming-dungeon-adventures-at-school-produs
   [project page]: https://www.hsbi.de/minden/produs/home
   [1]: dungeon/doc/img/monster.gif
-  [Java SE Development Kit 21 LTS]: https://jdk.java.net/21/
+  [Java SE Development Kit 25]: https://jdk.java.net/25/
   [Freiraum 2025]: https://stiftung-hochschullehre.de/foerderung/freiraum/
   [Stiftung Innovation in der Hochschullehre]: https://stiftung-hochschullehre.de/
   [Pakt für Informatik 2.0]: https://www.efre.nrw/einfach-machen/foerderung-finden/pakt-fuer-informatik-20

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Bielefeld University of Applied Sciences website.
 
 ## Requirements
 
-[Java SE Development Kit 25] installed.
+[Java SE Development Kit 25 LTS] installed.
 
 ## Known Limitations
 
@@ -184,7 +184,7 @@ All files in [`doc/publication/`] are licensed under [CC BY-SA 4.0].
   [PRODUS project]: #programming-dungeon-adventures-at-school-produs
   [project page]: https://www.hsbi.de/minden/produs/home
   [1]: dungeon/doc/img/monster.gif
-  [Java SE Development Kit 25]: https://jdk.java.net/25/
+  [Java SE Development Kit 25 LTS]: https://jdk.java.net/25/
   [Freiraum 2025]: https://stiftung-hochschullehre.de/foerderung/freiraum/
   [Stiftung Innovation in der Hochschullehre]: https://stiftung-hochschullehre.de/
   [Pakt für Informatik 2.0]: https://www.efre.nrw/einfach-machen/foerderung-finden/pakt-fuer-informatik-20

--- a/blockly/doc/installation.md
+++ b/blockly/doc/installation.md
@@ -128,7 +128,7 @@ Nach dem Erstellen der Executable müssen folgende Dateien in den `content`-Ordn
         cp ./blockly/build/libs/Blockly.jar ./blockly/frontend/webserver/content/blockly.jar
         ```
 
-Nun kann die Executable gestartet werden. Die erstellte Executable startet einen Webserver, welcher die Blockly-Oberfläche lädt und auch den Blockly-Dungeon in Java öffnet (dazu muss Java 21 oder höher installiert sein). Die Executable muss sich im selben Verzeichnis wie der `content`-Ordner befinden.
+Nun kann die Executable gestartet werden. Die erstellte Executable startet einen Webserver, welcher die Blockly-Oberfläche lädt und auch den Blockly-Dungeon in Java öffnet (dazu muss Java 25 oder höher installiert sein). Die Executable muss sich im selben Verzeichnis wie der `content`-Ordner befinden.
 
 Unter macOS (arm64) muss das Executable vorher freigegeben werden.  
 Dafür im Verzeichnis ein Terminal öffnen und:
@@ -141,4 +141,3 @@ Ab dann kann das Spiel mit
 über das Terminal gestartet werden.
 
 Evtl. die Webseite einmal neu laden, damit die Verbindung zum Dungeon korrekt läuft.
-

--- a/blockly/tooling/install.sh
+++ b/blockly/tooling/install.sh
@@ -6,9 +6,10 @@
 #=============================================================================
 # CONFIGURATION
 #=============================================================================
-JAVA_VERSION="21" # Used for version checking
-# Specific Java download URL for Temurin JDK 21 ARM64
-TEMURIN_JDK_URL="https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.3%2B9/OpenJDK21U-jdk_aarch64_linux_hotspot_21.0.3_9.tar.gz"
+JAVA_VERSION="25" # Used for version checking
+# Latest GA Temurin JDK 25 ARM64 download URL
+TEMURIN_JDK_URL="https://api.adoptium.net/v3/binary/latest/${JAVA_VERSION}/ga/linux/aarch64/jdk/hotspot/normal/eclipse"
+TEMURIN_JDK_ARCHIVE_NAME="temurin-jdk-${JAVA_VERSION}-aarch64.tar.gz"
 
 PROJECT_TAR_URL="<URL HERE>/Workshop.tar.gz" # Will be prompted if empty
 PROJECT_DESKTOP_NAME="Workshop"
@@ -91,11 +92,20 @@ update_system() {
     sudo apt install -y wget curl gpg software-properties-common apt-transport-https file
 }
 
+validate_java_archive() {
+    local archive_path="$1"
+
+    if ! tar -tzf "$archive_path" >/dev/null 2>&1; then
+        rm -f "$archive_path"
+        error_exit "Downloaded Java JDK archive is not a valid gzip tar archive."
+    fi
+}
+
 install_java() {
     log_message "Checking Java OpenJDK $JAVA_VERSION (Temurin) installation..."
 
     local temurin_archive_name
-    temurin_archive_name=$(basename "$TEMURIN_JDK_URL")
+    temurin_archive_name="$TEMURIN_JDK_ARCHIVE_NAME"
     local install_base_dir="/opt"
     local extracted_jdk_dir_name
     local java_home_path
@@ -107,8 +117,9 @@ install_java() {
     if [ $? -ne 0 ]; then
         error_exit "Failed to download Java JDK to determine structure."
     fi
+    validate_java_archive "$TEMP_DIR/$temurin_archive_name"
 
-    extracted_jdk_dir_name=$(tar -tf "$TEMP_DIR/$temurin_archive_name" | head -n 1 | cut -f1 -d"/")
+    extracted_jdk_dir_name=$(tar -tzf "$TEMP_DIR/$temurin_archive_name" | head -n 1 | cut -f1 -d"/")
     if [ -z "$extracted_jdk_dir_name" ]; then
         rm -f "$TEMP_DIR/$temurin_archive_name" # Clean up temp download
         error_exit "Could not determine JDK directory name from archive $temurin_archive_name."
@@ -156,6 +167,7 @@ EOF
     if [ $? -ne 0 ]; then
         error_exit "Failed to download Java JDK."
     fi
+    validate_java_archive "$TEMP_DIR/$temurin_archive_name"
 
     log_message "Creating installation directory $install_base_dir (if it doesn't exist)..."
     sudo mkdir -p "$install_base_dir"

--- a/blockly/tooling/install_doc.md
+++ b/blockly/tooling/install_doc.md
@@ -1,13 +1,13 @@
 # Raspberry Pi Installationsskript – Dokumentation
 
 ## 1. Übersicht  
-Dieses Bash-Skript automatisiert die Einrichtung der Raspberry PIs und des Workshop-Projekts. Es führt System-Updates durch, installiert Java (Temurin OpenJDK 21), Visual Studio Code und richtet ein Projekt das Workshop-Projekt ein. Das Skript ist für Debian-basierte Distributionen (z. B. Raspberry Pi OS) konzipiert und erfordert `sudo`-Rechte.
+Dieses Bash-Skript automatisiert die Einrichtung der Raspberry PIs und des Workshop-Projekts. Es führt System-Updates durch, installiert Java (Temurin OpenJDK 25), Visual Studio Code und richtet ein Projekt das Workshop-Projekt ein. Das Skript ist für Debian-basierte Distributionen (z. B. Raspberry Pi OS) konzipiert und erfordert `sudo`-Rechte.
 
 ---
 
 ## 2. Hauptfunktionen  
 - System-Update (`apt update && apt upgrade`)  
-- Installation Temurin OpenJDK 21 (arm64-Download, Extraktion nach `/opt/…`)  
+- Installation Temurin OpenJDK 25 (arm64-Download, Extraktion nach `/opt/…`)
 - Installation VS Code (arm-/amd64-Pakete)  
 - Download und des Workshop-Projekts:  
   - TAR-Datei herunterladen  
@@ -75,7 +75,7 @@ Workshop/
 ## 6. Aktuelle Probleme & Limitierungen  
 - **TAR-Struktur**: Skript erwartet exakt `Workshop`-Verzeichnis – Abweichungen führen zu Abbruch.  
 - **Cleanup**: Temporäre Dateien werden per `trap` gelöscht – evtl. Fehlermeldungen vor Cleanup nicht geloggt.  
-- **Java-Version**: Feste Version 21 – zukünftige Updates erfordern manuelles Anpassen `JAVA_VERSION` und URL.  
+- **Java-Version**: Feste Version 25 – zukünftige Updates erfordern manuelles Anpassen `JAVA_VERSION` und URL.
 
 ---
 

--- a/build.gradle
+++ b/build.gradle
@@ -44,10 +44,10 @@ allprojects {
 
     java {
         toolchain {
-            languageVersion = JavaLanguageVersion.of(21)
+            languageVersion = JavaLanguageVersion.of(25)
         }
-        sourceCompatibility = JavaVersion.toVersion(21)
-        targetCompatibility = JavaVersion.toVersion(21)
+        sourceCompatibility = JavaVersion.toVersion(25)
+        targetCompatibility = JavaVersion.toVersion(25)
     }
 
     [compileJava, compileTestJava]*.options*.encoding = 'UTF-8'

--- a/doc/produs_unterlagen/readme.md
+++ b/doc/produs_unterlagen/readme.md
@@ -34,11 +34,11 @@ The Blockly Dungeon is the beginner-friendly variant. You program the hero using
 
 ### What needs to be installed?
 
-You only need **Java 21** on your computer. Nothing else.
+You only need **Java 25 LTS** on your computer. Nothing else.
 
-**Installing Java 21:**
+**Installing Java 25 LTS:**
 
-- **Windows / Mac / Linux:** Download [Java 21](https://www.oracle.com/de/java/technologies/downloads/#java21). Choose the version matching your operating system (Windows, macOS or Linux) and install it. Restart your device. 
+- **Windows / Mac / Linux:** Download [Java 25 LTS](https://www.oracle.com/de/java/technologies/downloads/#java25). Choose the version matching your operating system (Windows, macOS or Linux) and install it. Restart your device.
 
 **Tip:** To verify that Java is installed correctly, open a terminal (Windows: `cmd` or PowerShell; Mac/Linux: Terminal) and type:
 
@@ -46,7 +46,7 @@ You only need **Java 21** on your computer. Nothing else.
 java -version
 ```
 
-You should see output like `openjdk version "21.x.x"`.
+You should see output like `openjdk version "25.x.x"`.
 
 ### Download and start the Blockly Dungeon
 
@@ -70,7 +70,7 @@ In the Java Dungeon you solve the same dungeon levels as in the web version, but
 
 ### What needs to be installed?
 
-1. **Java 21** (see [above](#installing-java-21))
+1. **Java 25 LTS** (see [above](#installing-java-25-lts))
 2. **Visual Studio Code** - download from: [https://code.visualstudio.com/](https://code.visualstudio.com/)
    - Available for Windows, Mac and Linux.
 3. **The Blockly Code Runner extension (.vsix file)**
@@ -116,7 +116,7 @@ The Advanced Dungeon is a standalone dungeon project for advanced users. Here yo
 
 ### What needs to be installed?
 
-1. **Java** - a Java version compatible with the repository (at least Java 21). Download: [https://jdk.java.net/21/](https://jdk.java.net/21/) or [Adoptium Temurin 21](https://adoptium.net/temurin/releases/?version=21).
+1. **Java** - a Java version compatible with the repository (at least Java 25). Download: [https://jdk.java.net/25/](https://jdk.java.net/25/) or [Adoptium Temurin 25](https://adoptium.net/temurin/releases/?version=25).
 2. **Git** - needed to download the project. Download: [https://git-scm.com/downloads](https://git-scm.com/downloads)
    - **Windows:** Download the installer and follow the instructions. The default settings are usually sufficient.
    - **Mac:** Git is often already pre-installed. If not: run `xcode-select --install` in the terminal or download from [https://git-scm.com/downloads/mac](https://git-scm.com/downloads/mac).

--- a/doc/produs_unterlagen/readme_de.md
+++ b/doc/produs_unterlagen/readme_de.md
@@ -34,11 +34,11 @@ Das Blockly Dungeon ist die einsteigerfreundliche Variante. Man programmiert den
 
 ### Was muss installiert werden?
 
-Man braucht nur **Java 21** auf dem Computer. Sonst nichts.
+Man braucht nur **Java 25 LTS** auf dem Computer. Sonst nichts.
 
-**Java 21 installieren:**
+**Java 25 LTS installieren:**
 
-- **Windows / Mac / Linux:** Lade [Java 21](https://www.oracle.com/de/java/technologies/downloads/#java21) herunter. Wähle dort die passende Version für dein Betriebssystem (Windows, macOS oder Linux) und installiere es. Starte dein Gerät neu.
+- **Windows / Mac / Linux:** Lade [Java 25 LTS](https://www.oracle.com/de/java/technologies/downloads/#java25) herunter. Wähle dort die passende Version für dein Betriebssystem (Windows, macOS oder Linux) und installiere es. Starte dein Gerät neu.
 
 **Tipp:** Um zu prüfen, ob Java korrekt installiert ist, öffne ein Terminal (Windows: `cmd` oder PowerShell; Mac/Linux: Terminal) und tippe:
 
@@ -46,7 +46,7 @@ Man braucht nur **Java 21** auf dem Computer. Sonst nichts.
 java -version
 ```
 
-Es sollte eine Ausgabe wie `openjdk version "21.x.x"` erscheinen.
+Es sollte eine Ausgabe wie `openjdk version "25.x.x"` erscheinen.
 
 ### Blockly Dungeon herunterladen und starten
 
@@ -70,7 +70,7 @@ Im Java Dungeon löst man die gleichen Dungeon-Level wie in der Web-Version, sch
 
 ### Was muss installiert werden?
 
-1. **Java 21** (siehe [oben](#java-21-installieren))
+1. **Java 25 LTS** (siehe [oben](#java-25-lts-installieren))
 2. **Visual Studio Code** - herunterladen von: [https://code.visualstudio.com/](https://code.visualstudio.com/)
    - Verfügbar für Windows, Mac und Linux.
 3. **Die Blockly-Code-Runner-Erweiterung (.vsix-Datei)**
@@ -116,7 +116,7 @@ Das Advanced Dungeon ist ein eigenständiges Dungeon-Projekt für Fortgeschritte
 
 ### Was muss installiert werden?
 
-1. **Java** - eine mit dem Repository kompatible Java-Version (mindestens Java 21). Download: [https://jdk.java.net/21/](https://jdk.java.net/21/) oder [Adoptium Temurin 21](https://adoptium.net/temurin/releases/?version=21).
+1. **Java** - eine mit dem Repository kompatible Java-Version (mindestens Java 25). Download: [https://jdk.java.net/25/](https://jdk.java.net/25/) oder [Adoptium Temurin 25](https://adoptium.net/temurin/releases/?version=25).
 2. **Git** - wird benötigt, um das Projekt herunterzuladen. Download: [https://git-scm.com/downloads](https://git-scm.com/downloads)
    - **Windows:** Lade den Installer herunter und folge den Anweisungen. Die Standardeinstellungen sind in der Regel ausreichend.
    - **Mac:** Git ist häufig schon vorinstalliert. Falls nicht: `xcode-select --install` im Terminal ausführen oder von [https://git-scm.com/downloads/mac](https://git-scm.com/downloads/mac) herunterladen.

--- a/dungeon/doc/network/report.md
+++ b/dungeon/doc/network/report.md
@@ -5,7 +5,7 @@ Datum: 22.09.2025
 
 ## Executive Summary
 
-Ziel: Echtzeit-Multiplayer für bis zu 6 Spieler pro Sitzung mit server-autoritativer Architektur. Der Server läuft mit 30 Hz. Implementierung in Java 21 / LibGDX mit Netty, TCP-first und optionalem UDP-Fast-Path. Sitzungen sind ephemer und der Server ist initial headless, die Architektur ist modular für spätere Erweiterungen.
+Ziel: Echtzeit-Multiplayer für bis zu 6 Spieler pro Sitzung mit server-autoritativer Architektur. Der Server läuft mit 30 Hz. Implementierung in Java 25 / LibGDX mit Netty, TCP-first und optionalem UDP-Fast-Path. Sitzungen sind ephemer und der Server ist initial headless, die Architektur ist modular für spätere Erweiterungen.
 
 Unmittelbare Konsequenzen: strikte Trennung von Client- und Serverlogik, ein ECS-basiertes Replikationsschema, eine Transport-Abstraktion (reliable vs. unreliable) über Netty und eine Lokale-Server-Option für einfacheres Debugging/Singleplayer-Kompatibilität.
 

--- a/theLastHourEscapeRoom/README.md
+++ b/theLastHourEscapeRoom/README.md
@@ -9,7 +9,7 @@ A scientist has vanished: You have 20 minutes to find out why. **The Last Hour**
 
 The Last Hour runs on Windows, Mac, and Unix systems. Mobile devices are not currently supported.
 
-The game requires [Java SE Development Kit 25](https://jdk.java.net/25/) to be installed.
+The game requires [Java SE Development Kit 25 LTS](https://jdk.java.net/25/) to be installed.
 
 ## How to Play (Singleplayer)
 

--- a/theLastHourEscapeRoom/README.md
+++ b/theLastHourEscapeRoom/README.md
@@ -9,13 +9,13 @@ A scientist has vanished: You have 20 minutes to find out why. **The Last Hour**
 
 The Last Hour runs on Windows, Mac, and Unix systems. Mobile devices are not currently supported.
 
-The game requires [Java SE Development Kit 21 LTS](https://jdk.java.net/21/) to be installed.
+The game requires [Java SE Development Kit 25](https://jdk.java.net/25/) to be installed.
 
 ## How to Play (Singleplayer)
 
 * Download [TheLastHour.jar](https://github.com/Dungeon-CampusMinden/Dungeon/releases)
 * Start the game by double-clicking the downloaded JAR file
-* If the JAR doesn't launch, make sure Java 21 is installed and open a terminal:
+* If the JAR doesn't launch, make sure Java 25 is installed and open a terminal:
   * Verify your Java installation with `java --version`
   * Start the game with `java -jar /PATH/TO/JAR/TheLastHour.jar` (replace the path with the actual location of the downloaded JAR)
 


### PR DESCRIPTION
closes #2548

Die Java-Version des Projekts wurde von 21 auf 25 angehoben.

* Gradle:
  * Java Toolchain auf Version 25 gesetzt.
  * Source- und Target-Compatibility auf Java 25 gesetzt.

* GitHub Actions:
  * CI-, Checkstyle-, Spotless- und Jar-Build-Workflows auf JDK 25 umgestellt.
  * Release-Instructions auf Java 25 LTS aktualisiert.

* Dokumentation:
  * Haupt-README auf Java 25 LTS aktualisiert.
  * TheLastHour-README auf Java 25 LTS aktualisiert.
  * Blockly-Installationsdokumentation auf Java 25 aktualisiert.
  * PRODUS-Anleitungen und Multiplayer-Report auf Java 25 aktualisiert.

* Tooling:
  * Raspberry-Pi-Installationsscript auf Temurin JDK 25 für Linux/aarch64 umgestellt.
  * JDK-Download wird vor der Installation als gzip-tar-Archiv validiert.

* Testing:
  * `gradlew.bat check` unter Java 25 erfolgreich ausgeführt.
  * `bash -n blockly/tooling/install.sh` erfolgreich ausgeführt.