### PR TITLE
Portal: added toggleComponent to solution and doc

### DIFF
--- a/doc/produs_unterlagen/solution/advancedDungeon/MyEnergyPelletCatcherBehavior.md
+++ b/doc/produs_unterlagen/solution/advancedDungeon/MyEnergyPelletCatcherBehavior.md
@@ -6,7 +6,7 @@ Diese Funktion beschreibt das Verhalten eines Energiegeschoss-Fängers. Beim Abf
 
 ```java
 public void catchPellet(Entity catcher, Entity pellet) {
-  Tools.deactivateToggle(catcher);
+  Tools.toggleComponent(catcher);
   Game.remove(pellet);
 }
 ```

--- a/portal/src/portal/riddles/utils/Tools.java
+++ b/portal/src/portal/riddles/utils/Tools.java
@@ -141,7 +141,7 @@ public class Tools {
     entity.fetch(ToggleableComponent.class).ifPresent(ToggleableComponent::deactivate);
   }
 
-    /**
+  /**
    * Toggelt den Schalter-Zustand eines Objekts.
    *
    * <p>Einige Objekte im Spiel können an- oder ausgeschaltet werden, zum Beispiel Pellet-Catcher.

--- a/portal/src/portal/riddles/utils/Tools.java
+++ b/portal/src/portal/riddles/utils/Tools.java
@@ -146,7 +146,7 @@ public class Tools {
    *
    * <p>Einige Objekte im Spiel können an- oder ausgeschaltet werden, zum Beispiel Pellet-Catcher.
    * Diese Methode versucht, die entsprechende Schalter-Komponente aus dem übergebenen Objekt zu
-   * lesen und zu toggeln den Schalter.
+   * lesen und den Schalter zu toggeln.
    *
    * @param entity Das Objekt, dessen Schalter-Zustand deaktiviert werden soll
    */

--- a/portal/src/portal/riddles/utils/Tools.java
+++ b/portal/src/portal/riddles/utils/Tools.java
@@ -141,6 +141,19 @@ public class Tools {
     entity.fetch(ToggleableComponent.class).ifPresent(ToggleableComponent::deactivate);
   }
 
+    /**
+   * Toggelt den Schalter-Zustand eines Objekts.
+   *
+   * <p>Einige Objekte im Spiel können an- oder ausgeschaltet werden, zum Beispiel Pellet-Catcher.
+   * Diese Methode versucht, die entsprechende Schalter-Komponente aus dem übergebenen Objekt zu
+   * lesen und zu toggeln den Schalter.
+   *
+   * @param entity Das Objekt, dessen Schalter-Zustand deaktiviert werden soll
+   */
+  public static void toggleComponent(Entity entity) {
+    entity.fetch(ToggleableComponent.class).ifPresent(ToggleableComponent::toggle);
+  }
+
   /**
    * Liefert das Portal mit dem angegebenen Namen zurück.
    *


### PR DESCRIPTION
Im Level `energypellet1` war die Lösung `Tools.deactivateToggle(catcher)`, welches falsch war da die Komponente schon deaktiviert war. Dies wurde in `Tools.toggleComponent(catcher)` geändert und funktioniert nun wieder richtig.
Im Code gibt es dafür jetzt die passende Methode und die Docs wurden auch abgeändert.