### PR TITLE
Blockly: Mülleimer reparieren

### DIFF
--- a/blockly/frontend/src/style.css
+++ b/blockly/frontend/src/style.css
@@ -214,3 +214,11 @@ header {
 .cross span::after {
     transform: rotate(-45deg);
 }
+
+#buttons {
+    pointer-events: none;
+}
+
+#buttons button {
+    pointer-events: auto;
+}


### PR DESCRIPTION
Der Mülleimer war nicht mehr richtig verfügbar und nicht benutzbar, wenn man ihn ganz oben anklickte. Jetzt kann man ihn wieder richtig benutzen. 

closes #2979
