### PR TITLE
Tooling: Spotless triggered by label on PR

### DIFF
--- a/.github/workflows/spotless.yml
+++ b/.github/workflows/spotless.yml
@@ -21,6 +21,37 @@ jobs:
             cancel-in-progress: false
 
         steps:
+            - name: Check label sender permissions
+              run: |
+                  ACTOR="${{ github.actor }}"
+                  REPO="${{ github.repository }}"
+                  OWNER="${{ github.repository_owner }}"
+                  IS_AUTHORIZED=false
+
+                  if [[ "$ACTOR" == "$OWNER" ]]; then
+                      IS_AUTHORIZED=true
+                  fi
+
+                  if [[ "$IS_AUTHORIZED" == "false" ]] && \
+                     gh api "orgs/$OWNER/members/$ACTOR" > /dev/null 2>&1; then
+                      IS_AUTHORIZED=true
+                  fi
+
+                  if [[ "$IS_AUTHORIZED" == "false" ]] && \
+                     gh api "repos/$REPO/collaborators/$ACTOR" > /dev/null 2>&1; then
+                      IS_AUTHORIZED=true
+                  fi
+
+                  if [[ "$IS_AUTHORIZED" == "false" ]]; then
+                      gh pr edit "${{ github.event.pull_request.number }}" \
+                          --repo "$REPO" \
+                          --remove-label "tooling:spotless" || true
+                      echo "::error::Only OWNER, MEMBER or COLLABORATOR can trigger spotless formatting."
+                      exit 1
+                  fi
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
             - name: Check if PR is from fork
               run:  |
                   IS_FORK="${{ github.event.pull_request.head.repo.full_name != github.repository }}"

--- a/.github/workflows/spotless.yml
+++ b/.github/workflows/spotless.yml
@@ -1,59 +1,43 @@
 name: Apply Spotless on PR
 
 on:
-    issue_comment:
-        types: [created]
+    pull_request_target:
+        types: [ labeled ]
 
 jobs:
     apply-spotless:
         name: Apply Spotless
 
-        if: |
-            github.event.issue.pull_request != null &&
-            github.event.comment.body == '/spotless' &&
-            (
-                github.event.comment.author_association == 'OWNER' ||
-                github.event.comment.author_association == 'MEMBER' ||
-                github.event.comment.author_association == 'COLLABORATOR'
-            )
+        if: github.event.label.name == 'tooling:spotless'
 
         runs-on: ubuntu-latest
 
         permissions:
             contents: write
-            pull-requests: read
+            pull-requests: write
 
         concurrency:
-            group: spotless-${{ github.event.issue.number }}
+            group: spotless-${{ github.event.pull_request.number }}
             cancel-in-progress: false
 
         steps:
-            - name: Get PR branch
-              id: pr
-              run: |
-                  PR_BRANCH=$(gh pr view ${{ github.event.issue.number }} --repo ${{ github.repository }} --json headRefName -q .headRefName)
-                  echo "branch=$PR_BRANCH" >> $GITHUB_OUTPUT
-              env:
-                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
             - name: Check if PR is from fork
               run:  |
-                    IS_FORK=$(gh pr view ${{ github.event.issue.number }} \
-                    --repo ${{ github.repository }} \
-                    --json isCrossRepository \
-                    -q '.isCrossRepository')
-
-                    if [ "$IS_FORK" = "true" ]; then
-                    echo "::error::/spotless is not supported for fork PRs. Please run ./gradlew spotlessApply locally."
-                    exit 1
-                    fi
+                  IS_FORK="${{ github.event.pull_request.head.repo.full_name != github.repository }}"
+                  if [ "$IS_FORK" = "true" ]; then
+                    gh pr edit "${{ github.event.pull_request.number }}" \
+                        --repo "${{ github.repository }}" \
+                        --remove-label "tooling:spotless" || true
+                      echo "::error::tooling:spotless is not supported for fork PRs. Please run ./gradlew spotlessApply locally."
+                      exit 1
+                  fi
               env:
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Checkout PR Branch
               uses: actions/checkout@v6
               with:
-                  ref: ${{ steps.pr.outputs.branch }}
+                  ref: ${{ github.event.pull_request.head.ref }}
                   token: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Set up JDK 25
@@ -76,3 +60,12 @@ jobs:
                   else
                       echo "No changes to commit."
                   fi
+
+            -   name: Remove tooling:spotless label
+                if: always()
+                run: |
+                    gh pr edit ${{ github.event.pull_request.number }} \
+                        --repo ${{ github.repository }} \
+                        --remove-label "tooling:spotless" || true
+                env:
+                    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Der Workflow wird nicht mehr durch einen Kommentar in der PR ausgelöst, sondern durch das Hinzufügen eines Labels über `pull_request_target` mit `types: [labeled]`.

Der Job wird über das Spotless-Label (`tooling:spotless`) mit folgender Bedingung ausgeführt:

```yaml
if: github.event.label.name == 'tooling:spotless'
```

Die Prüfung, ob die PR aus einem Fork stammt, bleibt weiterhin bestehen. Falls es sich um einen Fork handelt, kann Spotless durch ein Label nicht angewendet werden; der Step schlägt mit `exit 1` fehl und die nachfolgenden Steps des Jobs werden nicht ausgeführt.

Die Schritte für das Checkout der Branch, das Setup des JDKs sowie die Ausführung von `spotlessApply` bleiben unverändert.

Der letzte Step entfernt das Label `tooling:spotless` mit:

```yaml
if: always()
```

unabhängig davon, ob ein Commit durchgeführt wurde oder nicht.


closes #3015