### PR TITLE
Dungeon: Update LibGDX to 1.14.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,7 @@ allprojects {
         standardInput = System.in
         ignoreExitValue true
         workingDir = rootProject.projectDir
+        jvmArgs '--enable-native-access=ALL-UNNAMED'
         systemProperty 'BASELOGDIR', project.baseLogDir
         systemProperty 'BASEREFLECTIONDIR', project.baseReflectionDir
     }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -4,7 +4,7 @@ ext {
     protobufGradlePluginVersion = '0.10.0'
 
     // -- DEPENDENCIES
-    gdxVersion = '1.12.1'
+    gdxVersion = '1.14.1'
     aiVersion = '1.8.2'
     junitVersion = '6.0.3'
     junitLauncherVersion = '6.0.3'
@@ -23,7 +23,6 @@ ext {
         gdx                       : "com.badlogicgames.gdx:gdx:$gdxVersion",
         gdx_platform              : "com.badlogicgames.gdx:gdx-platform:$gdxVersion:natives-desktop",
         gdx_backend_lwjgl3        : "com.badlogicgames.gdx:gdx-backend-lwjgl3:$gdxVersion",
-        gdx_lwjgl3_glfw_awt_macos : "com.badlogicgames.gdx:gdx-lwjgl3-glfw-awt-macos:$gdxVersion",
         gdx_ai                    : "com.badlogicgames.gdx:gdx-ai:$aiVersion",
         gdx_freetype              : "com.badlogicgames.gdx:gdx-freetype:$gdxVersion",
         gdx_freetype_platform     : "com.badlogicgames.gdx:gdx-freetype-platform:$gdxVersion:natives-desktop",

--- a/dungeon/build.gradle
+++ b/dungeon/build.gradle
@@ -9,7 +9,6 @@ dependencies {
     api supportDependencies.gdx
     api supportDependencies.gdx_platform
     api supportDependencies.gdx_backend_lwjgl3
-    api supportDependencies.gdx_lwjgl3_glfw_awt_macos
     api supportDependencies.gdx_ai
     api supportDependencies.gdx_freetype
     api supportDependencies.gdx_freetype_platform

--- a/dungeon/src/core/game/GameLoop.java
+++ b/dungeon/src/core/game/GameLoop.java
@@ -11,7 +11,6 @@ import com.badlogic.gdx.backends.lwjgl3.Lwjgl3ApplicationConfiguration;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.scenes.scene2d.Stage;
 import com.badlogic.gdx.utils.Scaling;
-import com.badlogic.gdx.utils.SharedLibraryLoader;
 import com.badlogic.gdx.utils.viewport.ScalingViewport;
 import contrib.components.UIComponent;
 import contrib.crafting.Crafting;
@@ -171,9 +170,7 @@ public final class GameLoop extends ScreenAdapter {
     config.setWindowIcon(PreRunConfiguration.logoPath().pathString());
     config.disableAudio(PreRunConfiguration.disableAudio());
     config.setWindowListener(WindowEventManager.windowListener());
-    if (SharedLibraryLoader.isMac && Gdx.app == null) {
-      org.lwjgl.system.Configuration.GLFW_LIBRARY_NAME.set("glfw_async");
-    }
+    config.useGlfwAsync();
     if (PreRunConfiguration.fullScreen()) {
       config.setFullscreenMode(Lwjgl3ApplicationConfiguration.getDisplayMode());
     } else {


### PR DESCRIPTION
LibGDX wurde von 1.12.1 auf 1.14.1 aktualisiert, um paar Warnings beim Starten des Spiels zu verhindern. 

* Dependencies:
  * LibGDX auf die neueste Version 1.14.1 aktualisiert.
  * Die nicht mehr aktuelle `gdx-lwjgl3-glfw-awt-macos` Dependency entfernt.

* Runtime:
  * Native Access für die Gradle-Starter explizit aktiviert.
  * Die bisherige macOS-GLFW-Konfiguration auf `useGlfwAsync()` umgestellt.

Es kann sein, dass weiterhin noch Warnings bestehen, weil die LWJGL-Version nicht bei LibGDX aktualisiert wurde. Man könnte sie aber theoretisch gezielt zwingen, eine neuere Version zu nehmen. 
