### PR TITLE
remove Doors as level exit

### DIFF
--- a/dungeon/src/core/level/elements/tile/DoorTile.java
+++ b/dungeon/src/core/level/elements/tile/DoorTile.java
@@ -11,13 +11,9 @@ import core.utils.components.path.SimpleIPath;
  * Represents a Door in the game.
  *
  * <p>A Door connects two room-based levels.
- *
- * <p>You need to configure the door with {@link #otherDoor(DoorTile)} and {@link #doorstep(Tile)}.
  */
 public class DoorTile extends Tile {
 
-  private DoorTile otherDoor;
-  private Tile doorstep;
   private boolean open;
 
   /**
@@ -38,47 +34,12 @@ public class DoorTile extends Tile {
 
   @Override
   public boolean isAccessible() {
-    if (!open || (otherDoor != null && !otherDoor.isOpen())) return false;
-    else return levelElement.value();
+    return isOpen();
   }
 
   @Override
   public boolean canSeeThrough() {
     return this.open;
-  }
-
-  /**
-   * Connects this door with its other side in another room.
-   *
-   * @param otherDoor Door that will be connected to this door
-   */
-  public void otherDoor(DoorTile otherDoor) {
-    this.otherDoor = otherDoor;
-  }
-
-  /**
-   * @return Door that is connected to this door
-   */
-  public DoorTile otherDoor() {
-    return otherDoor;
-  }
-
-  /**
-   * Sets Tile in front of the door.
-   *
-   * @param doorstep Tile in front of the door
-   */
-  public void doorstep(final Tile doorstep) {
-    this.doorstep = doorstep;
-  }
-
-  /**
-   * Get Tile in front ot the door.
-   *
-   * @return Tile in front of the door.
-   */
-  public Tile doorstep() {
-    return doorstep;
   }
 
   /**
@@ -110,7 +71,7 @@ public class DoorTile extends Tile {
 
   @Override
   public IPath texturePath() {
-    if (open && (otherDoor == null || otherDoor.isOpen())) return texturePath;
+    if (open) return texturePath;
     else return closedTexturePath();
   }
 
@@ -118,20 +79,9 @@ public class DoorTile extends Tile {
   public String toString() {
     String tileStr = super.toString();
     tileStr = tileStr.replace("Tile", "DoorTile").replace("}", "");
-    String doorStepStr = this.doorstep == null ? "null" : this.doorstep.coordinate().toString();
-    String otherDoorStr = this.otherDoor == null ? "null" : this.otherDoor.coordinate().toString();
     String closedTexturePathStr =
         closedTexturePath() == null ? "null" : closedTexturePath().pathString();
-    return tileStr
-        + ", closedTexturePath="
-        + closedTexturePathStr
-        + ", open="
-        + this.open
-        + ", Doorstep="
-        + doorStepStr
-        + ", OtherDoor="
-        + otherDoorStr
-        + "}";
+    return tileStr + ", closedTexturePath=" + closedTexturePathStr + ", open=" + this.open + "}";
   }
 
   private IPath closedTexturePath() {

--- a/dungeon/src/core/systems/LevelSystem.java
+++ b/dungeon/src/core/systems/LevelSystem.java
@@ -8,16 +8,12 @@ import core.components.PlayerComponent;
 import core.components.PositionComponent;
 import core.level.Tile;
 import core.level.elements.ILevel;
-import core.level.elements.tile.DoorTile;
 import core.level.elements.tile.ExitTile;
 import core.level.elements.tile.PitTile;
 import core.level.loader.DungeonLoader;
-import core.sound.SoundSpec;
 import core.utils.IVoidFunction;
 import core.utils.Tuple;
-import core.utils.components.MissingComponentException;
 import core.utils.logging.DungeonLogger;
-import java.util.List;
 import java.util.Optional;
 
 /**
@@ -107,32 +103,6 @@ public final class LevelSystem extends System {
     return currentTile instanceof ExitTile endTile && endTile.isOpen();
   }
 
-  private Optional<ILevel> isOnDoor(final Entity entity) {
-    PositionComponent pc =
-        entity
-            .fetch(PositionComponent.class)
-            .orElseThrow(() -> MissingComponentException.build(entity, PositionComponent.class));
-    Tile currentTile = Game.tileAt(pc.position()).orElse(null);
-
-    if (!(currentTile instanceof DoorTile doorTile)) {
-      return Optional.empty();
-    }
-    if (!doorTile.isOpen() || doorTile.otherDoor() == null || !doorTile.otherDoor().isOpen()) {
-      return Optional.empty();
-    }
-
-    List<Tile> startTiles = doorTile.otherDoor().level().startTiles();
-    Tile doorstep = doorTile.otherDoor().doorstep();
-    if (startTiles.isEmpty()) startTiles.add(doorstep);
-    startTiles.set(0, doorstep);
-
-    return Optional.ofNullable(doorTile.otherDoor().level());
-  }
-
-  private void playSound() {
-    Game.audio().playGlobal(SoundSpec.builder(SOUND_EFFECT).volume(0.3f));
-  }
-
   /**
    * Execute the system logic.
    *
@@ -152,15 +122,6 @@ public final class LevelSystem extends System {
     if (Game.allPlayers().allMatch(this::isOnOpenEndTile)) {
       onEndTile.execute();
       return;
-    }
-
-    // Check if all heroes are on the same open door and load that level
-    List<ILevel> doorLevels =
-        Game.allPlayers().map(this::isOnDoor).flatMap(Optional::stream).distinct().toList();
-
-    if (doorLevels.size() == 1) {
-      loadLevel(doorLevels.get(0));
-      playSound();
     }
     openPits();
   }


### PR DESCRIPTION
Früher gab es mal die Mechanik das man mittel Türen zwischen Leveln hin und her gehen kann.
Diese Mechanik nutzen wir nicht mehr und kann daher entfernt werden (siehe auch #3034).

Dieser PR entfernt die verlinkungen zwischen zwei Door-Tiles.
Door-Tiles sind jetzt keinen Teleporter mehr, sondern "nur" Tiles die zwischen accessible und non-accessible wechseln können.

Enfernt auch einen Soundeffect der im LevelSystem hardoced war, wenn alle Spieler auf einer Tür zum nächsten Level standen (aber nicht auf dem Levelexit) 