### PR TITLE
Blockly: re-added pickup block

### DIFF
--- a/blockly/frontend/src/blocks/dungeon.ts
+++ b/blockly/frontend/src/blocks/dungeon.ts
@@ -510,6 +510,14 @@ export const blocks = Blockly.common.createBlockDefinitionsFromJsonArray([
     tooltip: "Feuerball in Richtung schießen",
   },
   {
+    type: "pickup",
+    message0: "aufheben",
+    previousStatement: null,
+    nextStatement: null,
+    colour: 30,
+    tooltip: "Sammel den Gegenstand unter dir auf.",
+  },
+  {
     type: "wait",
     message0: "warte",
     previousStatement: null,

--- a/blockly/frontend/src/generators/java/skills.ts
+++ b/blockly/frontend/src/generators/java/skills.ts
@@ -32,3 +32,7 @@ export function push(_block: Blockly.Block, _generator: Blockly.Generator) {
 export function pull(_block: Blockly.Block, _generator: Blockly.Generator) {
   return "hero.pull();";
 }
+
+export function pickup(_block: Blockly.Block, _generator: Blockly.Generator) {
+  return "hero.pickup();";
+}

--- a/blockly/frontend/src/toolbox.ts
+++ b/blockly/frontend/src/toolbox.ts
@@ -75,6 +75,10 @@ export const toolbox: Blockly.utils.toolbox.ToolboxDefinition = {
             },
             {
               kind: "block",
+              type: "pickup",
+            },
+            {
+              kind: "block",
               type: "push",
             },
             {


### PR DESCRIPTION
Der `pickup` block wurde ausversehen aus Blockly in  https://github.com/Dungeon-CampusMinden/Dungeon/pull/3006 entfernt. Mit diesen PR ist dieser wieder in Blockly.