### PR TITLE
Tooling: Add Blockly .exe to pipeline

### DIFF
--- a/.github/workflows/buildjar.yml
+++ b/.github/workflows/buildjar.yml
@@ -113,7 +113,7 @@ jobs:
                 uses: actions/upload-artifact@v7
                 with:
                     name: executable-${{ matrix.os }}
-                    path: app-*.zip
+                    path: Blockly-*.zip
     deploy:
         needs: [build, upload_extension, buildExecutables]
         runs-on: ubuntu-latest

--- a/.github/workflows/buildjar.yml
+++ b/.github/workflows/buildjar.yml
@@ -89,7 +89,7 @@ jobs:
                     if [ "${{ runner.os }}" == "Windows" ]; then
                       7z a Blockly-desktop-windows.zip  ./blockly/build/jpackage/blockly
                     else
-                      tar -czf Blockly-desktop-${{ matrix.os }}.tar.gz blockly/build/jpackage/blockly
+                      tar -czf Blockly-desktop-${{ matrix.os }}.tar.gz -C blockly/build/jpackage blockly
                     fi
                 shell: bash
 
@@ -103,7 +103,7 @@ jobs:
                     if [ "${{ runner.os }}" == "Windows" ]; then
                       7z a Blockly-web-windows.zip  ./blockly/build/jpackage/blockly-web
                     else
-                      tar -czf Blockly-web-${{ matrix.os }}.tar.gz blockly/build/jpackage/blockly-web
+                      tar -czf Blockly-web-${{ matrix.os }}.tar.gz -C blockly/build/jpackage blockly-web
                     fi
                 shell: bash
 

--- a/.github/workflows/buildjar.yml
+++ b/.github/workflows/buildjar.yml
@@ -132,7 +132,7 @@ jobs:
               run: |
                 TAG="v1.0.${{ github.run_number }}"
                 gh release create "$TAG" *.jar *.vsix *.zip *.tar.gz \
-                  --title "Release $TAG" \
+                  --title "Dungeon Games" \
                   --notes-file ".github/workflows/releaseInstructions.md" \
                   --draft=true \
                   --prerelease=false

--- a/.github/workflows/buildjar.yml
+++ b/.github/workflows/buildjar.yml
@@ -2,8 +2,6 @@ name: Build and Release Blockly JARs
 
 on:
     workflow_dispatch:
-    push:
-
 jobs:
     build:
         runs-on: ubuntu-latest
@@ -61,7 +59,6 @@ jobs:
                   name: vs-code-extension
                   path: doc/produs_unterlagen/blockly-code-runner-1.0.2.vsix
 
-
     buildExecutables:
         runs-on: ${{ matrix.os }}
         strategy:
@@ -77,8 +74,6 @@ jobs:
                 with:
                     java-version: '25'
                     distribution: 'temurin'
-#                    cache: 'gradle'
-
             -   name: Make gradlew executable
                 run: chmod +x gradlew
 

--- a/.github/workflows/buildjar.yml
+++ b/.github/workflows/buildjar.yml
@@ -74,7 +74,7 @@ jobs:
             -   name: Set up JDK
                 uses: actions/setup-java@v4
                 with:
-                    java-version: '21'
+                    java-version: '25'
                     distribution: 'temurin'
                     cache: 'gradle'
 

--- a/.github/workflows/buildjar.yml
+++ b/.github/workflows/buildjar.yml
@@ -77,7 +77,7 @@ jobs:
                 with:
                     java-version: '25'
                     distribution: 'temurin'
-                    cache: 'gradle'
+#                    cache: 'gradle'
 
             -   name: Make gradlew executable
                 run: chmod +x gradlew

--- a/.github/workflows/buildjar.yml
+++ b/.github/workflows/buildjar.yml
@@ -87,9 +87,9 @@ jobs:
                 # zip the folder
                 run: |
                     if [ "${{ runner.os }}" == "Windows" ]; then
-                      7z a Blockly-desktop-windows.zip  ./blockly/build/jpackage/blockly
+                      7z a Blockly-desktop-${{ matrix.platform_name }}.zip  ./blockly/build/jpackage/blockly
                     else
-                      tar -czf Blockly-desktop-${{ matrix.os }}.tar.gz -C blockly/build/jpackage blockly
+                      tar -czf Blockly-desktop-${{ matrix.platform_name }}.tar.gz -C blockly/build/jpackage blockly
                     fi
                 shell: bash
 
@@ -101,9 +101,9 @@ jobs:
                 # zip the folder
                 run: |
                     if [ "${{ runner.os }}" == "Windows" ]; then
-                      7z a Blockly-web-windows.zip  ./blockly/build/jpackage/blockly-web
+                      7z a Blockly-web-${{ matrix.platform_name }}.zip  ./blockly/build/jpackage/blockly-web
                     else
-                      tar -czf Blockly-web-${{ matrix.os }}.tar.gz -C blockly/build/jpackage blockly-web
+                      tar -czf Blockly-web-${{ matrix.platform_name }}.tar.gz -C blockly/build/jpackage blockly-web
                     fi
                 shell: bash
 

--- a/.github/workflows/buildjar.yml
+++ b/.github/workflows/buildjar.yml
@@ -37,17 +37,16 @@ jobs:
             - name: Make gradlew executable
               run: chmod +x gradlew
 
-            # 4. Beide JARs bauen (Desktop und Web)
+            # 4. Jar desktop and web
             - name: Build JARs with Gradle
               run: ./gradlew jarDesktop jarWeb
 
-            # 5. Beide JAR-Artefakte für den nächsten Job speichern
+            # 5. save both jar artefacts
             - name: Upload Build Artifacts
               uses: actions/upload-artifact@v7
               with:
                   name: Blockly-JARs
                   path: blockly/build/libs/*.jar
-
     upload_extension:
         runs-on: ubuntu-latest
         steps:
@@ -60,8 +59,48 @@ jobs:
               with:
                   name: vs-code-extension
                   path: doc/produs_unterlagen/blockly-code-runner-1.0.2.vsix
+
+
+    buildExecutables:
+        runs-on: ${{ matrix.os }}
+        strategy:
+            matrix:
+                # run on ubuntu and windows
+                os: [ ubuntu-latest, windows-latest]
+        steps:
+            -   name: Checkout Code
+                uses: actions/checkout@v4
+
+            -   name: Set up JDK
+                uses: actions/setup-java@v4
+                with:
+                    java-version: '21'
+                    distribution: 'temurin'
+                    cache: 'gradle'
+
+            -   name: Make gradlew executable
+                run: chmod +x gradlew
+
+            -   name: Build with JLink
+                run: ./gradlew :blockly:jpackageImage
+
+            -   name: Archive Executable
+                # zip the folder
+                run: |
+                    if [ "${{ runner.os }}" == "Windows" ]; then
+                      7z a app-windows.zip  ./blockly/build/jpackage/blockly
+                    else
+                      zip -r app-${{ matrix.os }}.zip blockly/build/jpackage/blockly
+                    fi
+                shell: bash
+
+            -   name: Upload Artifacts
+                uses: actions/upload-artifact@v4
+                with:
+                    name: executable-${{ matrix.os }}
+                    path: app-*.zip
     deploy:
-        needs: [build, upload_extension]
+        needs: [build, upload_extension, buildExecutables]
         runs-on: ubuntu-latest
         permissions:
             contents: write
@@ -76,15 +115,15 @@ jobs:
               with:
                 name: Blockly-JARs
 
-            - name: Download VS-Code Extension
-              uses: actions/download-artifact@v8
+            - name: Download all artifacts
+              uses: actions/download-artifact@v4
               with:
-                name: vs-code-extension
+                  merge-multiple: true
 
             - name: Create GitHub Release
               run: |
                 TAG="v1.0.${{ github.run_number }}"
-                gh release create "$TAG" *.jar *.vsix \
+                gh release create "$TAG" *.jar *.vsix *.zip \
                   --title "Release $TAG" \
                   --notes-file ".github/workflows/releaseInstructions.md" \
                   --draft=true \

--- a/.github/workflows/buildjar.yml
+++ b/.github/workflows/buildjar.yml
@@ -89,9 +89,9 @@ jobs:
                 # zip the folder
                 run: |
                     if [ "${{ runner.os }}" == "Windows" ]; then
-                      7z a app-windows.zip  ./blockly/build/jpackage/blockly
+                      7z a Blockly-desktop-windows.zip  ./blockly/build/jpackage/blockly
                     else
-                      zip -r app-${{ matrix.os }}.zip blockly/build/jpackage/blockly
+                      zip -r Blockly-desktop-${{ matrix.os }}.zip blockly/build/jpackage/blockly
                     fi
                 shell: bash
 
@@ -103,9 +103,9 @@ jobs:
                 # zip the folder
                 run: |
                     if [ "${{ runner.os }}" == "Windows" ]; then
-                      7z a app-web-windows.zip  ./blockly/build/jpackage/blockly-web
+                      7z a Blockly-web-windows.zip  ./blockly/build/jpackage/blockly-web
                     else
-                      zip -r app-web-${{ matrix.os }}.zip blockly/build/jpackage/blockly-web
+                      zip -r Blockly-web-${{ matrix.os }}.zip blockly/build/jpackage/blockly-web
                     fi
                 shell: bash
 
@@ -125,13 +125,8 @@ jobs:
               with:
                   fetch-depth: 0
 
-            - name: Download the JARs
-              uses: actions/download-artifact@v8
-              with:
-                name: Blockly-JARs
-
             - name: Download all artifacts
-              uses: actions/download-artifact@v4
+              uses: actions/download-artifact@v8
               with:
                   merge-multiple: true
 

--- a/.github/workflows/buildjar.yml
+++ b/.github/workflows/buildjar.yml
@@ -70,10 +70,10 @@ jobs:
                 os: [ ubuntu-latest, windows-latest]
         steps:
             -   name: Checkout Code
-                uses: actions/checkout@v4
+                uses: actions/checkout@v6
 
             -   name: Set up JDK
-                uses: actions/setup-java@v4
+                uses: actions/setup-java@v5
                 with:
                     java-version: '25'
                     distribution: 'temurin'
@@ -103,14 +103,14 @@ jobs:
                 # zip the folder
                 run: |
                     if [ "${{ runner.os }}" == "Windows" ]; then
-                      7z a app-windows.zip  ./blockly/build/jpackage/blockly-web
+                      7z a app-web-windows.zip  ./blockly/build/jpackage/blockly-web
                     else
-                      zip -r app-${{ matrix.os }}.zip blockly/build/jpackage/blockly-web
+                      zip -r app-web-${{ matrix.os }}.zip blockly/build/jpackage/blockly-web
                     fi
                 shell: bash
 
             -   name: Upload Artifacts
-                uses: actions/upload-artifact@v4
+                uses: actions/upload-artifact@v7
                 with:
                     name: executable-${{ matrix.os }}
                     path: app-*.zip

--- a/.github/workflows/buildjar.yml
+++ b/.github/workflows/buildjar.yml
@@ -63,8 +63,11 @@ jobs:
         runs-on: ${{ matrix.os }}
         strategy:
             matrix:
-                # run on ubuntu and windows
-                os: [ ubuntu-latest, windows-latest]
+                include:
+                    - os: windows-latest
+                      platform_name: windows-x86_64
+                    - os: ubuntu-latest
+                      platform_name: linux-x86_64
         steps:
             -   name: Checkout Code
                 uses: actions/checkout@v6
@@ -86,7 +89,7 @@ jobs:
                     if [ "${{ runner.os }}" == "Windows" ]; then
                       7z a Blockly-desktop-windows.zip  ./blockly/build/jpackage/blockly
                     else
-                      zip -r Blockly-desktop-${{ matrix.os }}.zip blockly/build/jpackage/blockly
+                      tar -czf Blockly-desktop-${{ matrix.os }}.tar.gz blockly/build/jpackage/blockly
                     fi
                 shell: bash
 
@@ -100,7 +103,7 @@ jobs:
                     if [ "${{ runner.os }}" == "Windows" ]; then
                       7z a Blockly-web-windows.zip  ./blockly/build/jpackage/blockly-web
                     else
-                      zip -r Blockly-web-${{ matrix.os }}.zip blockly/build/jpackage/blockly-web
+                      tar -czf Blockly-web-${{ matrix.os }}.tar.gz blockly/build/jpackage/blockly-web
                     fi
                 shell: bash
 
@@ -108,7 +111,7 @@ jobs:
                 uses: actions/upload-artifact@v7
                 with:
                     name: executable-${{ matrix.os }}
-                    path: Blockly-*.zip
+                    path: Blockly-*
     deploy:
         needs: [build, upload_extension, buildExecutables]
         runs-on: ubuntu-latest
@@ -128,7 +131,7 @@ jobs:
             - name: Create GitHub Release
               run: |
                 TAG="v1.0.${{ github.run_number }}"
-                gh release create "$TAG" *.jar *.vsix *.zip \
+                gh release create "$TAG" *.jar *.vsix *.zip *.tar.gz \
                   --title "Release $TAG" \
                   --notes-file ".github/workflows/releaseInstructions.md" \
                   --draft=true \

--- a/.github/workflows/buildjar.yml
+++ b/.github/workflows/buildjar.yml
@@ -2,6 +2,7 @@ name: Build and Release Blockly JARs
 
 on:
     workflow_dispatch:
+    push:
 
 jobs:
     build:
@@ -91,6 +92,20 @@ jobs:
                       7z a app-windows.zip  ./blockly/build/jpackage/blockly
                     else
                       zip -r app-${{ matrix.os }}.zip blockly/build/jpackage/blockly
+                    fi
+                shell: bash
+
+
+            -   name: Build with JLink 2
+                run: ./gradlew :blockly:jpackageImageWeb
+
+            -   name: Archive Executable
+                # zip the folder
+                run: |
+                    if [ "${{ runner.os }}" == "Windows" ]; then
+                      7z a app-windows.zip  ./blockly/build/jpackage/blockly-web
+                    else
+                      zip -r app-${{ matrix.os }}.zip blockly/build/jpackage/blockly-web
                     fi
                 shell: bash
 


### PR DESCRIPTION
Die Pipeline baut jetzt auch automatisch die JLink Ordner mit. Diese werden für Windows und Ubuntu gebaut. Somit werden dem Release zusätzlich vier neue Ordner hinzugefügt. 

closes #2896