### PR TITLE
Blockly: Hide Portal Blocks

### DIFF
--- a/blockly/src/level/produs/Level004.java
+++ b/blockly/src/level/produs/Level004.java
@@ -48,6 +48,8 @@ public class Level004 extends BlocklyLevel {
         "wait",
         "pickup",
         "drop_item",
+        "shoot_green_portal",
+        "shoot_blue_portal",
         // Kategorien
         "Abfragen",
         "Bedingung",

--- a/blockly/src/level/produs/Level005.java
+++ b/blockly/src/level/produs/Level005.java
@@ -41,6 +41,8 @@ public class Level005 extends BlocklyLevel {
         "wait",
         "pickup",
         "drop_item",
+        "shoot_green_portal",
+        "shoot_blue_portal",
         // Kategorien
         "Abfragen",
         "Bedingung",

--- a/blockly/src/level/produs/Level006.java
+++ b/blockly/src/level/produs/Level006.java
@@ -44,6 +44,8 @@ public class Level006 extends BlocklyLevel {
         "wait",
         "pickup",
         "drop_item",
+        "shoot_green_portal",
+        "shoot_blue_portal",
         // Kategorien
         "Abfragen",
         "Bedingung",

--- a/blockly/src/level/produs/Level007.java
+++ b/blockly/src/level/produs/Level007.java
@@ -43,6 +43,8 @@ public class Level007 extends BlocklyLevel {
         "wait",
         "pickup",
         "drop_item",
+        "shoot_green_portal",
+        "shoot_blue_portal",
         // Kategorien
         "Abfragen",
         "Bedingung",

--- a/blockly/src/level/produs/Level008.java
+++ b/blockly/src/level/produs/Level008.java
@@ -44,6 +44,8 @@ public class Level008 extends BlocklyLevel {
         "wait",
         "pickup",
         "drop_item",
+        "shoot_green_portal",
+        "shoot_blue_portal",
         // Kategorien
         "Abfragen",
         "Bedingung",

--- a/blockly/src/level/produs/Level009.java
+++ b/blockly/src/level/produs/Level009.java
@@ -45,6 +45,8 @@ public class Level009 extends BlocklyLevel {
         "fireball",
         "wait",
         "pickup",
+        "shoot_green_portal",
+        "shoot_blue_portal",
         // Kategorien
         "Abfragen",
         "Bedingung",

--- a/blockly/src/level/produs/Level010.java
+++ b/blockly/src/level/produs/Level010.java
@@ -31,6 +31,8 @@ public class Level010 extends BlocklyLevel {
         "while_loop",
         // Inventar und Charakter
         "wait",
+        "shoot_green_portal",
+        "shoot_blue_portal",
         // Kategorien
         "Abfragen",
         "Bedingung",

--- a/blockly/src/level/produs/Level011.java
+++ b/blockly/src/level/produs/Level011.java
@@ -35,6 +35,8 @@ public class Level011 extends BlocklyLevel {
         "while_loop",
         // Inventar und Charakter
         "wait",
+        "shoot_green_portal",
+        "shoot_blue_portal",
         // Kategorien
         "Abfragen",
         "Bedingung",

--- a/blockly/src/level/produs/Level012.java
+++ b/blockly/src/level/produs/Level012.java
@@ -44,6 +44,8 @@ public class Level012 extends BlocklyLevel {
         "while_loop",
         // Inventar und Charakter
         "wait",
+        "shoot_green_portal",
+        "shoot_blue_portal",
         // Kategorien
         "Abfragen",
         "Bedingung",

--- a/blockly/src/level/produs/Level013.java
+++ b/blockly/src/level/produs/Level013.java
@@ -47,6 +47,8 @@ public class Level013 extends BlocklyLevel {
         // Inventar und Charakter
         "drop_item",
         "wait",
+        "shoot_green_portal",
+        "shoot_blue_portal",
         // Bedingung
         "logic_wall_direction",
         "logic_floor_direction",

--- a/blockly/src/level/produs/Level014.java
+++ b/blockly/src/level/produs/Level014.java
@@ -30,6 +30,8 @@ public class Level014 extends BlocklyLevel {
     this.blockBlocklyElement(
         // Inventar und Charakter
         "wait",
+        "shoot_green_portal",
+        "shoot_blue_portal",
         // Bedingung
         "logic_monster_direction",
         "logic_bossView_direction",

--- a/blockly/src/level/produs/Level015.java
+++ b/blockly/src/level/produs/Level015.java
@@ -30,6 +30,8 @@ public class Level015 extends BlocklyLevel {
     this.blockBlocklyElement(
         // Inventar und Charakter
         "wait",
+        "shoot_green_portal",
+        "shoot_blue_portal",
         // Bedingung
         "logic_monster_direction",
         "logic_bossView_direction",

--- a/blockly/src/level/produs/Level016.java
+++ b/blockly/src/level/produs/Level016.java
@@ -41,6 +41,8 @@ public class Level016 extends BlocklyLevel {
     this.blockBlocklyElement(
         // Inventar und Charakter
         "wait",
+        "shoot_green_portal",
+        "shoot_blue_portal",
         // Bedingung
         "logic_bossView_direction",
         // Variable

--- a/blockly/src/level/produs/Level017.java
+++ b/blockly/src/level/produs/Level017.java
@@ -26,6 +26,8 @@ public class Level017 extends BlocklyLevel {
     this.blockBlocklyElement(
         // Inventar und Charakter
         "wait",
+        "shoot_green_portal",
+        "shoot_blue_portal",
         // Variable
         "get_number",
         "switch_case",

--- a/blockly/src/level/produs/Level018.java
+++ b/blockly/src/level/produs/Level018.java
@@ -28,6 +28,8 @@ public class Level018 extends BlocklyLevel {
     this.blockBlocklyElement(
         // Inventar und Charakter
         "wait",
+        "shoot_green_portal",
+        "shoot_blue_portal",
         // Variable
         "get_number",
         "switch_case",

--- a/blockly/src/level/produs/Level019.java
+++ b/blockly/src/level/produs/Level019.java
@@ -33,6 +33,8 @@ public class Level019 extends BlocklyLevel {
     this.blockBlocklyElement(
         // Inventar und Charakter
         "wait",
+        "shoot_green_portal",
+        "shoot_blue_portal",
         // Variable
         "get_number",
         "switch_case",

--- a/blockly/src/level/produs/Level020.java
+++ b/blockly/src/level/produs/Level020.java
@@ -83,7 +83,7 @@ public class Level020 extends BlocklyLevel {
   public Level020(
       LevelElement[][] layout, DesignLabel designLabel, Map<String, Point> namedPoints) {
     super(layout, designLabel, namedPoints, "Level 20");
-    this.blockBlocklyElement();
+    this.blockBlocklyElement("shoot_green_portal", "shoot_blue_portal");
 
     addWebPopup(new ImagePopup("popups/level020/webpopups/01_intro.jpg"));
 

--- a/blockly/src/level/produs/Level021.java
+++ b/blockly/src/level/produs/Level021.java
@@ -47,6 +47,8 @@ public class Level021 extends BlocklyLevel {
     this.blockBlocklyElement(
         // Inventar und Charakter
         "drop_item",
+        "shoot_green_portal",
+        "shoot_blue_portal",
         // Variable
         "get_number",
         "switch_case",

--- a/blockly/src/level/produs/Level022.java
+++ b/blockly/src/level/produs/Level022.java
@@ -37,6 +37,8 @@ public class Level022 extends BlocklyLevel {
     this.blockBlocklyElement(
         // Inventar und Charakter
         "drop_item",
+        "shoot_green_portal",
+        "shoot_blue_portal",
         // Variable
         "get_number",
         "switch_case",


### PR DESCRIPTION
closes #3048

Setzt die Portal-Skills in allen Leveln auf die Blockliste, sodass diese nicht mehr als Blöcke im Webinterface angezeigt werden.