### PR TITLE
Blockly: Add finally workaround

### DIFF
--- a/blockly/src/client/Client.java
+++ b/blockly/src/client/Client.java
@@ -166,9 +166,14 @@ public class Client {
       if (httpServer != null) {
         httpServer.stop(0);
       }
-      BlocklyCodeRunner.instance().stopCode();
-      FrontendServer.stopServer();
-      FolderExtractor.deleteCompilerResources();
+
+      try {
+        FrontendServer.stopServer();
+        BlocklyCodeRunner.instance().stopCode();
+        FolderExtractor.deleteCompilerResources();
+      } catch( Exception e) {
+        java.lang.System.out.println("Error stopping server");
+      }
     }
   }
 

--- a/blockly/src/client/Client.java
+++ b/blockly/src/client/Client.java
@@ -171,7 +171,7 @@ public class Client {
         FrontendServer.stopServer();
         BlocklyCodeRunner.instance().stopCode();
         FolderExtractor.deleteCompilerResources();
-      } catch( Exception e) {
+      } catch (Exception e) {
         java.lang.System.out.println("Error stopping server");
       }
     }


### PR DESCRIPTION
Das Problem ist das, das Frontend manchmal nicht geschlossen wird, wenn ein Fehler im Backend aufkommt. Außerdem entsteht der Fehler in einem Finally-Block. Dafür wurde jetzt als Workaround ein try-catch in den finally Block eingebaut. Das Stoppen des Frontend Servers passiert immer als erstes. 

closes #2943