### PR TITLE
Dungeon: Fix camera focus during level load

### DIFF
--- a/dungeon/src/core/game/GameLoop.java
+++ b/dungeon/src/core/game/GameLoop.java
@@ -462,13 +462,22 @@ public final class GameLoop extends ScreenAdapter {
               }
             }
 
-            Game.add(
+            Entity hero =
                 HeroBuilder.builder()
                     .id(event.entityId())
                     .characterClass(CharacterClass.fromByteId(event.characterClassId()))
                     .isLocalPlayer(isLocal)
                     .username(pc.playerName())
-                    .build());
+                    .build();
+            if (event.positionComponent() != null) {
+              hero.fetch(PositionComponent.class)
+                  .ifPresent(
+                      position -> {
+                        position.position(event.positionComponent().position());
+                        position.viewDirection(event.positionComponent().viewDirection());
+                      });
+            }
+            Game.add(hero);
             trackNetworkEntity(ctx, event.entityId());
             return;
           }
@@ -853,7 +862,6 @@ public final class GameLoop extends ScreenAdapter {
    * @param entity entity to set on the start of the level, normally this is the player.
    */
   private static void placeOnLevelStart(final Entity entity) {
-    ECSManagement.add(entity);
     entity
         .fetch(PositionComponent.class)
         .ifPresent(
@@ -863,6 +871,7 @@ public final class GameLoop extends ScreenAdapter {
                       pc::position, () -> LOGGER.warn("No start tile found for the current level"));
               pc.viewDirection(Direction.DOWN); // look down by default
             });
+    ECSManagement.add(entity);
 
     // reset animations
     entity.fetch(DrawComponent.class).ifPresent(DrawComponent::resetState);

--- a/dungeon/src/core/systems/CameraSystem.java
+++ b/dungeon/src/core/systems/CameraSystem.java
@@ -137,11 +137,19 @@ public final class CameraSystem extends System {
   @Override
   public void execute() {
     filteredEntityStream(CameraComponent.class, PositionComponent.class)
+        .filter(CameraSystem::hasLegalPosition)
         .findAny()
         .ifPresentOrElse(this::focus, this::focus);
 
     approachFocusPoint();
     CAMERA.update();
+  }
+
+  private static boolean hasLegalPosition(Entity entity) {
+    return entity
+        .fetch(PositionComponent.class)
+        .map(position -> !position.position().equals(PositionComponent.ILLEGAL_POSITION))
+        .orElse(false);
   }
 
   @Override


### PR DESCRIPTION
Beim Levelwechsel konnte die Kamera kurz auf eine ungültige Position zeigen, weil der Hero erst nach dem ECS-Add auf den Level-Start gesetzt wurde. Dadurch konnten Systeme die Entity kurz mit der alten oder noch ungültigen Position sehen.

* GameLoop:
  * Heroes werden beim Levelwechsel erst auf den Start-Tile gesetzt und danach wieder in ECS registriert.
  * Multiplayer-Hero-Spawns übernehmen Position und Blickrichtung aus dem `EntitySpawnEvent`, bevor die Entity hinzugefügt wird.

* CameraSystem:
  * Kamera-Fokus ignoriert Entities mit `PositionComponent.ILLEGAL_POSITION`.
  * Der bestehende Fallback auf Start-Tile / `0,0` bleibt erhalten, wenn noch kein gültiges Kamera-Ziel vorhanden ist.
