### PR TITLE
Dungeon: Fix Blockly portal tutorial keybind

### DIFF
--- a/portal/src/portal/controlls/Hero.java
+++ b/portal/src/portal/controlls/Hero.java
@@ -47,21 +47,13 @@ public record Hero(Entity hero) {
    */
   public Hero(Entity hero) {
     this.hero = hero;
-    if (!PortalRegistry.isDebugMode()) {
-      // Entfernt alle bisherigen Tastenzuweisungen (außer der zum Schließen der UI)
-      hero.fetch(InputComponent.class)
-          .ifPresent(
-              inputComponent ->
-                  inputComponent.removeCallbacksIf(
-                      (entry -> !Objects.equals(entry.getKey(), KeyboardConfig.CLOSE_UI.value()))));
-    }
   }
 
   /**
    * Setzt den Controller für die Spielfigur.
    *
-   * <p>Registriert Tasgittendrücke und übergibt sie an den übergebenen {@link PlayerController},
-   * der die Verarbeitung übernimmt.
+   * <p>Registriert Tastendrücke und übergibt sie an den übergebenen {@link PlayerController}, der
+   * die Verarbeitung übernimmt.
    *
    * @param controller Ein {@link PlayerController}-Objekt, das die Eingaben verarbeitet. Wenn
    *     {@code null}, wird keine Aktion durchgeführt.
@@ -72,7 +64,15 @@ public record Hero(Entity hero) {
     hero.fetch(InputComponent.class)
         .ifPresent(
             ic -> {
+              if (!PortalRegistry.isDebugMode()) {
+                // Controller mode owns gameplay input, but UI close remains an engine callback.
+                ic.removeCallbacksIf(
+                    entry -> !Objects.equals(entry.getKey(), KeyboardConfig.CLOSE_UI.value()));
+              }
               for (int key = 0; key <= Input.Keys.MAX_KEYCODE; key++) {
+                if (Objects.equals(key, KeyboardConfig.CLOSE_UI.value())) {
+                  continue;
+                }
                 int finalKey = key;
                 ic.registerCallback(
                     key,


### PR DESCRIPTION
closes #3067

Beim Erzeugen des Portal-Hero-Wrappers wurden die vorhandenen Input-Callbacks zu früh entfernt. Dadurch ging im Blockly-Client der `P`-Callback verloren, mit dem die Tutorial-Dialoge erneut angezeigt werden sollen.

* Portal-Input:
  * Der `Hero`-Wrapper entfernt bestehende Keybindings nicht mehr direkt im Konstruktor.
  * Die Controller-spezifische Callback-Bereinigung passiert erst beim Setzen eines Portal-Controllers.
  * `CLOSE_UI` bleibt als Engine-Callback erhalten und wird nicht vom Portal-Controller überschrieben.

* Dokumentation:
  * Tippfehler in der Javadoc von `setController` korrigiert.